### PR TITLE
M3-144 개인 기록 픽셀 정보 api 구현

### DIFF
--- a/src/main/java/com/m3pro/groundflip/controller/PixelController.java
+++ b/src/main/java/com/m3pro/groundflip/controller/PixelController.java
@@ -2,6 +2,7 @@ package com.m3pro.groundflip.controller;
 
 import java.util.List;
 
+import com.m3pro.groundflip.domain.dto.pixelUser.IndividualHistoryPixelInfoResponse;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -73,6 +74,19 @@ public class PixelController {
 		@PathVariable Long pixelId) {
 		return Response.createSuccess(
 			pixelService.getIndividualPixelInfo(pixelId)
+		);
+	}
+
+	@Operation(summary = "개인 기록 픽셀 정보 조회", description = "픽셀의 개인 기록 정보를 조회 API")
+	@GetMapping("/individual-history/{pixelId}")
+	public Response<IndividualHistoryPixelInfoResponse> getIndividualPixelInfo(
+			@Parameter(description = "찾고자 하는 pixelId", required = true)
+			@PathVariable Long pixelId,
+			@Parameter(description = "조회하고자 하는 userId", required = true)
+			@RequestParam(name = "user-id") Long userId
+			) {
+		return Response.createSuccess(
+				pixelService.getIndividualHistoryPixelInfo(pixelId, userId)
 		);
 	}
 

--- a/src/main/java/com/m3pro/groundflip/domain/dto/pixelUser/IndividualHistoryPixelInfoResponse.java
+++ b/src/main/java/com/m3pro/groundflip/domain/dto/pixelUser/IndividualHistoryPixelInfoResponse.java
@@ -1,0 +1,18 @@
+package com.m3pro.groundflip.domain.dto.pixelUser;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Data
+public class IndividualHistoryPixelInfoResponse {
+    private String address;
+    private int addressNumber;
+    private int visitCount;
+    private List<LocalDateTime> visitList;
+}

--- a/src/main/java/com/m3pro/groundflip/repository/PixelUserRepository.java
+++ b/src/main/java/com/m3pro/groundflip/repository/PixelUserRepository.java
@@ -17,8 +17,8 @@ public interface PixelUserRepository extends JpaRepository<PixelUser, Long> {
 	@Query(value = """
 		select pu.pixel_id as pixelId, pu.user_id as userId, u.nickname as nickname, u.profile_image as profileImage from pixel_user pu
 		        join user u
-		          on pu.user_id = u.user_id
-		         where pu.pixel_id = :pixel_id
+		          on pu.user_id = u.user_id 
+		         where pu.pixel_id = :pixel_id and pu.created_at >= current_date() 
 		        group by pu.user_id;
 		""", nativeQuery = true)
 	List<VisitedUser> findAllVisitedUserByPixelId(

--- a/src/main/java/com/m3pro/groundflip/repository/PixelUserRepository.java
+++ b/src/main/java/com/m3pro/groundflip/repository/PixelUserRepository.java
@@ -15,48 +15,53 @@ import com.m3pro.groundflip.domain.entity.PixelUser;
 
 public interface PixelUserRepository extends JpaRepository<PixelUser, Long> {
 	@Query(value = """
-		select pu.pixel_id as pixelId, pu.user_id as userId, u.nickname as nickname, u.profile_image as profileImage from pixel_user pu
-		        join user u
-		          on pu.user_id = u.user_id 
-		         where pu.pixel_id = :pixel_id and pu.created_at >= current_date() 
-		        group by pu.user_id;
-		""", nativeQuery = true)
+			SELECT pu.pixel_id AS pixelId,
+			       pu.user_id AS userId,
+			       u.nickname AS nickname,
+			       u.profile_image AS profileImage 
+			FROM pixel_user pu
+			JOIN user u ON pu.user_id = u.user_id 
+			WHERE pu.pixel_id = :pixel_id AND pu.created_at >= current_date() 
+			GROUP BY pu.user_id;
+			""", nativeQuery = true)
 	List<VisitedUser> findAllVisitedUserByPixelId(
 		@Param("pixel_id") Long pixelId);
 
 	@Query(value = """
-		select pu.user_id as userId, u.nickname as nickname, u.profile_image as profileImage from pixel_user pu
-		        join user u
-		            on pu.user_id = u.user_id
-		        where pu.pixel_id = :pixel_id
-		        order by pu.created_at desc
-		        limit 1;
+		SELECT pu.user_id AS userId,
+		       u.nickname AS nickname,
+		       u.profile_image AS profileImage 
+		FROM pixel_user pu 
+		JOIN user u ON pu.user_id = u.user_id 
+		WHERE pu.pixel_id = :pixel_id 
+		ORDER BY pu.created_at DESC 
+		LIMIT 1
 		""", nativeQuery = true)
 	PixelOwnerUser findCurrentOwnerByPixelId(
 		@Param("pixel_id") Long pixelId);
 
 	@Query(value = """
-		SELECT COUNT(DISTINCT pu.pixel_id) as count
-		FROM pixel_user pu
-		WHERE pu.user_id = :user_id;
+		SELECT COUNT(DISTINCT pu.pixel_id) AS count 
+		FROM pixel_user pu 
+		WHERE pu.user_id = :user_id
 		""", nativeQuery = true)
 	PixelCount findAccumulatePixelCountByUserId(
 		@Param("user_id") Long userId);
 
 	@Query(value = """
-		SELECT count(user_id) as count
+		SELECT count(user_id) AS count 
 		FROM (SELECT pu.*
 		FROM pixel_user pu
 		         JOIN (
 		    SELECT pixel_id, MAX(created_at) AS latest_created_at
 		    FROM pixel_user
-		    WHERE pixel_id IN (SELECT DISTINCT pu.pixel_id as unique_pixel_count 
+		    WHERE pixel_id IN (SELECT DISTINCT pu.pixel_id AS unique_pixel_count 
 		                       FROM pixel_user pu WHERE pu.user_id = :user_id)
 		    GROUP BY pixel_id
-		) latest ON pu.pixel_id = latest.pixel_id AND pu.created_at = latest.latest_created_at
-		WHERE pu.pixel_id IN (SELECT DISTINCT pu.pixel_id as unique_pixel_count 
+		) latest ON pu.pixel_id = latest.pixel_id AND pu.created_at = latest.latest_created_at 
+		WHERE pu.pixel_id IN (SELECT DISTINCT pu.pixel_id AS unique_pixel_count  
 		                      FROM pixel_user pu WHERE pu.user_id = :user_id)) res
-		where res.user_id = :user_id
+		where res.user_id = :user_id 
 		""", nativeQuery = true)
 	PixelCount findCurrentPixelCountByUserId(
 		@Param("user_id") Long userId);

--- a/src/main/java/com/m3pro/groundflip/repository/PixelUserRepository.java
+++ b/src/main/java/com/m3pro/groundflip/repository/PixelUserRepository.java
@@ -61,5 +61,5 @@ public interface PixelUserRepository extends JpaRepository<PixelUser, Long> {
 	PixelCount findCurrentPixelCountByUserId(
 		@Param("user_id") Long userId);
 
-	List<PixelUser> findAllByPixelAndUser(Pixel pixel, User user);
+	List<PixelUser> findAllByPixelAndUserOrderByCreatedAt(Pixel pixel, User user);
 }

--- a/src/main/java/com/m3pro/groundflip/repository/PixelUserRepository.java
+++ b/src/main/java/com/m3pro/groundflip/repository/PixelUserRepository.java
@@ -2,6 +2,8 @@ package com.m3pro.groundflip.repository;
 
 import java.util.List;
 
+import com.m3pro.groundflip.domain.entity.Pixel;
+import com.m3pro.groundflip.domain.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -58,4 +60,6 @@ public interface PixelUserRepository extends JpaRepository<PixelUser, Long> {
 		""", nativeQuery = true)
 	PixelCount findCurrentPixelCountByUserId(
 		@Param("user_id") Long userId);
+
+	List<PixelUser> findAllByPixelAndUser(Pixel pixel, User user);
 }

--- a/src/main/java/com/m3pro/groundflip/service/PixelService.java
+++ b/src/main/java/com/m3pro/groundflip/service/PixelService.java
@@ -112,7 +112,7 @@ public class PixelService {
 
 		User user = userRepository.getReferenceById(userId);
 
-		List<PixelUser> visitHistory = pixelUserRepository.findAllByPixelAndUser(pixel, user);
+		List<PixelUser> visitHistory = pixelUserRepository.findAllByPixelAndUserOrderByCreatedAt(pixel, user);
 
 		return new IndividualHistoryPixelInfoResponse(pixel.getAddress(), pixel.getAddressNumber(), visitHistory.size(), visitHistory.stream().map(BaseTimeEntity::getCreatedAt).toList());
 	}

--- a/src/main/java/com/m3pro/groundflip/service/PixelService.java
+++ b/src/main/java/com/m3pro/groundflip/service/PixelService.java
@@ -3,18 +3,16 @@ package com.m3pro.groundflip.service;
 import java.util.List;
 import java.util.Optional;
 
+import com.m3pro.groundflip.domain.dto.pixel.*;
+import com.m3pro.groundflip.domain.dto.pixelUser.IndividualHistoryPixelInfoResponse;
+import com.m3pro.groundflip.domain.entity.User;
+import com.m3pro.groundflip.domain.entity.global.BaseTimeEntity;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.GeometryFactory;
 import org.locationtech.jts.geom.Point;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.m3pro.groundflip.domain.dto.pixel.IndividualHistoryPixelResponse;
-import com.m3pro.groundflip.domain.dto.pixel.IndividualPixelInfoResponse;
-import com.m3pro.groundflip.domain.dto.pixel.IndividualPixelResponse;
-import com.m3pro.groundflip.domain.dto.pixel.PixelOccupyRequest;
-import com.m3pro.groundflip.domain.dto.pixel.PixelOwnerUserResponse;
-import com.m3pro.groundflip.domain.dto.pixel.VisitedUserInfo;
 import com.m3pro.groundflip.domain.dto.pixelUser.PixelCount;
 import com.m3pro.groundflip.domain.dto.pixelUser.PixelOwnerUser;
 import com.m3pro.groundflip.domain.dto.pixelUser.VisitedUser;
@@ -106,5 +104,16 @@ public class PixelService {
 			.build();
 
 		pixelUserRepository.save(pixelUser);
+	}
+
+	public IndividualHistoryPixelInfoResponse getIndividualHistoryPixelInfo(Long pixelId, Long userId) {
+		Pixel pixel = pixelRepository.findById(pixelId)
+				.orElseThrow(() -> new AppException(ErrorCode.PIXEL_NOT_FOUND));
+
+		User user = userRepository.getReferenceById(userId);
+
+		List<PixelUser> visitHistory = pixelUserRepository.findAllByPixelAndUser(pixel, user);
+
+		return new IndividualHistoryPixelInfoResponse(pixel.getAddress(), pixel.getAddressNumber(), visitHistory.size(), visitHistory.stream().map(BaseTimeEntity::getCreatedAt).toList());
 	}
 }

--- a/src/main/java/com/m3pro/groundflip/service/PixelService.java
+++ b/src/main/java/com/m3pro/groundflip/service/PixelService.java
@@ -1,5 +1,6 @@
 package com.m3pro.groundflip.service;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -112,8 +113,10 @@ public class PixelService {
 
 		User user = userRepository.getReferenceById(userId);
 
-		List<PixelUser> visitHistory = pixelUserRepository.findAllByPixelAndUserOrderByCreatedAt(pixel, user);
+		List<LocalDateTime> visitList = pixelUserRepository.findAllByPixelAndUserOrderByCreatedAt(pixel, user).stream()
+				.map(BaseTimeEntity::getCreatedAt)
+				.toList();
 
-		return new IndividualHistoryPixelInfoResponse(pixel.getAddress(), pixel.getAddressNumber(), visitHistory.size(), visitHistory.stream().map(BaseTimeEntity::getCreatedAt).toList());
+		return new IndividualHistoryPixelInfoResponse(pixel.getAddress(), pixel.getAddressNumber(), visitList.size(), visitList);
 	}
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -21,7 +21,6 @@ spring:
     properties:
       hibernate:
         format_sql: true
-        show_sql: true
 
 logging:
   level:

--- a/src/test/java/com/m3pro/groundflip/service/TestUtils.java
+++ b/src/test/java/com/m3pro/groundflip/service/TestUtils.java
@@ -1,0 +1,20 @@
+package com.m3pro.groundflip.service;
+
+import com.m3pro.groundflip.domain.entity.PixelUser;
+import com.m3pro.groundflip.domain.entity.global.BaseTimeEntity;
+
+import java.lang.reflect.Field;
+import java.time.LocalDateTime;
+
+public class TestUtils {
+    public static void setCreatedAtOfPixelUser(PixelUser pixelUser, LocalDateTime createdAt) {
+        try {
+            Field createdAtField = BaseTimeEntity.class.getDeclaredField("createdAt");
+            createdAtField.setAccessible(true);
+            createdAtField.set(pixelUser, createdAt);
+        } catch (NoSuchFieldException | IllegalAccessException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+}


### PR DESCRIPTION
## 작업 내용*

- 특정  픽셀에 대한 개인 기록 정보 가져오는 api 완성
- 해당 api에 대한 테스트 코드 작성
- 기존 sql문들 style 수정

## 고민한 내용*
- 아래 두 방식 중 뭐가 나을 지 고민이 됐다.


```sql
select pixel.address, pixel.address_number, pixel_user.created_at
from pixel_user
join pixel on {픽셀 아이디} = pixel.pixel_id
where user_id = {사용자 아이디};
```

```sql
select  pixel_user.created_at
from pixel_user
where pixel_user.pixel_id = {픽셀 아이디} and pixel_user.user_id = {사용자 아이디}

select *
from pixel
where pixel.pixel_id = {픽셀 아이디}
```
- 하지만 join연산은 매우 비용이 크다는 것을 고려해 단일 쿼리 두 번을 사용하고 각 쿼리가 인덱스를 타게끔 했다.
- 테스트 코드 또한 논리적으로 맞는 것인지 헷갈렸다
- 또한 테스트 코드에서 basetime entity의 createdAt을 builder로 생성할 수 없었다.
- 따라서 리플렉션 기능을 활용하여 해당 필드를 삽입하여 활용했다.

## 리뷰 요구사항

- 테스트 코드의 합당성
- 쿼리문 검토