### PR TITLE
M3-127 백엔드 도커 CI/CD 구축

### DIFF
--- a/.github/workflows/cd_dev.yml
+++ b/.github/workflows/cd_dev.yml
@@ -1,0 +1,56 @@
+name: Backend Dev Server CD
+
+#on:
+#  push:
+#    branches: [ "develop" ]
+on:
+  pull_request:
+    branches:
+      - develop
+
+jobs:
+  build:
+    runs-on: ubuntu-20.04
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: JDK 17 설치
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'corretto'
+
+      - name: env 설정
+        run: |
+          echo "DB_URI=${{ secrets.DB_URI }}" >> .env
+          echo "DB_USERNAME=${{ secrets.DB_USERNAME }}" >> .env
+          echo "DB_PASSWORD=${{ secrets.DB_PASSWORD }}" >> .env
+          echo "SPRING_PROFILES_ACTIVE=dev" >> .env
+
+      - name: gradlew에 실행 권한 부여
+        run: chmod +x ./gradlew
+
+      - name: 프로젝트 빌드
+        run: ./gradlew clean bootjar
+
+      - name: 압축
+        run: zip -r ./ground_flip.zip .
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_REGION}}
+
+      - name: S3에 업로드
+        run: aws s3 cp ground_flip.zip s3://ground-flip-dev/deploy/ground_flip.zip --region ap-northeast-2
+
+      - name: Code Deploy 로 배포
+        run: >
+          aws deploy create-deployment --application-name ground_flip
+          --deployment-config-name CodeDeployDefault.AllAtOnce
+          --deployment-group-name ground_flip_dev
+          --s3-location bucket=ground-flip-dev,bundleType=zip,key=deploy/ground_flip.zip

--- a/.github/workflows/cd_dev.yml
+++ b/.github/workflows/cd_dev.yml
@@ -50,7 +50,7 @@ jobs:
 
       - name: Code Deploy 로 배포
         run: >
-          aws deploy create-deployment --application-name ground_flip_dev
+          aws deploy create-deployment --application-name ground-flip-dev
           --deployment-config-name CodeDeployDefault.AllAtOnce
           --deployment-group-name ground_flip_dev
           --s3-location bucket=ground-flip-dev,bundleType=zip,key=deploy/ground_flip.zip

--- a/.github/workflows/cd_dev.yml
+++ b/.github/workflows/cd_dev.yml
@@ -50,7 +50,7 @@ jobs:
 
       - name: Code Deploy 로 배포
         run: >
-          aws deploy create-deployment --application-name ground_flip
+          aws deploy create-deployment --application-name ground_flip_dev
           --deployment-config-name CodeDeployDefault.AllAtOnce
           --deployment-group-name ground_flip_dev
           --s3-location bucket=ground-flip-dev,bundleType=zip,key=deploy/ground_flip.zip

--- a/.github/workflows/cd_dev.yml
+++ b/.github/workflows/cd_dev.yml
@@ -1,12 +1,8 @@
 name: Backend Dev Server CD
 
-#on:
-#  push:
-#    branches: [ "develop" ]
 on:
-  pull_request:
-    branches:
-      - develop
+  push:
+    branches: [ "develop" ]
 
 jobs:
   build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
       - develop
 
 jobs:
-  build:
+  build_and_test:
     runs-on: ubuntu-20.04
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,9 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@417ae3ccd767c252f5661f1ace9f835f9654f2b5
 
+      - name: Grant execute permission to gradlew
+        run: chmod +x ./gradlew
+
       - name: Build with Gradle
         run: ./gradlew build
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,29 @@
+name: BackEnd CI
+
+on:
+  pull_request:
+    branches:
+      - develop
+
+jobs:
+  build:
+    runs-on: ubuntu-20.04
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: JDK 17 설치
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'corretto'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@417ae3ccd767c252f5661f1ace9f835f9654f2b5
+
+      - name: Build with Gradle
+        run: ./gradlew build
+
+      - name: Test with Gradle
+        run: ./gradlew test

--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,5 @@ out/
 
 ### VS Code ###
 .vscode/
+
+*.env

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,4 @@
+FROM openjdk:17-jdk
+ARG JAR_FILE=build/libs/*.jar
+COPY ${JAR_FILE} app.jar
+ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/appspec.yml
+++ b/appspec.yml
@@ -1,0 +1,18 @@
+version: 0.0
+os: linux
+
+files:
+  - source:  /
+    destination: /home/ubuntu/ground_flip
+    overwrite: yes
+permissions:
+  - object: /
+    pattern: "**"
+    owner: ubuntu
+    group: ubuntu
+
+hooks:
+  AfterInstall:
+    - location: deploy.sh
+      timeout: 500
+      runas : root

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+APP_NAME="ground_flip"
+REPOSITORY=/home/ubuntu/ground_flip
+
+echo "> Check the currently running container"
+CONTAINER_ID=$(docker ps -aqf "name=$APP_NAME")
+pwd
+ls
+if [ -z "$CONTAINER_ID" ];
+then
+  echo "> No such container is running."
+else
+  echo "> Stop and remove container: $CONTAINER_ID"
+  docker stop "$CONTAINER_ID"
+  docker rm "$CONTAINER_ID"
+fi
+
+echo "> Remove previous Docker image"
+docker rmi "$APP_NAME"
+
+echo "> Build Docker image"
+docker build -t "$APP_NAME" "$REPOSITORY"
+
+echo "> Run the Docker container"
+docker run -d -p 8080:8080 --env-file /home/ubuntu/ground_flip/.env --name "$APP_NAME" "$APP_NAME"

--- a/src/test/java/com/m3pro/groundflip/GroundFlipApplicationTests.java
+++ b/src/test/java/com/m3pro/groundflip/GroundFlipApplicationTests.java
@@ -2,8 +2,10 @@ package com.m3pro.groundflip;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
+@ActiveProfiles("test")
 class GroundFlipApplicationTests {
 
 	@Test


### PR DESCRIPTION
## 작업 내용*
- ci 구축
- 개발용 서버 cd 구축
- 도커 파일 구성
## 고민한 내용*
### CI 파이프 라인
develop 브랜치에 PR을 날리면 머지하기전에 몇가지 검사를 실행하도록 했다.
- 빌드
  - gradle 을 사용해 빌드 한다.
- 테스트
  - gradle 을 사용해 테스트 한다.

### CD 파이프 라인
develop 브랜치에 머지되면 자동으로 개발용 서버에 배포되게 한다. codeDeploy를 사용했다. 다만 개발용이다보니 무중단 배포는 아니고 도커 컨테이너를 내린후 새로운 컨테이너로 대체 하는 방식을 사용했다.
만약 환경변수를 건드렸다면 cd 스크립트와 레포지토리 시크릿을 바꿔야한다.
##### 과정
- 빌드
- 압축
- s3 업로드
- cdoe deploy 실행
  - s3 에서 빌드 파일 다운
  - 실행 
