### PR TITLE
M3-120 픽셀 차지하는 API가 x, y를 받게끔 수정

### DIFF
--- a/src/main/java/com/m3pro/groundflip/domain/dto/pixel/PixelOccupyRequest.java
+++ b/src/main/java/com/m3pro/groundflip/domain/dto/pixel/PixelOccupyRequest.java
@@ -18,6 +18,9 @@ public class PixelOccupyRequest {
 	@Schema(description = "커뮤니티 ID", nullable = true, example = "78611")
 	private Long communityId;
 
-	@Schema(description = "픽셀 ID", example = "78611")
-	private Long pixelId;
+	@Schema(description = "픽셀의 세로 상대좌표", example = "222")
+	private Long x;
+
+	@Schema(description = "픽셀의 가로 상대좌표", example = "233")
+	private Long y;
 }

--- a/src/main/java/com/m3pro/groundflip/repository/PixelRepository.java
+++ b/src/main/java/com/m3pro/groundflip/repository/PixelRepository.java
@@ -1,6 +1,7 @@
 package com.m3pro.groundflip.repository;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.locationtech.jts.geom.Point;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -77,4 +78,6 @@ public interface PixelRepository extends JpaRepository<Pixel, Long> {
 		@Param("center") Point center,
 		@Param("radius") int radius,
 		@Param("user_id") Long userId);
+
+	Optional<Pixel> findByXAndY(Long x, Long y);
 }

--- a/src/main/java/com/m3pro/groundflip/service/PixelService.java
+++ b/src/main/java/com/m3pro/groundflip/service/PixelService.java
@@ -61,7 +61,7 @@ public class PixelService {
 	public void occupyPixel(PixelOccupyRequest pixelOccupyRequest) {
 		Long communityId = pixelOccupyRequest.getCommunityId();
 
-		Pixel targetPixel = pixelRepository.findById(pixelOccupyRequest.getPixelId())
+		Pixel targetPixel = pixelRepository.findByXAndY(pixelOccupyRequest.getX(), pixelOccupyRequest.getY())
 			.orElseThrow(() -> new AppException(ErrorCode.PIXEL_NOT_FOUND));
 
 		if (pixelOccupyRequest.getCommunityId() == null) {


### PR DESCRIPTION
## 작업 내용*

- 기존에 pixelId를 받는 방식에서 상대좌표인 x,y 를 받게끔 수정

## 고민한 내용*

- 프론트 측에서 pixelId를 알아내기 어려워 추가적인 로직이 필요했습니다.
- 이를 해결하기 위해 프론트 측에서 스스로 알 수 있는 정보인 상대좌표로 픽셀을 특정하게끔 변경하였습니다.

## 스크린샷