### PR TITLE
M3-143 개인전 픽셀 정보 api 구현

### DIFF
--- a/src/main/java/com/m3pro/groundflip/controller/PixelController.java
+++ b/src/main/java/com/m3pro/groundflip/controller/PixelController.java
@@ -3,6 +3,7 @@ package com.m3pro.groundflip.controller;
 import java.util.List;
 
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -11,6 +12,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.m3pro.groundflip.domain.dto.Response;
 import com.m3pro.groundflip.domain.dto.pixel.IndividualHistoryPixelResponse;
+import com.m3pro.groundflip.domain.dto.pixel.IndividualPixelInfoResponse;
 import com.m3pro.groundflip.domain.dto.pixel.IndividualPixelResponse;
 import com.m3pro.groundflip.domain.dto.pixel.PixelOccupyRequest;
 import com.m3pro.groundflip.service.PixelService;
@@ -61,6 +63,16 @@ public class PixelController {
 		@RequestParam(name = "user-id") @NotNull() Long userId) {
 		return Response.createSuccess(
 			pixelService.getNearIndividualHistoryPixelsByCoordinate(currentLatitude, currentLongitude, radius, userId)
+		);
+	}
+
+	@Operation(summary = "개인전 픽셀 정보 조회", description = "특정 개인전 픽셀의 정보를 조회 API")
+	@GetMapping("/individual-mode/{pixelId}")
+	public Response<IndividualPixelInfoResponse> getIndividualPixelInfo(
+		@Parameter(description = "찾고자 하는 pixelId", required = true)
+		@PathVariable Long pixelId) {
+		return Response.createSuccess(
+			new IndividualPixelInfoResponse()
 		);
 	}
 

--- a/src/main/java/com/m3pro/groundflip/controller/PixelController.java
+++ b/src/main/java/com/m3pro/groundflip/controller/PixelController.java
@@ -72,7 +72,7 @@ public class PixelController {
 		@Parameter(description = "찾고자 하는 pixelId", required = true)
 		@PathVariable Long pixelId) {
 		return Response.createSuccess(
-			new IndividualPixelInfoResponse()
+			pixelService.getIndividualPixelInfo(pixelId)
 		);
 	}
 

--- a/src/main/java/com/m3pro/groundflip/domain/dto/pixel/IndividualPixelInfoResponse.java
+++ b/src/main/java/com/m3pro/groundflip/domain/dto/pixel/IndividualPixelInfoResponse.java
@@ -2,6 +2,8 @@ package com.m3pro.groundflip.domain.dto.pixel;
 
 import java.util.List;
 
+import com.m3pro.groundflip.domain.entity.Pixel;
+
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -19,4 +21,15 @@ public class IndividualPixelInfoResponse {
 	private Integer visitCount;
 	private PixelOwnedUser ownUser;
 	private List<VisitedUserInfo> visitList;
+
+	public static IndividualPixelInfoResponse from(Pixel pixel, PixelOwnedUser pixelOwnedUser,
+		List<VisitedUserInfo> visitedUserList) {
+		return IndividualPixelInfoResponse.builder()
+			.address(pixel.getAddress())
+			.addressNumber(pixel.getAddressNumber())
+			.visitCount(visitedUserList.size())
+			.ownUser(pixelOwnedUser)
+			.visitList(visitedUserList)
+			.build();
+	}
 }

--- a/src/main/java/com/m3pro/groundflip/domain/dto/pixel/IndividualPixelInfoResponse.java
+++ b/src/main/java/com/m3pro/groundflip/domain/dto/pixel/IndividualPixelInfoResponse.java
@@ -1,0 +1,22 @@
+package com.m3pro.groundflip.domain.dto.pixel;
+
+import java.util.List;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Data
+@Builder
+@Schema(title = "개인전 픽셀 정보")
+public class IndividualPixelInfoResponse {
+	private String address;
+	private Integer addressNumber;
+	private Integer visitCount;
+	private PixelOwnedUser ownUser;
+	private List<VisitedUserInfo> visitList;
+}

--- a/src/main/java/com/m3pro/groundflip/domain/dto/pixel/IndividualPixelInfoResponse.java
+++ b/src/main/java/com/m3pro/groundflip/domain/dto/pixel/IndividualPixelInfoResponse.java
@@ -19,16 +19,16 @@ public class IndividualPixelInfoResponse {
 	private String address;
 	private Integer addressNumber;
 	private Integer visitCount;
-	private PixelOwnedUser ownUser;
+	private PixelOwnerUserResponse pixelOwnerUser;
 	private List<VisitedUserInfo> visitList;
 
-	public static IndividualPixelInfoResponse from(Pixel pixel, PixelOwnedUser pixelOwnedUser,
+	public static IndividualPixelInfoResponse from(Pixel pixel, PixelOwnerUserResponse pixelOwnerUserResponse,
 		List<VisitedUserInfo> visitedUserList) {
 		return IndividualPixelInfoResponse.builder()
 			.address(pixel.getAddress())
 			.addressNumber(pixel.getAddressNumber())
 			.visitCount(visitedUserList.size())
-			.ownUser(pixelOwnedUser)
+			.pixelOwnerUser(pixelOwnerUserResponse)
 			.visitList(visitedUserList)
 			.build();
 	}

--- a/src/main/java/com/m3pro/groundflip/domain/dto/pixel/PixelOwnedUser.java
+++ b/src/main/java/com/m3pro/groundflip/domain/dto/pixel/PixelOwnedUser.java
@@ -1,0 +1,17 @@
+package com.m3pro.groundflip.domain.dto.pixel;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Data
+@Builder
+public class PixelOwnedUser {
+	private String name;
+	private String profileImageUrl;
+	private Integer currentPixelCount;
+	private Integer accumulatePixelCount;
+}

--- a/src/main/java/com/m3pro/groundflip/domain/dto/pixel/PixelOwnedUser.java
+++ b/src/main/java/com/m3pro/groundflip/domain/dto/pixel/PixelOwnedUser.java
@@ -1,5 +1,8 @@
 package com.m3pro.groundflip.domain.dto.pixel;
 
+import com.m3pro.groundflip.domain.dto.pixelUser.PixelCount;
+import com.m3pro.groundflip.domain.dto.pixelUser.PixelOwnerUser;
+
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -10,8 +13,18 @@ import lombok.NoArgsConstructor;
 @Data
 @Builder
 public class PixelOwnedUser {
-	private String name;
+	private String nickname;
 	private String profileImageUrl;
 	private Integer currentPixelCount;
 	private Integer accumulatePixelCount;
+
+	public static PixelOwnedUser from(PixelOwnerUser pixelOwnerUser, PixelCount currentPixelCount,
+		PixelCount accumulatePixelCount) {
+		return PixelOwnedUser.builder()
+			.nickname(pixelOwnerUser.getNickname())
+			.profileImageUrl(pixelOwnerUser.getProfileImage())
+			.accumulatePixelCount(accumulatePixelCount.getCount())
+			.currentPixelCount(currentPixelCount.getCount())
+			.build();
+	}
 }

--- a/src/main/java/com/m3pro/groundflip/domain/dto/pixel/PixelOwnedUser.java
+++ b/src/main/java/com/m3pro/groundflip/domain/dto/pixel/PixelOwnedUser.java
@@ -20,11 +20,15 @@ public class PixelOwnedUser {
 
 	public static PixelOwnedUser from(PixelOwnerUser pixelOwnerUser, PixelCount currentPixelCount,
 		PixelCount accumulatePixelCount) {
-		return PixelOwnedUser.builder()
-			.nickname(pixelOwnerUser.getNickname())
-			.profileImageUrl(pixelOwnerUser.getProfileImage())
-			.accumulatePixelCount(accumulatePixelCount.getCount())
-			.currentPixelCount(currentPixelCount.getCount())
-			.build();
+		if (pixelOwnerUser == null) {
+			return null;
+		} else {
+			return PixelOwnedUser.builder()
+				.nickname(pixelOwnerUser.getNickname())
+				.profileImageUrl(pixelOwnerUser.getProfileImage())
+				.accumulatePixelCount(accumulatePixelCount.getCount())
+				.currentPixelCount(currentPixelCount.getCount())
+				.build();
+		}
 	}
 }

--- a/src/main/java/com/m3pro/groundflip/domain/dto/pixel/PixelOwnerUserResponse.java
+++ b/src/main/java/com/m3pro/groundflip/domain/dto/pixel/PixelOwnerUserResponse.java
@@ -12,18 +12,18 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @Data
 @Builder
-public class PixelOwnedUser {
+public class PixelOwnerUserResponse {
 	private String nickname;
 	private String profileImageUrl;
 	private Integer currentPixelCount;
 	private Integer accumulatePixelCount;
 
-	public static PixelOwnedUser from(PixelOwnerUser pixelOwnerUser, PixelCount currentPixelCount,
+	public static PixelOwnerUserResponse from(PixelOwnerUser pixelOwnerUser, PixelCount currentPixelCount,
 		PixelCount accumulatePixelCount) {
 		if (pixelOwnerUser == null) {
 			return null;
 		} else {
-			return PixelOwnedUser.builder()
+			return PixelOwnerUserResponse.builder()
 				.nickname(pixelOwnerUser.getNickname())
 				.profileImageUrl(pixelOwnerUser.getProfileImage())
 				.accumulatePixelCount(accumulatePixelCount.getCount())

--- a/src/main/java/com/m3pro/groundflip/domain/dto/pixel/PixelOwnerUserResponse.java
+++ b/src/main/java/com/m3pro/groundflip/domain/dto/pixel/PixelOwnerUserResponse.java
@@ -13,6 +13,7 @@ import lombok.NoArgsConstructor;
 @Data
 @Builder
 public class PixelOwnerUserResponse {
+	private Long userId;
 	private String nickname;
 	private String profileImageUrl;
 	private Integer currentPixelCount;
@@ -24,6 +25,7 @@ public class PixelOwnerUserResponse {
 			return null;
 		} else {
 			return PixelOwnerUserResponse.builder()
+				.userId(pixelOwnerUser.getUserId())
 				.nickname(pixelOwnerUser.getNickname())
 				.profileImageUrl(pixelOwnerUser.getProfileImage())
 				.accumulatePixelCount(accumulatePixelCount.getCount())

--- a/src/main/java/com/m3pro/groundflip/domain/dto/pixel/VisitedUserInfo.java
+++ b/src/main/java/com/m3pro/groundflip/domain/dto/pixel/VisitedUserInfo.java
@@ -1,0 +1,15 @@
+package com.m3pro.groundflip.domain.dto.pixel;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Data
+@Builder
+public class VisitedUserInfo {
+	private String nickname;
+	private String profileImageUrl;
+}

--- a/src/main/java/com/m3pro/groundflip/domain/dto/pixel/VisitedUserInfo.java
+++ b/src/main/java/com/m3pro/groundflip/domain/dto/pixel/VisitedUserInfo.java
@@ -1,5 +1,7 @@
 package com.m3pro.groundflip.domain.dto.pixel;
 
+import com.m3pro.groundflip.domain.dto.pixelUser.VisitedUser;
+
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -12,4 +14,11 @@ import lombok.NoArgsConstructor;
 public class VisitedUserInfo {
 	private String nickname;
 	private String profileImageUrl;
+
+	public static VisitedUserInfo from(VisitedUser visitedUser) {
+		return VisitedUserInfo.builder()
+			.nickname(visitedUser.getNickname())
+			.profileImageUrl(visitedUser.getProfileImage())
+			.build();
+	}
 }

--- a/src/main/java/com/m3pro/groundflip/domain/dto/pixelUser/PixelCount.java
+++ b/src/main/java/com/m3pro/groundflip/domain/dto/pixelUser/PixelCount.java
@@ -1,0 +1,5 @@
+package com.m3pro.groundflip.domain.dto.pixelUser;
+
+public interface PixelCount {
+	int getCount();
+}

--- a/src/main/java/com/m3pro/groundflip/domain/dto/pixelUser/PixelOwnerUser.java
+++ b/src/main/java/com/m3pro/groundflip/domain/dto/pixelUser/PixelOwnerUser.java
@@ -1,0 +1,9 @@
+package com.m3pro.groundflip.domain.dto.pixelUser;
+
+public interface PixelOwnerUser {
+	Long getUserId();
+
+	String getNickname();
+
+	String getProfileImage();
+}

--- a/src/main/java/com/m3pro/groundflip/domain/dto/pixelUser/VisitedUser.java
+++ b/src/main/java/com/m3pro/groundflip/domain/dto/pixelUser/VisitedUser.java
@@ -1,0 +1,11 @@
+package com.m3pro.groundflip.domain.dto.pixelUser;
+
+public interface VisitedUser {
+	Long getPixelId();
+
+	Long getUserId();
+
+	String getNickname();
+
+	String getProfileImage();
+}

--- a/src/main/java/com/m3pro/groundflip/domain/entity/User.java
+++ b/src/main/java/com/m3pro/groundflip/domain/entity/User.java
@@ -35,6 +35,8 @@ public class User extends BaseTimeEntity {
 	@Pattern(regexp = "[가-힣a-zA-Z0-9]{3,10}", message = "닉네임은 한글, 영어, 숫자를 조합해 3글자 이상, 10글자 이하입니다.")
 	private String nickname;
 
+	private String profileImage;
+
 	private Date birthYear;
 
 	private Gender gender;

--- a/src/main/java/com/m3pro/groundflip/repository/PixelUserRepository.java
+++ b/src/main/java/com/m3pro/groundflip/repository/PixelUserRepository.java
@@ -29,4 +29,12 @@ public interface PixelUserRepository extends JpaRepository<PixelUser, Long> {
 		""", nativeQuery = true)
 	List<Object[]> findCurrentOwnerByPixelId(
 		@Param("pixel_id") int pixelId);
+
+	@Query(value = """
+		SELECT COUNT(DISTINCT pu.pixel_id) as unique_pixel_count
+		FROM pixel_user pu
+		WHERE pu.user_id = :user_id;
+		""", nativeQuery = true)
+	List<Object[]> findAccumulatePixelCountByUserId(
+		@Param("user_id") int userId);
 }

--- a/src/main/java/com/m3pro/groundflip/repository/PixelUserRepository.java
+++ b/src/main/java/com/m3pro/groundflip/repository/PixelUserRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import com.m3pro.groundflip.domain.dto.pixelUser.PixelOwnerUser;
 import com.m3pro.groundflip.domain.dto.pixelUser.VisitedUser;
 import com.m3pro.groundflip.domain.entity.PixelUser;
 
@@ -21,14 +22,14 @@ public interface PixelUserRepository extends JpaRepository<PixelUser, Long> {
 		@Param("pixel_id") int pixelId);
 
 	@Query(value = """
-		select pu.user_id, u.nickname, u.profile_image from pixel_user pu
+		select pu.user_id as userId, u.nickname as nickname, u.profile_image as profileImage from pixel_user pu
 		        join user u
 		            on pu.user_id = u.user_id
 		        where pu.pixel_id = :pixel_id
 		        order by pu.created_at desc
 		        limit 1;
 		""", nativeQuery = true)
-	List<Object[]> findCurrentOwnerByPixelId(
+	PixelOwnerUser findCurrentOwnerByPixelId(
 		@Param("pixel_id") int pixelId);
 
 	@Query(value = """

--- a/src/main/java/com/m3pro/groundflip/repository/PixelUserRepository.java
+++ b/src/main/java/com/m3pro/groundflip/repository/PixelUserRepository.java
@@ -18,4 +18,15 @@ public interface PixelUserRepository extends JpaRepository<PixelUser, Long> {
 		""", nativeQuery = true)
 	List<Object[]> findAllVisitedUserByPixelId(
 		@Param("pixel_id") int pixelId);
+
+	@Query(value = """
+		select pu.user_id, u.nickname, u.profile_image from pixel_user pu
+		        join user u
+		            on pu.user_id = u.user_id
+		        where pu.pixel_id = :pixel_id
+		        order by pu.created_at desc
+		        limit 1;
+		""", nativeQuery = true)
+	List<Object[]> findCurrentOwnerByPixelId(
+		@Param("pixel_id") int pixelId);
 }

--- a/src/main/java/com/m3pro/groundflip/repository/PixelUserRepository.java
+++ b/src/main/java/com/m3pro/groundflip/repository/PixelUserRepository.java
@@ -6,17 +6,18 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import com.m3pro.groundflip.domain.dto.pixelUser.VisitedUser;
 import com.m3pro.groundflip.domain.entity.PixelUser;
 
 public interface PixelUserRepository extends JpaRepository<PixelUser, Long> {
 	@Query(value = """
-		select pu.pixel_id, pu.user_id, u.nickname, u.profile_image from pixel_user pu
+		select pu.pixel_id as pixelId, pu.user_id as userId, u.nickname as nickname, u.profile_image as profileImage from pixel_user pu
 		        join user u
 		          on pu.user_id = u.user_id
 		         where pu.pixel_id = :pixel_id
 		        group by pu.user_id;
 		""", nativeQuery = true)
-	List<Object[]> findAllVisitedUserByPixelId(
+	List<VisitedUser> findAllVisitedUserByPixelId(
 		@Param("pixel_id") int pixelId);
 
 	@Query(value = """

--- a/src/main/java/com/m3pro/groundflip/repository/PixelUserRepository.java
+++ b/src/main/java/com/m3pro/groundflip/repository/PixelUserRepository.java
@@ -20,7 +20,7 @@ public interface PixelUserRepository extends JpaRepository<PixelUser, Long> {
 		        group by pu.user_id;
 		""", nativeQuery = true)
 	List<VisitedUser> findAllVisitedUserByPixelId(
-		@Param("pixel_id") int pixelId);
+		@Param("pixel_id") Long pixelId);
 
 	@Query(value = """
 		select pu.user_id as userId, u.nickname as nickname, u.profile_image as profileImage from pixel_user pu
@@ -31,7 +31,7 @@ public interface PixelUserRepository extends JpaRepository<PixelUser, Long> {
 		        limit 1;
 		""", nativeQuery = true)
 	PixelOwnerUser findCurrentOwnerByPixelId(
-		@Param("pixel_id") int pixelId);
+		@Param("pixel_id") Long pixelId);
 
 	@Query(value = """
 		SELECT COUNT(DISTINCT pu.pixel_id) as count
@@ -39,7 +39,7 @@ public interface PixelUserRepository extends JpaRepository<PixelUser, Long> {
 		WHERE pu.user_id = :user_id;
 		""", nativeQuery = true)
 	PixelCount findAccumulatePixelCountByUserId(
-		@Param("user_id") int userId);
+		@Param("user_id") Long userId);
 
 	@Query(value = """
 		SELECT count(user_id) as count
@@ -57,5 +57,5 @@ public interface PixelUserRepository extends JpaRepository<PixelUser, Long> {
 		where res.user_id = :user_id
 		""", nativeQuery = true)
 	PixelCount findCurrentPixelCountByUserId(
-		@Param("user_id") int userId);
+		@Param("user_id") Long userId);
 }

--- a/src/main/java/com/m3pro/groundflip/repository/PixelUserRepository.java
+++ b/src/main/java/com/m3pro/groundflip/repository/PixelUserRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import com.m3pro.groundflip.domain.dto.pixelUser.PixelCount;
 import com.m3pro.groundflip.domain.dto.pixelUser.PixelOwnerUser;
 import com.m3pro.groundflip.domain.dto.pixelUser.VisitedUser;
 import com.m3pro.groundflip.domain.entity.PixelUser;
@@ -33,15 +34,15 @@ public interface PixelUserRepository extends JpaRepository<PixelUser, Long> {
 		@Param("pixel_id") int pixelId);
 
 	@Query(value = """
-		SELECT COUNT(DISTINCT pu.pixel_id) as unique_pixel_count
+		SELECT COUNT(DISTINCT pu.pixel_id) as count
 		FROM pixel_user pu
 		WHERE pu.user_id = :user_id;
 		""", nativeQuery = true)
-	List<Object[]> findAccumulatePixelCountByUserId(
+	PixelCount findAccumulatePixelCountByUserId(
 		@Param("user_id") int userId);
 
 	@Query(value = """
-		SELECT count(user_id)
+		SELECT count(user_id) as count
 		FROM (SELECT pu.*
 		FROM pixel_user pu
 		         JOIN (
@@ -55,6 +56,6 @@ public interface PixelUserRepository extends JpaRepository<PixelUser, Long> {
 		                      FROM pixel_user pu WHERE pu.user_id = :user_id)) res
 		where res.user_id = :user_id
 		""", nativeQuery = true)
-	List<Object[]> findCurrentPixelCountByUserId(
+	PixelCount findCurrentPixelCountByUserId(
 		@Param("user_id") int userId);
 }

--- a/src/main/java/com/m3pro/groundflip/repository/PixelUserRepository.java
+++ b/src/main/java/com/m3pro/groundflip/repository/PixelUserRepository.java
@@ -1,8 +1,21 @@
 package com.m3pro.groundflip.repository;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import com.m3pro.groundflip.domain.entity.PixelUser;
 
 public interface PixelUserRepository extends JpaRepository<PixelUser, Long> {
+	@Query(value = """
+		select pu.pixel_id, pu.user_id, u.nickname, u.profile_image from pixel_user pu
+		        join user u
+		          on pu.user_id = u.user_id
+		         where pu.pixel_id = :pixel_id
+		        group by pu.user_id;
+		""", nativeQuery = true)
+	List<Object[]> findAllVisitedUserByPixelId(
+		@Param("pixel_id") int pixelId);
 }

--- a/src/main/java/com/m3pro/groundflip/service/PixelService.java
+++ b/src/main/java/com/m3pro/groundflip/service/PixelService.java
@@ -1,6 +1,7 @@
 package com.m3pro.groundflip.service;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.GeometryFactory;
@@ -9,8 +10,14 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.m3pro.groundflip.domain.dto.pixel.IndividualHistoryPixelResponse;
+import com.m3pro.groundflip.domain.dto.pixel.IndividualPixelInfoResponse;
 import com.m3pro.groundflip.domain.dto.pixel.IndividualPixelResponse;
 import com.m3pro.groundflip.domain.dto.pixel.PixelOccupyRequest;
+import com.m3pro.groundflip.domain.dto.pixel.PixelOwnedUser;
+import com.m3pro.groundflip.domain.dto.pixel.VisitedUserInfo;
+import com.m3pro.groundflip.domain.dto.pixelUser.PixelCount;
+import com.m3pro.groundflip.domain.dto.pixelUser.PixelOwnerUser;
+import com.m3pro.groundflip.domain.dto.pixelUser.VisitedUser;
 import com.m3pro.groundflip.domain.entity.Pixel;
 import com.m3pro.groundflip.domain.entity.PixelUser;
 import com.m3pro.groundflip.exception.AppException;
@@ -25,17 +32,12 @@ import lombok.RequiredArgsConstructor;
 @Service
 @RequiredArgsConstructor
 public class PixelService {
-	private final GeometryFactory geometryFactory;
-
-	private final PixelRepository pixelRepository;
-
-	private final PixelUserRepository pixelUserRepository;
-
-	private final CommunityRepository communityRepository;
-
-	private final UserRepository userRepository;
-
 	private static final int WGS84_SRID = 4326;
+	private final GeometryFactory geometryFactory;
+	private final PixelRepository pixelRepository;
+	private final PixelUserRepository pixelUserRepository;
+	private final CommunityRepository communityRepository;
+	private final UserRepository userRepository;
 
 	public List<IndividualPixelResponse> getNearIndividualPixelsByCoordinate(double currentLatitude,
 		double currentLongitude, int radius) {
@@ -55,6 +57,26 @@ public class PixelService {
 		return pixelRepository.findAllIndividualPixelsHistoryByCoordinate(point, radius, userId).stream()
 			.map(IndividualHistoryPixelResponse::from)
 			.toList();
+	}
+
+	public IndividualPixelInfoResponse getIndividualPixelInfo(Long pixelId) {
+		Optional<Pixel> pixel = pixelRepository.findById(pixelId);
+		if (pixel.isEmpty()) {
+			throw new AppException(ErrorCode.PIXEL_NOT_FOUND);
+		}
+
+		PixelOwnerUser pixelOwnerUser = pixelUserRepository.findCurrentOwnerByPixelId(pixelId);
+		List<VisitedUser> visitedUsers = pixelUserRepository.findAllVisitedUserByPixelId(pixelId);
+		PixelCount accumulatePixelCount = pixelUserRepository.findAccumulatePixelCountByUserId(
+			pixelOwnerUser.getUserId());
+		PixelCount currentPixelCount = pixelUserRepository.findCurrentPixelCountByUserId(
+			pixelOwnerUser.getUserId());
+
+		return IndividualPixelInfoResponse.from(
+			pixel.get(),
+			PixelOwnedUser.from(pixelOwnerUser, currentPixelCount, accumulatePixelCount),
+			visitedUsers.stream().map(VisitedUserInfo::from).toList()
+		);
 	}
 
 	@Transactional

--- a/src/main/java/com/m3pro/groundflip/service/PixelService.java
+++ b/src/main/java/com/m3pro/groundflip/service/PixelService.java
@@ -13,7 +13,7 @@ import com.m3pro.groundflip.domain.dto.pixel.IndividualHistoryPixelResponse;
 import com.m3pro.groundflip.domain.dto.pixel.IndividualPixelInfoResponse;
 import com.m3pro.groundflip.domain.dto.pixel.IndividualPixelResponse;
 import com.m3pro.groundflip.domain.dto.pixel.PixelOccupyRequest;
-import com.m3pro.groundflip.domain.dto.pixel.PixelOwnedUser;
+import com.m3pro.groundflip.domain.dto.pixel.PixelOwnerUserResponse;
 import com.m3pro.groundflip.domain.dto.pixel.VisitedUserInfo;
 import com.m3pro.groundflip.domain.dto.pixelUser.PixelCount;
 import com.m3pro.groundflip.domain.dto.pixelUser.PixelOwnerUser;
@@ -66,16 +66,16 @@ public class PixelService {
 		}
 
 		List<VisitedUser> visitedUsers = pixelUserRepository.findAllVisitedUserByPixelId(pixelId);
-		PixelOwnedUser pixelOwnedUser = getPixelOwnerUserInfo(pixelId);
+		PixelOwnerUserResponse pixelOwnerUserResponse = getPixelOwnerUserInfo(pixelId);
 
 		return IndividualPixelInfoResponse.from(
 			pixel.get(),
-			pixelOwnedUser,
+			pixelOwnerUserResponse,
 			visitedUsers.stream().map(VisitedUserInfo::from).toList()
 		);
 	}
 
-	private PixelOwnedUser getPixelOwnerUserInfo(Long pixelId) {
+	private PixelOwnerUserResponse getPixelOwnerUserInfo(Long pixelId) {
 		PixelOwnerUser pixelOwnerUser = pixelUserRepository.findCurrentOwnerByPixelId(pixelId);
 		if (pixelOwnerUser == null) {
 			return null;
@@ -84,7 +84,7 @@ public class PixelService {
 				pixelOwnerUser.getUserId());
 			PixelCount currentPixelCount = pixelUserRepository.findCurrentPixelCountByUserId(
 				pixelOwnerUser.getUserId());
-			return PixelOwnedUser.from(pixelOwnerUser, currentPixelCount, accumulatePixelCount);
+			return PixelOwnerUserResponse.from(pixelOwnerUser, currentPixelCount, accumulatePixelCount);
 		}
 	}
 

--- a/src/main/java/com/m3pro/groundflip/service/PixelService.java
+++ b/src/main/java/com/m3pro/groundflip/service/PixelService.java
@@ -65,18 +65,27 @@ public class PixelService {
 			throw new AppException(ErrorCode.PIXEL_NOT_FOUND);
 		}
 
-		PixelOwnerUser pixelOwnerUser = pixelUserRepository.findCurrentOwnerByPixelId(pixelId);
 		List<VisitedUser> visitedUsers = pixelUserRepository.findAllVisitedUserByPixelId(pixelId);
-		PixelCount accumulatePixelCount = pixelUserRepository.findAccumulatePixelCountByUserId(
-			pixelOwnerUser.getUserId());
-		PixelCount currentPixelCount = pixelUserRepository.findCurrentPixelCountByUserId(
-			pixelOwnerUser.getUserId());
+		PixelOwnedUser pixelOwnedUser = getPixelOwnerUserInfo(pixelId);
 
 		return IndividualPixelInfoResponse.from(
 			pixel.get(),
-			PixelOwnedUser.from(pixelOwnerUser, currentPixelCount, accumulatePixelCount),
+			pixelOwnedUser,
 			visitedUsers.stream().map(VisitedUserInfo::from).toList()
 		);
+	}
+
+	private PixelOwnedUser getPixelOwnerUserInfo(Long pixelId) {
+		PixelOwnerUser pixelOwnerUser = pixelUserRepository.findCurrentOwnerByPixelId(pixelId);
+		if (pixelOwnerUser == null) {
+			return null;
+		} else {
+			PixelCount accumulatePixelCount = pixelUserRepository.findAccumulatePixelCountByUserId(
+				pixelOwnerUser.getUserId());
+			PixelCount currentPixelCount = pixelUserRepository.findCurrentPixelCountByUserId(
+				pixelOwnerUser.getUserId());
+			return PixelOwnedUser.from(pixelOwnerUser, currentPixelCount, accumulatePixelCount);
+		}
 	}
 
 	@Transactional

--- a/src/test/java/com/m3pro/groundflip/service/PixelServiceTest.java
+++ b/src/test/java/com/m3pro/groundflip/service/PixelServiceTest.java
@@ -49,7 +49,7 @@ class PixelServiceTest {
 	}
 
 	@Test
-	@DisplayName("[getIndividualPixelInfo] 없는 pixelId 를 넣을 경우 PIXEL_NOT_FOUND 에러")
+	@DisplayName("[getIndividualPixelInfo] 정상적으로 픽셀에 대한 정보가 있는 경우")
 	void getIndividualPixelInfoSuccess() {
 		// Given
 		Long pixelId = 1L;

--- a/src/test/java/com/m3pro/groundflip/service/PixelServiceTest.java
+++ b/src/test/java/com/m3pro/groundflip/service/PixelServiceTest.java
@@ -1,0 +1,167 @@
+package com.m3pro.groundflip.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.m3pro.groundflip.domain.dto.pixel.IndividualPixelInfoResponse;
+import com.m3pro.groundflip.domain.dto.pixelUser.PixelCount;
+import com.m3pro.groundflip.domain.dto.pixelUser.PixelOwnerUser;
+import com.m3pro.groundflip.domain.dto.pixelUser.VisitedUser;
+import com.m3pro.groundflip.domain.entity.Pixel;
+import com.m3pro.groundflip.exception.AppException;
+import com.m3pro.groundflip.exception.ErrorCode;
+import com.m3pro.groundflip.repository.PixelRepository;
+import com.m3pro.groundflip.repository.PixelUserRepository;
+
+@ExtendWith(MockitoExtension.class)
+class PixelServiceTest {
+	@Mock
+	PixelRepository pixelRepository;
+	@Mock
+	private PixelUserRepository pixelUserRepository;
+	@InjectMocks
+	private PixelService pixelService;
+
+	@Test
+	@DisplayName("[getIndividualPixelInfo] 없는 pixelId 를 넣을 경우 PIXEL_NOT_FOUND 에러")
+	void getIndividualPixelInfoPixelNotFound() {
+		// Given
+		Long pixelId = 1L;
+		when(pixelRepository.findById(pixelId)).thenReturn(Optional.empty());
+
+		// When
+		AppException exception = assertThrows(AppException.class, () -> pixelService.getIndividualPixelInfo(pixelId));
+
+		// Then
+		assertEquals(ErrorCode.PIXEL_NOT_FOUND, exception.getErrorCode());
+
+	}
+
+	@Test
+	@DisplayName("[getIndividualPixelInfo] 없는 pixelId 를 넣을 경우 PIXEL_NOT_FOUND 에러")
+	void getIndividualPixelInfoSuccess() {
+		// Given
+		Long pixelId = 1L;
+		String address = "서울";
+		int addressNumber = 1;
+
+		Pixel pixel = Pixel.builder()
+			.id(pixelId)
+			.address(address)
+			.addressNumber(addressNumber)
+			.build();
+
+		List<VisitedUser> visitedUsers = List.of(
+			new VisitedUser() {
+				@Override
+				public Long getPixelId() {
+					return pixelId;
+				}
+
+				@Override
+				public Long getUserId() {
+					return 100L;
+				}
+
+				@Override
+				public String getNickname() {
+					return "JohnDoe";
+				}
+
+				@Override
+				public String getProfileImage() {
+					return "http://profileImage.png";
+				}
+			}
+		);
+		PixelOwnerUser pixelOwnerUser = new PixelOwnerUser() {
+			@Override
+			public Long getUserId() {
+				return 100L;
+			}
+
+			@Override
+			public String getNickname() {
+				return "JohnDoe";
+			}
+
+			@Override
+			public String getProfileImage() {
+				return "profileImage.png";
+			}
+		};
+		PixelCount accumulatePixelCount = new PixelCount() {
+			@Override
+			public int getCount() {
+				return 10;
+			}
+		};
+		PixelCount currentPixelCount = new PixelCount() {
+			@Override
+			public int getCount() {
+				return 5;
+			}
+		};
+
+		when(pixelRepository.findById(pixelId)).thenReturn(Optional.of(pixel));
+		when(pixelUserRepository.findAllVisitedUserByPixelId(pixelId)).thenReturn(visitedUsers);
+		when(pixelUserRepository.findCurrentOwnerByPixelId(pixelId)).thenReturn(pixelOwnerUser);
+		when(pixelUserRepository.findAccumulatePixelCountByUserId(pixelOwnerUser.getUserId())).thenReturn(
+			accumulatePixelCount);
+		when(pixelUserRepository.findCurrentPixelCountByUserId(pixelOwnerUser.getUserId())).thenReturn(
+			currentPixelCount);
+
+		// When
+		IndividualPixelInfoResponse response = pixelService.getIndividualPixelInfo(pixelId);
+
+		// Then
+		assertThat(response.getAddress()).isEqualTo(address);
+		assertThat(response.getAddressNumber()).isEqualTo(addressNumber);
+		assertThat(response.getVisitCount()).isEqualTo(visitedUsers.size());
+		assertThat(response.getVisitList().get(0).getNickname()).isEqualTo("JohnDoe");
+		assertThat(response.getPixelOwnerUser().getCurrentPixelCount()).isEqualTo(currentPixelCount.getCount());
+		assertThat(response.getPixelOwnerUser().getNickname()).isEqualTo(pixelOwnerUser.getNickname());
+	}
+
+	@Test
+	@DisplayName("[getIndividualPixelInfo] pixelId에 해당하는 픽셀에 방문한 사람이 없는 경우")
+	void getIndividualPixelInfoNoVisitedUser() {
+		// Given
+		Long pixelId = 1L;
+		String address = "서울";
+		int addressNumber = 1;
+
+		Pixel pixel = Pixel.builder()
+			.id(pixelId)
+			.address(address)
+			.addressNumber(addressNumber)
+			.build();
+
+		List<VisitedUser> visitedUsers = List.of();
+		PixelOwnerUser pixelOwnerUser = null;
+
+		when(pixelRepository.findById(pixelId)).thenReturn(Optional.of(pixel));
+		when(pixelUserRepository.findAllVisitedUserByPixelId(pixelId)).thenReturn(visitedUsers);
+		when(pixelUserRepository.findCurrentOwnerByPixelId(pixelId)).thenReturn(pixelOwnerUser);
+
+		// When
+		IndividualPixelInfoResponse response = pixelService.getIndividualPixelInfo(pixelId);
+
+		// Then
+		assertThat(response.getAddress()).isEqualTo(address);
+		assertThat(response.getAddressNumber()).isEqualTo(addressNumber);
+		assertThat(response.getVisitCount()).isEqualTo(0);
+		assertThat(response.getPixelOwnerUser()).isNull();
+	}
+}


### PR DESCRIPTION
## 작업 내용*

- /api/individual-mode/{pixelId} api 구현
- service 코드 단위 코드 작성

## 고민한 내용*

### 없는 픽셀의 요청인 경우
없는 픽셀의 경우는 PIXEL_NOT_FOUND 에러를 반환하게 처리헸다.

### 픽셀에 방문한 사용자가 없는 경우
픽셀에 방문한 사용자가 없는 경우는 PixelOwnerUser 의 값을 null 로 처리 했다. 기존 로직에서 해당 부분을 처리하는 메서드를 따로 분리해 없는 경우와 있는 경우를 분리했다.

```
	private PixelOwnerUserResponse getPixelOwnerUserInfo(Long pixelId) {
		PixelOwnerUser pixelOwnerUser = pixelUserRepository.findCurrentOwnerByPixelId(pixelId);
		if (pixelOwnerUser == null) {
			return null;
		} else {
			PixelCount accumulatePixelCount = pixelUserRepository.findAccumulatePixelCountByUserId(
				pixelOwnerUser.getUserId());
			PixelCount currentPixelCount = pixelUserRepository.findCurrentPixelCountByUserId(
				pixelOwnerUser.getUserId());
			return PixelOwnerUserResponse.from(pixelOwnerUser, currentPixelCount, accumulatePixelCount);
		}
	}
```
없을 떄는 응답으로 가는 body에 null 이 들어가게 된다.

### 테스트 코드
3 가지의 경우를 테스트 했다.
- 없는 pixelId 를 넣을 경우
- 정상적인 경우
- 픽셀에 방문한 사람이 없는 경우

이번 테스트 코드에 기본적인 테스트 코드를 넣어 놓았으니 참고 해보면 좋을 것 같네요
#### Exception 이 터지는지 확인하는 코드
```
AppException exception = assertThrows(AppException.class, () -> pixelService.getIndividualPixelInfo(pixelId));
```

#### 클래스 모킹하고 사용하는 법
```
	@Mock
	PixelRepository pixelRepository;

@Test
	@DisplayName("[getIndividualPixelInfo] 없는 pixelId 를 넣을 경우 PIXEL_NOT_FOUND 에러")
	void getIndividualPixelInfoPixelNotFound() {
when(pixelRepository.findById(pixelId)).thenReturn(Optional.empty());
}
```

이외에도 여러가지 있습니다. 모킹된 클래스가 몇번 호출되었는지 확인하는 기능, 호출 되었을때 인자값을 확인하는 방법 등 다양한 방법이 있습니다.

## 리뷰 요구사항

- dto를 많이 만들었는데 이름이 잘 어울리나 확인해주세요~

## 스크린샷