### PR TITLE
M3-155 누적 픽셀, 현재 픽셀 갯수 가져오는 api 구현

### DIFF
--- a/src/main/java/com/m3pro/groundflip/controller/PixelController.java
+++ b/src/main/java/com/m3pro/groundflip/controller/PixelController.java
@@ -99,4 +99,9 @@ public class PixelController {
 		return Response.createSuccessWithNoData();
 	}
 
+	@Operation(summary = "픽셀 개수 조회", description = "특정 유저의 현재 소유중인 픽셀, 누적 픽셀을 조회하는 api")
+	@GetMapping("/count")
+	public Response<PixelCountResponse> getPixelCount(@RequestParam(name = "user-id") @NotNull() Long userId) {
+		return Response.createSuccess(pixelService.getPixelCount(userId));
+	}
 }

--- a/src/main/java/com/m3pro/groundflip/domain/dto/pixel/PixelCountResponse.java
+++ b/src/main/java/com/m3pro/groundflip/domain/dto/pixel/PixelCountResponse.java
@@ -1,0 +1,20 @@
+package com.m3pro.groundflip.domain.dto.pixel;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Data
+@Builder
+@Schema(title = "픽셀 개수")
+public class PixelCountResponse {
+    @Schema(description = "현재 차지하고 있는 픽셀 개수", example = "5")
+    private Integer currentPixelCount;
+
+    @Schema(description = "지금까지 차지한 픽셀 개수", example = "5")
+    private Integer accumulatePixelCount;
+}

--- a/src/main/java/com/m3pro/groundflip/repository/PixelUserRepository.java
+++ b/src/main/java/com/m3pro/groundflip/repository/PixelUserRepository.java
@@ -49,20 +49,17 @@ public interface PixelUserRepository extends JpaRepository<PixelUser, Long> {
 		@Param("user_id") Long userId);
 
 	@Query(value = """
-		SELECT count(user_id) AS count 
-		FROM (SELECT pu.*
-		FROM pixel_user pu
-		         JOIN (
-		    SELECT pixel_id, MAX(created_at) AS latest_created_at
-		    FROM pixel_user
-		    WHERE pixel_id IN (SELECT DISTINCT pu.pixel_id AS unique_pixel_count 
-		                       FROM pixel_user pu WHERE pu.user_id = :user_id)
-		    GROUP BY pixel_id
-		) latest ON pu.pixel_id = latest.pixel_id AND pu.created_at = latest.latest_created_at 
-		WHERE pu.pixel_id IN (SELECT DISTINCT pu.pixel_id AS unique_pixel_count  
-		                      FROM pixel_user pu WHERE pu.user_id = :user_id)) res
-		where res.user_id = :user_id 
-		""", nativeQuery = true)
+        SELECT COUNT(*) AS count
+        FROM pixel_user pu
+        JOIN (
+            SELECT MAX(pixel_user_id) AS latest_pixel_user_id
+            FROM pixel_user
+            GROUP BY pixel_id
+        ) latest_visits
+        ON
+        pu.pixel_user_id = latest_visits.latest_pixel_user_id
+        WHERE pu.user_id = :user_id
+        """, nativeQuery = true)
 	PixelCount findCurrentPixelCountByUserId(
 		@Param("user_id") Long userId);
 

--- a/src/main/java/com/m3pro/groundflip/service/PixelService.java
+++ b/src/main/java/com/m3pro/groundflip/service/PixelService.java
@@ -177,4 +177,10 @@ public class PixelService {
 		}
 	}
 
+	public PixelCountResponse getPixelCount(Long userId) {
+		return PixelCountResponse.builder()
+				.currentPixelCount(pixelUserRepository.findCurrentPixelCountByUserId(userId).getCount())
+				.accumulatePixelCount(pixelUserRepository.findAccumulatePixelCountByUserId(userId).getCount())
+				.build();
+	}
 }

--- a/src/test/java/com/m3pro/groundflip/service/PixelServiceTest.java
+++ b/src/test/java/com/m3pro/groundflip/service/PixelServiceTest.java
@@ -9,6 +9,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
+import com.m3pro.groundflip.domain.dto.pixel.PixelCountResponse;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -299,5 +301,26 @@ class PixelServiceTest {
 
         // Then
         assertEquals(ErrorCode.PIXEL_NOT_FOUND, exception.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("픽셀 갯수가 정상적으로 불러와지는지 확인")
+    void getPixelCountSuccess() {
+        // Given
+        Long userId = 1L;
+
+        PixelCount currentPixelCount = () -> 3;
+
+        PixelCount accumulatePixelCount = () -> 5;
+
+        when(pixelUserRepository.findCurrentPixelCountByUserId(userId)).thenReturn(currentPixelCount);
+        when(pixelUserRepository.findAccumulatePixelCountByUserId(userId)).thenReturn(accumulatePixelCount);
+
+        // When
+        PixelCountResponse pixelCount = pixelService.getPixelCount(userId);
+
+        // Then
+        assertEquals(pixelCount.getCurrentPixelCount(), currentPixelCount.getCount());
+        assertEquals(pixelCount.getAccumulatePixelCount(), accumulatePixelCount.getCount());
     }
 }


### PR DESCRIPTION
## 작업 내용*

- 현재 픽셀 수, 누적 픽셀 수를 가져오는 기능 구현

## 고민한 내용*

- 이전에 작성된 쿼리를 개선하였다.
- 처음엔 CTE를 쓰는 등 여러 안을 생각했지만, '각 픽셀의 최신 기록을 모두 구하고 이 최신기록의 user가 누군지 확인하자'
- 라는 아이디어에 기반해 쿼리를 작성하니 매우 간결해졌다.
- 특히 별다른 조건이 없는 외래키(pixel_id)에 기반한 group by는 생각보다 빠르게 연산이 가능했다.

## 리뷰 요구사항
- 쿼리문의 합당성
