### PR TITLE
M3-140 픽셀 개인전 정보를 가져오는 API 다시 만들기

### DIFF
--- a/src/main/java/com/m3pro/groundflip/config/GeometryConfig.java
+++ b/src/main/java/com/m3pro/groundflip/config/GeometryConfig.java
@@ -1,0 +1,16 @@
+package com.m3pro.groundflip.config;
+
+import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.PrecisionModel;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class GeometryConfig {
+	private static final int WGS84_SRID = 4326;
+
+	@Bean
+	public GeometryFactory geometryFactory() {
+		return new GeometryFactory(new PrecisionModel(), WGS84_SRID);
+	}
+}

--- a/src/main/java/com/m3pro/groundflip/config/GeometryConverter.java
+++ b/src/main/java/com/m3pro/groundflip/config/GeometryConverter.java
@@ -1,0 +1,24 @@
+package com.m3pro.groundflip.config;
+
+import org.geolatte.geom.G2D;
+import org.geolatte.geom.Point;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.PrecisionModel;
+import org.springframework.stereotype.Component;
+
+@Component
+public class GeometryConverter {
+	private static final GeometryFactory geometryFactory = new GeometryFactory(new PrecisionModel(), 4326);
+
+	public static org.locationtech.jts.geom.Point convertGeomToJts(Object geolattePoint) {
+		Point<G2D> point = (Point<G2D>)geolattePoint;
+		if (geolattePoint == null) {
+			return null;
+		}
+
+		G2D position = point.getPosition();
+		Coordinate coordinate = new Coordinate(position.getLon(), position.getLat());
+		return geometryFactory.createPoint(coordinate);
+	}
+}

--- a/src/main/java/com/m3pro/groundflip/config/GeometryConverter.java
+++ b/src/main/java/com/m3pro/groundflip/config/GeometryConverter.java
@@ -13,9 +13,6 @@ public class GeometryConverter {
 
 	public static org.locationtech.jts.geom.Point convertGeomToJts(Object geolattePoint) {
 		Point<G2D> point = (Point<G2D>)geolattePoint;
-		if (geolattePoint == null) {
-			return null;
-		}
 
 		G2D position = point.getPosition();
 		Coordinate coordinate = new Coordinate(position.getLon(), position.getLat());

--- a/src/main/java/com/m3pro/groundflip/controller/PixelController.java
+++ b/src/main/java/com/m3pro/groundflip/controller/PixelController.java
@@ -11,6 +11,9 @@ import com.m3pro.groundflip.domain.dto.Response;
 import com.m3pro.groundflip.domain.dto.pixel.IndividualPixelResponse;
 import com.m3pro.groundflip.service.PixelService;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
 import lombok.RequiredArgsConstructor;
 
 @RestController
@@ -19,6 +22,12 @@ import lombok.RequiredArgsConstructor;
 public class PixelController {
 	private final PixelService pixelService;
 
+	@Operation(summary = "개인전 픽셀 조회", description = "특정 좌표를 중심으로 반경 내 개인전 픽셀 정보를 조회 API")
+	@Parameters({
+		@Parameter(name = "current-latitude", description = "원의 중심 좌표의 위도", example = "37.503717"),
+		@Parameter(name = "current-longitude", description = "원의 중심 좌표의 경도", example = "127.044317"),
+		@Parameter(name = "radius", description = "미터 단위의 반경", example = "1000"),
+	})
 	@GetMapping("/individual-mode")
 	public Response<List<IndividualPixelResponse>> getNearIndividualPixels(
 		@RequestParam(name = "current-latitude") double currentLatitude,

--- a/src/main/java/com/m3pro/groundflip/controller/PixelController.java
+++ b/src/main/java/com/m3pro/groundflip/controller/PixelController.java
@@ -19,7 +19,7 @@ import lombok.RequiredArgsConstructor;
 public class PixelController {
 	private final PixelService pixelService;
 
-	@GetMapping("/individual")
+	@GetMapping("/individual-mode")
 	public Response<List<IndividualPixelResponse>> getNearIndividualPixels(
 		@RequestParam(name = "current-latitude") double currentLatitude,
 		@RequestParam(name = "current-longitude") double currentLongitude,

--- a/src/main/java/com/m3pro/groundflip/controller/PixelController.java
+++ b/src/main/java/com/m3pro/groundflip/controller/PixelController.java
@@ -21,11 +21,11 @@ public class PixelController {
 
 	@GetMapping("/individual")
 	public Response<List<IndividualPixelResponse>> getNearIndividualPixels(
-		@RequestParam(name = "current-x") int currentX,
-		@RequestParam(name = "current-y") int currentY,
-		@RequestParam(name = "x-range", required = false, defaultValue = "20") int xRange,
-		@RequestParam(name = "y-range", required = false, defaultValue = "10") int yRange) {
-		return Response.createSuccess(pixelService.getNearIndividualPixels(currentX, currentY, xRange, yRange));
+		@RequestParam(name = "current-latitude") double currentLatitude,
+		@RequestParam(name = "current-longitude") double currentLongitude,
+		@RequestParam(name = "radius") int radius) {
+		return Response.createSuccess(
+			pixelService.getNearIndividualPixelsByCoordinate(currentLatitude, currentLongitude, radius));
 	}
 
 }

--- a/src/main/java/com/m3pro/groundflip/domain/dto/pixel/IndividualPixelResponse.java
+++ b/src/main/java/com/m3pro/groundflip/domain/dto/pixel/IndividualPixelResponse.java
@@ -1,22 +1,41 @@
 package com.m3pro.groundflip.domain.dto.pixel;
 
-import com.m3pro.groundflip.domain.entity.Pixel;
+import org.locationtech.jts.geom.Point;
+
+import com.m3pro.groundflip.config.GeometryConverter;
 
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
 @AllArgsConstructor
 @NoArgsConstructor
 @Data
+@Builder
 public class IndividualPixelResponse {
-	private double latitude;
-	private double longitude;
-	private double x;
-	private double y;
+	private long pixelId;
 
-	public static IndividualPixelResponse from(Pixel pixel) {
-		return new IndividualPixelResponse(pixel.getCoordinate().getX(), pixel.getCoordinate().getY(), pixel.getX(),
-			pixel.getY());
+	private double latitude;
+
+	private double longitude;
+
+	private long userId;
+
+	private long x;
+
+	private long y;
+
+	public static IndividualPixelResponse from(Object[] queryResult) {
+		Point coordinate = GeometryConverter.convertGeomToJts(queryResult[1]);
+
+		return IndividualPixelResponse.builder()
+			.pixelId((long)queryResult[0])
+			.latitude(coordinate.getY())
+			.longitude(coordinate.getX())
+			.userId((long)queryResult[2])
+			.x((long)queryResult[3])
+			.y((long)queryResult[4])
+			.build();
 	}
 }

--- a/src/main/java/com/m3pro/groundflip/domain/dto/pixel/IndividualPixelResponse.java
+++ b/src/main/java/com/m3pro/groundflip/domain/dto/pixel/IndividualPixelResponse.java
@@ -4,6 +4,7 @@ import org.locationtech.jts.geom.Point;
 
 import com.m3pro.groundflip.config.GeometryConverter;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -13,17 +14,24 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @Data
 @Builder
+@Schema(title = "개인전 픽셀 정보")
 public class IndividualPixelResponse {
+	@Schema(description = "픽셀 ID", example = "78611")
 	private long pixelId;
 
+	@Schema(description = "픽셀 좌측 상단 위도", example = "37.503717")
 	private double latitude;
 
+	@Schema(description = "픽셀 좌측 상단 경도", example = "127.044317")
 	private double longitude;
 
+	@Schema(description = "소유주의 ID", example = "3")
 	private long userId;
 
+	@Schema(description = "픽셀 세로 상대 좌표", example = "224")
 	private long x;
 
+	@Schema(description = "픽셀 가로 상대 좌표", example = "210")
 	private long y;
 
 	public static IndividualPixelResponse from(Object[] queryResult) {

--- a/src/main/java/com/m3pro/groundflip/service/PixelService.java
+++ b/src/main/java/com/m3pro/groundflip/service/PixelService.java
@@ -2,6 +2,9 @@ package com.m3pro.groundflip.service;
 
 import java.util.List;
 
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.Point;
 import org.springframework.stereotype.Service;
 
 import com.m3pro.groundflip.domain.dto.pixel.IndividualPixelResponse;
@@ -12,11 +15,15 @@ import lombok.RequiredArgsConstructor;
 @Service
 @RequiredArgsConstructor
 public class PixelService {
+	private final GeometryFactory geometryFactory;
 	private final PixelRepository pixelRepository;
 
-	public List<IndividualPixelResponse> getNearIndividualPixels(int currentX, int currentY, int xRange, int yRange) {
-		return pixelRepository.findAllNearPixels(currentX, currentY, xRange, yRange)
-			.stream()
+	public List<IndividualPixelResponse> getNearIndividualPixelsByCoordinate(double currentLatitude,
+		double currentLongitude, int radius) {
+		Point point = geometryFactory.createPoint(new Coordinate(currentLongitude, currentLatitude));
+		point.setSRID(4326);
+
+		return pixelRepository.findAllIndividualPixelsByCoordinate(point, radius).stream()
 			.map(IndividualPixelResponse::from)
 			.toList();
 	}

--- a/src/main/java/com/m3pro/groundflip/service/PixelService.java
+++ b/src/main/java/com/m3pro/groundflip/service/PixelService.java
@@ -17,11 +17,12 @@ import lombok.RequiredArgsConstructor;
 public class PixelService {
 	private final GeometryFactory geometryFactory;
 	private final PixelRepository pixelRepository;
+	private static final int WGS84_SRID = 4326;
 
 	public List<IndividualPixelResponse> getNearIndividualPixelsByCoordinate(double currentLatitude,
 		double currentLongitude, int radius) {
 		Point point = geometryFactory.createPoint(new Coordinate(currentLongitude, currentLatitude));
-		point.setSRID(4326);
+		point.setSRID(WGS84_SRID);
 
 		return pixelRepository.findAllIndividualPixelsByCoordinate(point, radius).stream()
 			.map(IndividualPixelResponse::from)


### PR DESCRIPTION
## 작업 내용*

- 픽셀 개인전 정보를 가져오는 API 구현
- @Query 사용

## 고민한 내용*

- GIS 자료형을 스프링에서 쓰기 위해 여러 제약들이 존재했음
- 스프링의 GIS 자료형은 두 가지가 있음. Geom, locationtech.
- 대부분 레퍼런스들이 locationtech를 사용했기에 그렇게 구현함.
- 하지만 Hibernate 내부에서 Geom을 사용하기에 쿼리 결과로 온 자료형이 locationtech와 호환이 안맞는 문제가 발생
- 또한 native query를 사용할 때 interface로 결과를 받아야 했지만 Point 자료형은 직렬화 ,역직렬화도 어려웠음.
- 따라서 Geom 자료형을 locationtech로 직접 변환 후 위경도값을 꺼내 DTO를 만드는 식으로 구현하였음.


## 스크린샷