### PR TITLE
M3-177 토큰 리프레쉬

### DIFF
--- a/src/main/java/com/m3pro/groundflip/config/SecurityConfig.java
+++ b/src/main/java/com/m3pro/groundflip/config/SecurityConfig.java
@@ -34,7 +34,6 @@ public class SecurityConfig {
 					.requestMatchers("/v3/api-docs/**").permitAll()
 					.requestMatchers("/api/swagger-ui/**").permitAll()
 					.requestMatchers("/api/docs/**").permitAll()
-					.requestMatchers("/api/**").permitAll()
 					.anyRequest().hasRole("USER"));
 
 		httpSecurity.addFilterBefore(jwtAuthorizationFilter, UsernamePasswordAuthenticationFilter.class);

--- a/src/main/java/com/m3pro/groundflip/config/SecurityConfig.java
+++ b/src/main/java/com/m3pro/groundflip/config/SecurityConfig.java
@@ -1,8 +1,5 @@
 package com.m3pro.groundflip.config;
 
-import com.m3pro.groundflip.jwt.JwtAuthorizationFilter;
-import com.m3pro.groundflip.jwt.JwtExceptionFilter;
-import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -12,33 +9,39 @@ import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
+import com.m3pro.groundflip.jwt.JwtAuthorizationFilter;
+import com.m3pro.groundflip.jwt.JwtExceptionFilter;
+
+import lombok.RequiredArgsConstructor;
+
 @Configuration
 @EnableWebSecurity
 @RequiredArgsConstructor
 public class SecurityConfig {
-    private final JwtAuthorizationFilter jwtAuthorizationFilter;
+	private final JwtAuthorizationFilter jwtAuthorizationFilter;
 
-    @Bean
-    protected SecurityFilterChain configure(HttpSecurity httpSecurity) throws Exception {
-        httpSecurity
-                .csrf(AbstractHttpConfigurer::disable)
-                .httpBasic(AbstractHttpConfigurer::disable)
-                .formLogin(AbstractHttpConfigurer::disable)
-                .sessionManagement((sessionManagement) ->
-                        sessionManagement.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
-                .authorizeHttpRequests((authorizeHttpRequests) ->
-                        authorizeHttpRequests
-                        .requestMatchers("/api/auth/**").permitAll()
-                        .requestMatchers("/v3/api-docs/**").permitAll()
-                        .requestMatchers("/api/swagger-ui/**").permitAll()
-                        .requestMatchers("/api/docs/**").permitAll()
-                        .requestMatchers("/api/**").permitAll()
-                        .anyRequest().hasRole("USER"));
+	@Bean
+	protected SecurityFilterChain configure(HttpSecurity httpSecurity) throws Exception {
+		httpSecurity
+			.csrf(AbstractHttpConfigurer::disable)
+			.httpBasic(AbstractHttpConfigurer::disable)
+			.formLogin(AbstractHttpConfigurer::disable)
+			.sessionManagement((sessionManagement) ->
+				sessionManagement.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+			.authorizeHttpRequests((authorizeHttpRequests) ->
+				authorizeHttpRequests
+					.requestMatchers("/api/auth/**").permitAll()
+					.requestMatchers("/v3/api-docs/**").permitAll()
+					.requestMatchers("/api/swagger-ui/**").permitAll()
+					.requestMatchers("/api/docs/**").permitAll()
+					.requestMatchers("/api/**").permitAll()
+					.anyRequest().hasRole("USER"));
 
-        httpSecurity.addFilterBefore(jwtAuthorizationFilter, UsernamePasswordAuthenticationFilter.class);
+		httpSecurity.addFilterBefore(jwtAuthorizationFilter, UsernamePasswordAuthenticationFilter.class);
 
-        httpSecurity.addFilterBefore(new JwtExceptionFilter(), JwtAuthorizationFilter.class);
+		httpSecurity.addFilterBefore(new JwtExceptionFilter(), JwtAuthorizationFilter.class);
 
-        return httpSecurity.build();
-    }
+		return httpSecurity.build();
+	}
 }
+

--- a/src/main/java/com/m3pro/groundflip/config/SwaggerConfig.java
+++ b/src/main/java/com/m3pro/groundflip/config/SwaggerConfig.java
@@ -7,7 +7,6 @@ import org.springframework.http.HttpHeaders;
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
-import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
 
 @Configuration
@@ -21,9 +20,6 @@ public class SwaggerConfig {
 			.in(SecurityScheme.In.HEADER)
 			.name(HttpHeaders.AUTHORIZATION);
 
-		SecurityRequirement addSecurityItem = new SecurityRequirement();
-		addSecurityItem.addList("Authorization");
-
 		return new OpenAPI()
 			.info(new Info()
 				.title("Ground Flip API")
@@ -32,7 +28,5 @@ public class SwaggerConfig {
 			.components(new Components()
 				.addSecuritySchemes("Authorization", bearerAuth
 				));
-		// .addSecurityItem(addSecurityItem);
-
 	}
 }

--- a/src/main/java/com/m3pro/groundflip/config/SwaggerConfig.java
+++ b/src/main/java/com/m3pro/groundflip/config/SwaggerConfig.java
@@ -1,0 +1,38 @@
+package com.m3pro.groundflip.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpHeaders;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+
+@Configuration
+public class SwaggerConfig {
+	@Bean
+	public OpenAPI openApi() {
+		SecurityScheme bearerAuth = new SecurityScheme()
+			.type(SecurityScheme.Type.HTTP)
+			.scheme("bearer")
+			.bearerFormat("Authorization")
+			.in(SecurityScheme.In.HEADER)
+			.name(HttpHeaders.AUTHORIZATION);
+
+		SecurityRequirement addSecurityItem = new SecurityRequirement();
+		addSecurityItem.addList("Authorization");
+
+		return new OpenAPI()
+			.info(new Info()
+				.title("Ground Flip API")
+				.description("Ground Flip 의 api 문서입니다.")
+				.version("1.0.0"))
+			.components(new Components()
+				.addSecuritySchemes("Authorization", bearerAuth
+				));
+		// .addSecurityItem(addSecurityItem);
+
+	}
+}

--- a/src/main/java/com/m3pro/groundflip/controller/AuthController.java
+++ b/src/main/java/com/m3pro/groundflip/controller/AuthController.java
@@ -33,7 +33,7 @@ public class AuthController {
 	@Operation(summary = "access token 재발급", description = "만료된 access token 을 refresh token으로 재발급 하는 API")
 	@PostMapping("/reissue")
 	public Response<Tokens> reissueToken(@RequestBody ReissueRequest reissueRequest) {
-		return Response.createSuccess(new Tokens());
+		return Response.createSuccess(authService.reissueToken(reissueRequest.getRefreshToken()));
 	}
 }
 

--- a/src/main/java/com/m3pro/groundflip/controller/AuthController.java
+++ b/src/main/java/com/m3pro/groundflip/controller/AuthController.java
@@ -8,8 +8,8 @@ import org.springframework.web.bind.annotation.RestController;
 import com.m3pro.groundflip.domain.dto.Response;
 import com.m3pro.groundflip.domain.dto.auth.LoginRequest;
 import com.m3pro.groundflip.domain.dto.auth.LoginResponse;
+import com.m3pro.groundflip.domain.dto.auth.ReissueReponse;
 import com.m3pro.groundflip.domain.dto.auth.ReissueRequest;
-import com.m3pro.groundflip.domain.dto.auth.Tokens;
 import com.m3pro.groundflip.enums.Provider;
 import com.m3pro.groundflip.service.AuthService;
 
@@ -32,7 +32,7 @@ public class AuthController {
 
 	@Operation(summary = "access token 재발급", description = "만료된 access token 을 refresh token으로 재발급 하는 API")
 	@PostMapping("/reissue")
-	public Response<Tokens> reissueToken(@RequestBody ReissueRequest reissueRequest) {
+	public Response<ReissueReponse> reissueToken(@RequestBody ReissueRequest reissueRequest) {
 		return Response.createSuccess(authService.reissueToken(reissueRequest.getRefreshToken()));
 	}
 }

--- a/src/main/java/com/m3pro/groundflip/controller/AuthController.java
+++ b/src/main/java/com/m3pro/groundflip/controller/AuthController.java
@@ -1,26 +1,29 @@
 package com.m3pro.groundflip.controller;
 
-import com.m3pro.groundflip.domain.dto.Response;
-import com.m3pro.groundflip.domain.dto.auth.LoginRequest;
-import com.m3pro.groundflip.domain.dto.auth.LoginResponse;
-import com.m3pro.groundflip.enums.Provider;
-import com.m3pro.groundflip.service.AuthService;
-import io.swagger.v3.oas.annotations.Operation;
-import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.m3pro.groundflip.domain.dto.Response;
+import com.m3pro.groundflip.domain.dto.auth.LoginRequest;
+import com.m3pro.groundflip.domain.dto.auth.LoginResponse;
+import com.m3pro.groundflip.enums.Provider;
+import com.m3pro.groundflip.service.AuthService;
+
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/auth")
 public class AuthController {
-    private final AuthService authService;
+	private final AuthService authService;
 
-    @Operation(summary = "카카오 로그인", description = "카카오에서 받은 액세스 토큰을 통해 회원가입 또는 로그인하는 API")
-    @PostMapping("/kakao/login")
-    public Response<LoginResponse> loginKaKao(@RequestBody LoginRequest loginRequest) {
-        return Response.createSuccess(authService.login(Provider.KAKAO, loginRequest));
-    }
+	@Operation(summary = "카카오 로그인", description = "카카오에서 받은 액세스 토큰을 통해 회원가입 또는 로그인하는 API")
+	@PostMapping("/kakao/login")
+	public Response<LoginResponse> loginKaKao(@RequestBody LoginRequest loginRequest) {
+		return Response.createSuccess(authService.login(Provider.KAKAO, loginRequest));
+	}
 }
+

--- a/src/main/java/com/m3pro/groundflip/controller/AuthController.java
+++ b/src/main/java/com/m3pro/groundflip/controller/AuthController.java
@@ -8,15 +8,19 @@ import org.springframework.web.bind.annotation.RestController;
 import com.m3pro.groundflip.domain.dto.Response;
 import com.m3pro.groundflip.domain.dto.auth.LoginRequest;
 import com.m3pro.groundflip.domain.dto.auth.LoginResponse;
+import com.m3pro.groundflip.domain.dto.auth.ReissueRequest;
+import com.m3pro.groundflip.domain.dto.auth.Tokens;
 import com.m3pro.groundflip.enums.Provider;
 import com.m3pro.groundflip.service.AuthService;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/auth")
+@Tag(name = "auth", description = "인증 인가 API")
 public class AuthController {
 	private final AuthService authService;
 
@@ -24,6 +28,12 @@ public class AuthController {
 	@PostMapping("/kakao/login")
 	public Response<LoginResponse> loginKaKao(@RequestBody LoginRequest loginRequest) {
 		return Response.createSuccess(authService.login(Provider.KAKAO, loginRequest));
+	}
+
+	@Operation(summary = "access token 재발급", description = "만료된 access token 을 refresh token으로 재발급 하는 API")
+	@PostMapping("/reissue")
+	public Response<Tokens> reissueToken(@RequestBody ReissueRequest reissueRequest) {
+		return Response.createSuccess(new Tokens());
 	}
 }
 

--- a/src/main/java/com/m3pro/groundflip/controller/CommunityController.java
+++ b/src/main/java/com/m3pro/groundflip/controller/CommunityController.java
@@ -15,11 +15,13 @@ import com.m3pro.groundflip.service.CommunityService;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/groups")
+@SecurityRequirement(name = "Authorization")
 public class CommunityController {
 	private final CommunityService communityService;
 

--- a/src/main/java/com/m3pro/groundflip/controller/PixelController.java
+++ b/src/main/java/com/m3pro/groundflip/controller/PixelController.java
@@ -22,6 +22,7 @@ import com.m3pro.groundflip.service.PixelService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
@@ -34,6 +35,7 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 @RequestMapping("/api/pixels")
 @Tag(name = "pixels", description = "픽셀 API")
+@SecurityRequirement(name = "Authorization")
 public class PixelController {
 	private final PixelService pixelService;
 

--- a/src/main/java/com/m3pro/groundflip/controller/PixelController.java
+++ b/src/main/java/com/m3pro/groundflip/controller/PixelController.java
@@ -2,12 +2,8 @@ package com.m3pro.groundflip.controller;
 
 import java.util.List;
 
-import com.m3pro.groundflip.domain.dto.pixel.*;
-import com.m3pro.groundflip.domain.dto.pixelUser.IndividualHistoryPixelInfoResponse;
-
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -15,7 +11,12 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.m3pro.groundflip.domain.dto.Response;
-
+import com.m3pro.groundflip.domain.dto.pixel.IndividualHistoryPixelResponse;
+import com.m3pro.groundflip.domain.dto.pixel.IndividualModePixelResponse;
+import com.m3pro.groundflip.domain.dto.pixel.IndividualPixelInfoResponse;
+import com.m3pro.groundflip.domain.dto.pixel.PixelCountResponse;
+import com.m3pro.groundflip.domain.dto.pixel.PixelOccupyRequest;
+import com.m3pro.groundflip.domain.dto.pixelUser.IndividualHistoryPixelInfoResponse;
 import com.m3pro.groundflip.service.PixelService;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -105,3 +106,4 @@ public class PixelController {
 		return Response.createSuccess(pixelService.getPixelCount(userId));
 	}
 }
+

--- a/src/main/java/com/m3pro/groundflip/controller/UserController.java
+++ b/src/main/java/com/m3pro/groundflip/controller/UserController.java
@@ -1,7 +1,5 @@
 package com.m3pro.groundflip.controller;
 
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;

--- a/src/main/java/com/m3pro/groundflip/controller/UserController.java
+++ b/src/main/java/com/m3pro/groundflip/controller/UserController.java
@@ -14,6 +14,7 @@ import com.m3pro.groundflip.service.UserService;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 
@@ -21,6 +22,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 @RequestMapping("/api/users")
 @Tag(name = "users", description = "사용자 API")
+@SecurityRequirement(name = "Authorization")
 public class UserController {
 	private final UserService userService;
 

--- a/src/main/java/com/m3pro/groundflip/domain/dto/StepRecord/UserStepInfo.java
+++ b/src/main/java/com/m3pro/groundflip/domain/dto/StepRecord/UserStepInfo.java
@@ -1,8 +1,8 @@
 package com.m3pro.groundflip.domain.dto.StepRecord;
 
-import com.m3pro.groundflip.domain.entity.StepRecord;
-
 import java.sql.Date;
+
+import com.m3pro.groundflip.domain.entity.StepRecord;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;

--- a/src/main/java/com/m3pro/groundflip/domain/dto/auth/KaKaoUserInfoResponse.java
+++ b/src/main/java/com/m3pro/groundflip/domain/dto/auth/KaKaoUserInfoResponse.java
@@ -3,28 +3,30 @@ package com.m3pro.groundflip.domain.dto.auth;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.m3pro.groundflip.enums.Provider;
+
 import lombok.Getter;
 
 @Getter
 @JsonIgnoreProperties(ignoreUnknown = true)
 
-public class KaKaoUserInfoResponse implements OauthUserInfoResponse{
-    @JsonProperty("kakao_account")
-    private KakaoAccount kakaoAccount;
+public class KaKaoUserInfoResponse implements OauthUserInfoResponse {
+	@JsonProperty("kakao_account")
+	private KakaoAccount kakaoAccount;
 
-    @Getter
-    @JsonIgnoreProperties(ignoreUnknown = true)
-    static class KakaoAccount {
-        private String email;
-    }
+	@Override
+	public String getEmail() {
+		return kakaoAccount.getEmail();
+	}
 
-    @Override
-    public String getEmail() {
-        return kakaoAccount.getEmail();
-    }
+	@Override
+	public Provider getOAuthProvider() {
+		return Provider.KAKAO;
+	}
 
-    @Override
-    public Provider getOAuthProvider() {
-        return Provider.KAKAO;
-    }
+	@Getter
+	@JsonIgnoreProperties(ignoreUnknown = true)
+	static class KakaoAccount {
+		private String email;
+	}
 }
+

--- a/src/main/java/com/m3pro/groundflip/domain/dto/auth/KakaoTokenValidationResponse.java
+++ b/src/main/java/com/m3pro/groundflip/domain/dto/auth/KakaoTokenValidationResponse.java
@@ -2,11 +2,13 @@ package com.m3pro.groundflip.domain.dto.auth;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
+
 import lombok.Getter;
 
 @Getter
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class KakaoTokenValidationResponse {
-    @JsonProperty("app_id")
-    private Integer appId;
+	@JsonProperty("app_id")
+	private Integer appId;
 }
+

--- a/src/main/java/com/m3pro/groundflip/domain/dto/auth/LoginRequest.java
+++ b/src/main/java/com/m3pro/groundflip/domain/dto/auth/LoginRequest.java
@@ -12,6 +12,7 @@ import lombok.NoArgsConstructor;
 @Builder
 @Schema(title = "로그인 요청 Body")
 public class LoginRequest {
-    @Schema(description = "프로바이더로부터 받은 액세스 토큰", example = "dslafjkdsrtjlejldfkajlasljdf")
-    private String accessToken;
+	@Schema(description = "프로바이더로부터 받은 액세스 토큰", example = "dslafjkdsrtjlejldfkajlasljdf")
+	private String accessToken;
 }
+

--- a/src/main/java/com/m3pro/groundflip/domain/dto/auth/LoginResponse.java
+++ b/src/main/java/com/m3pro/groundflip/domain/dto/auth/LoginResponse.java
@@ -10,12 +10,13 @@ import lombok.NoArgsConstructor;
 @Data
 @Schema(title = "로그인 응답")
 public class LoginResponse {
-    @Schema(description = "서버에서 발급한 액세스 토큰")
-    private String accessToken;
+	@Schema(description = "서버에서 발급한 액세스 토큰")
+	private String accessToken;
 
-    @Schema(description = "서버에서 발급한 리프레쉬 토큰")
-    private String refreshToken;
+	@Schema(description = "서버에서 발급한 리프레쉬 토큰")
+	private String refreshToken;
 
-    @Schema(description = "최초 로그인(회원가입)인지 여부", example = "true")
-    private Boolean isSignUp;
+	@Schema(description = "최초 로그인(회원가입)인지 여부", example = "true")
+	private Boolean isSignUp;
 }
+

--- a/src/main/java/com/m3pro/groundflip/domain/dto/auth/LoginResponse.java
+++ b/src/main/java/com/m3pro/groundflip/domain/dto/auth/LoginResponse.java
@@ -3,20 +3,21 @@ package com.m3pro.groundflip.domain.dto.auth;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 
+@EqualsAndHashCode(callSuper = true)
 @AllArgsConstructor
 @NoArgsConstructor
 @Data
 @Schema(title = "로그인 응답")
-public class LoginResponse {
-	@Schema(description = "서버에서 발급한 액세스 토큰")
-	private String accessToken;
-
-	@Schema(description = "서버에서 발급한 리프레쉬 토큰")
-	private String refreshToken;
-
+public class LoginResponse extends Tokens {
 	@Schema(description = "최초 로그인(회원가입)인지 여부", example = "true")
 	private Boolean isSignUp;
+
+	public LoginResponse(String accessToken, String refreshToken, Boolean isSignUp) {
+		super(accessToken, refreshToken);
+		this.isSignUp = isSignUp;
+	}
 }
 

--- a/src/main/java/com/m3pro/groundflip/domain/dto/auth/LoginResponse.java
+++ b/src/main/java/com/m3pro/groundflip/domain/dto/auth/LoginResponse.java
@@ -3,21 +3,20 @@ package com.m3pro.groundflip.domain.dto.auth;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Data;
-import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 
-@EqualsAndHashCode(callSuper = true)
 @AllArgsConstructor
 @NoArgsConstructor
 @Data
 @Schema(title = "로그인 응답")
-public class LoginResponse extends Tokens {
+public class LoginResponse {
+	@Schema(description = "서버에서 발급한 액세스 토큰")
+	private String accessToken;
+
+	@Schema(description = "서버에서 발급한 리프레쉬 토큰")
+	private String refreshToken;
+
 	@Schema(description = "최초 로그인(회원가입)인지 여부", example = "true")
 	private Boolean isSignUp;
-
-	public LoginResponse(String accessToken, String refreshToken, Boolean isSignUp) {
-		super(accessToken, refreshToken);
-		this.isSignUp = isSignUp;
-	}
 }
 

--- a/src/main/java/com/m3pro/groundflip/domain/dto/auth/OauthUserInfoResponse.java
+++ b/src/main/java/com/m3pro/groundflip/domain/dto/auth/OauthUserInfoResponse.java
@@ -3,6 +3,8 @@ package com.m3pro.groundflip.domain.dto.auth;
 import com.m3pro.groundflip.enums.Provider;
 
 public interface OauthUserInfoResponse {
-    String getEmail();
-    Provider getOAuthProvider();
+	String getEmail();
+
+	Provider getOAuthProvider();
 }
+

--- a/src/main/java/com/m3pro/groundflip/domain/dto/auth/ReissueReponse.java
+++ b/src/main/java/com/m3pro/groundflip/domain/dto/auth/ReissueReponse.java
@@ -8,11 +8,11 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor
 @Data
-@Schema(title = "토큰")
-public class Tokens {
-	@Schema(description = "서버에서 발급한 액세스 토큰")
+@Schema(title = "토큰 재발급 응답")
+public class ReissueReponse {
+	@Schema(description = "서버에서 재발급한 액세스 토큰")
 	private String accessToken;
 
-	@Schema(description = "서버에서 발급한 리프레쉬 토큰")
+	@Schema(description = "서버에서 재발급한 리프레쉬 토큰")
 	private String refreshToken;
 }

--- a/src/main/java/com/m3pro/groundflip/domain/dto/auth/ReissueRequest.java
+++ b/src/main/java/com/m3pro/groundflip/domain/dto/auth/ReissueRequest.java
@@ -1,0 +1,18 @@
+package com.m3pro.groundflip.domain.dto.auth;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Data
+@Builder
+@Schema(title = "토큰 재발급 요청 Body")
+public class ReissueRequest {
+	@Schema(description = "refresh token", example = "dslafjkdsrtjlejldfkajlasljdf")
+	private String refreshToken;
+}
+

--- a/src/main/java/com/m3pro/groundflip/domain/dto/auth/Tokens.java
+++ b/src/main/java/com/m3pro/groundflip/domain/dto/auth/Tokens.java
@@ -1,0 +1,18 @@
+package com.m3pro.groundflip.domain.dto.auth;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Data
+@Schema(title = "토큰")
+public class Tokens {
+	@Schema(description = "서버에서 발급한 액세스 토큰")
+	private String accessToken;
+
+	@Schema(description = "서버에서 발급한 리프레쉬 토큰")
+	private String refreshToken;
+}

--- a/src/main/java/com/m3pro/groundflip/domain/dto/community/CommunityInfoResponse.java
+++ b/src/main/java/com/m3pro/groundflip/domain/dto/community/CommunityInfoResponse.java
@@ -19,7 +19,7 @@ public class CommunityInfoResponse {
 	private int groupRanking;
 	private int memberCount;
 
-	public static CommunityInfoResponse from(Community community, int groupRanking, int memberCount){
+	public static CommunityInfoResponse from(Community community, int groupRanking, int memberCount) {
 		return CommunityInfoResponse.builder()
 			.name(community.getName())
 			.pixelColor(community.getPixelColor())
@@ -29,5 +29,4 @@ public class CommunityInfoResponse {
 			.memberCount(memberCount)
 			.build();
 	}
-
 }

--- a/src/main/java/com/m3pro/groundflip/domain/dto/pixel/IndividualHistoryPixelResponse.java
+++ b/src/main/java/com/m3pro/groundflip/domain/dto/pixel/IndividualHistoryPixelResponse.java
@@ -4,18 +4,18 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 @Schema(title = "개인기록 픽셀 정보")
 public interface IndividualHistoryPixelResponse {
-    @Schema(description = "픽셀 ID", example = "78611")
-    Long getPixelId();
+	@Schema(description = "픽셀 ID", example = "78611")
+	Long getPixelId();
 
-    @Schema(description = "픽셀 좌측 상단 위도", example = "37.503717")
-    double getLatitude();
+	@Schema(description = "픽셀 좌측 상단 위도", example = "37.503717")
+	double getLatitude();
 
-    @Schema(description = "픽셀 좌측 상단 경도", example = "127.044317")
-    double getLongitude();
+	@Schema(description = "픽셀 좌측 상단 경도", example = "127.044317")
+	double getLongitude();
 
-    @Schema(description = "픽셀 세로 상대 좌표", example = "224")
-    Integer getX();
+	@Schema(description = "픽셀 세로 상대 좌표", example = "224")
+	Integer getX();
 
-    @Schema(description = "픽셀 가로 상대 좌표", example = "210")
-    Integer getY();
+	@Schema(description = "픽셀 가로 상대 좌표", example = "210")
+	Integer getY();
 }

--- a/src/main/java/com/m3pro/groundflip/domain/dto/pixel/IndividualModePixelResponse.java
+++ b/src/main/java/com/m3pro/groundflip/domain/dto/pixel/IndividualModePixelResponse.java
@@ -4,21 +4,21 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 @Schema(title = "개인전 픽셀 정보")
 public interface IndividualModePixelResponse {
-    @Schema(description = "픽셀 ID", example = "78611")
-    Long getPixelId();
+	@Schema(description = "픽셀 ID", example = "78611")
+	Long getPixelId();
 
-    @Schema(description = "픽셀 좌측 상단 위도", example = "37.503717")
-    double getLatitude();
+	@Schema(description = "픽셀 좌측 상단 위도", example = "37.503717")
+	double getLatitude();
 
-    @Schema(description = "픽셀 좌측 상단 경도", example = "127.044317")
-    double getLongitude();
+	@Schema(description = "픽셀 좌측 상단 경도", example = "127.044317")
+	double getLongitude();
 
-    @Schema(description = "소유주의 ID", example = "3")
-    Long getUserId();
+	@Schema(description = "소유주의 ID", example = "3")
+	Long getUserId();
 
-    @Schema(description = "픽셀 세로 상대 좌표", example = "224")
-    Integer getX();
+	@Schema(description = "픽셀 세로 상대 좌표", example = "224")
+	Integer getX();
 
-    @Schema(description = "픽셀 가로 상대 좌표", example = "210")
-    Integer getY();
+	@Schema(description = "픽셀 가로 상대 좌표", example = "210")
+	Integer getY();
 }

--- a/src/main/java/com/m3pro/groundflip/domain/dto/pixel/IndividualPixelInfoResponse.java
+++ b/src/main/java/com/m3pro/groundflip/domain/dto/pixel/IndividualPixelInfoResponse.java
@@ -16,33 +16,33 @@ import lombok.NoArgsConstructor;
 @Builder
 @Schema(title = "개인전 픽셀 정보")
 public class IndividualPixelInfoResponse {
-    private String address;
-    private Integer addressNumber;
-    private Integer visitCount;
-    private PixelOwnerUserResponse pixelOwnerUser;
-    private List<VisitedUserInfo> visitList;
+	private String address;
+	private Integer addressNumber;
+	private Integer visitCount;
+	private PixelOwnerUserResponse pixelOwnerUser;
+	private List<VisitedUserInfo> visitList;
 
-    public static IndividualPixelInfoResponse from(Pixel pixel, PixelOwnerUserResponse pixelOwnerUserResponse,
-                                                   List<VisitedUserInfo> visitedUserList) {
-        String realAddress;
+	public static IndividualPixelInfoResponse from(Pixel pixel, PixelOwnerUserResponse pixelOwnerUserResponse,
+		List<VisitedUserInfo> visitedUserList) {
+		String realAddress;
 
-        if (pixel.getAddress() != null) {
-            String[] addressArr = pixel.getAddress().split(" ");
-            if (addressArr[0].equals("대한민국")) {
-                realAddress = addressArr[0];
-            } else {
-                realAddress = addressArr[1] + ' ' + addressArr[2];
-            }
-        } else {
-            realAddress = null;
-        }
+		if (pixel.getAddress() != null) {
+			String[] addressArr = pixel.getAddress().split(" ");
+			if (addressArr[0].equals("대한민국")) {
+				realAddress = addressArr[0];
+			} else {
+				realAddress = addressArr[1] + ' ' + addressArr[2];
+			}
+		} else {
+			realAddress = null;
+		}
 
-        return IndividualPixelInfoResponse.builder()
-                .address(realAddress)
-                .addressNumber(pixel.getAddressNumber())
-                .visitCount(visitedUserList.size())
-                .pixelOwnerUser(pixelOwnerUserResponse)
-                .visitList(visitedUserList)
-                .build();
-    }
+		return IndividualPixelInfoResponse.builder()
+			.address(realAddress)
+			.addressNumber(pixel.getAddressNumber())
+			.visitCount(visitedUserList.size())
+			.pixelOwnerUser(pixelOwnerUserResponse)
+			.visitList(visitedUserList)
+			.build();
+	}
 }

--- a/src/main/java/com/m3pro/groundflip/domain/dto/pixel/PixelCountResponse.java
+++ b/src/main/java/com/m3pro/groundflip/domain/dto/pixel/PixelCountResponse.java
@@ -12,9 +12,9 @@ import lombok.NoArgsConstructor;
 @Builder
 @Schema(title = "픽셀 개수")
 public class PixelCountResponse {
-    @Schema(description = "현재 차지하고 있는 픽셀 개수", example = "5")
-    private Integer currentPixelCount;
+	@Schema(description = "현재 차지하고 있는 픽셀 개수", example = "5")
+	private Integer currentPixelCount;
 
-    @Schema(description = "지금까지 차지한 픽셀 개수", example = "5")
-    private Integer accumulatePixelCount;
+	@Schema(description = "지금까지 차지한 픽셀 개수", example = "5")
+	private Integer accumulatePixelCount;
 }

--- a/src/main/java/com/m3pro/groundflip/domain/dto/pixelUser/IndividualHistoryPixelInfoResponse.java
+++ b/src/main/java/com/m3pro/groundflip/domain/dto/pixelUser/IndividualHistoryPixelInfoResponse.java
@@ -1,18 +1,18 @@
 package com.m3pro.groundflip.domain.dto.pixelUser;
 
+import java.time.LocalDateTime;
+import java.util.List;
+
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-
-import java.time.LocalDateTime;
-import java.util.List;
 
 @AllArgsConstructor
 @NoArgsConstructor
 @Data
 public class IndividualHistoryPixelInfoResponse {
-    private String address;
-    private Integer addressNumber;
-    private Integer visitCount;
-    private List<LocalDateTime> visitList;
+	private String address;
+	private Integer addressNumber;
+	private Integer visitCount;
+	private List<LocalDateTime> visitList;
 }

--- a/src/main/java/com/m3pro/groundflip/domain/entity/User.java
+++ b/src/main/java/com/m3pro/groundflip/domain/entity/User.java
@@ -5,6 +5,7 @@ import java.util.Date;
 import com.m3pro.groundflip.domain.entity.global.BaseTimeEntity;
 import com.m3pro.groundflip.enums.Gender;
 import com.m3pro.groundflip.enums.Provider;
+import com.m3pro.groundflip.enums.UserStatus;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -14,7 +15,6 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
-
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.Pattern;
 import lombok.AccessLevel;
@@ -47,6 +47,9 @@ public class User extends BaseTimeEntity {
 
 	@Enumerated(EnumType.STRING)
 	private Provider provider;
+
+	@Enumerated(EnumType.STRING)
+	private UserStatus status;
 
 	@Email
 	private String email;

--- a/src/main/java/com/m3pro/groundflip/enums/UserStatus.java
+++ b/src/main/java/com/m3pro/groundflip/enums/UserStatus.java
@@ -1,0 +1,13 @@
+package com.m3pro.groundflip.enums;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public enum UserStatus {
+	PENDING("pending"),
+	COMPLETE("complete");
+
+	private final String status;
+}

--- a/src/main/java/com/m3pro/groundflip/jwt/JwtAuthorizationFilter.java
+++ b/src/main/java/com/m3pro/groundflip/jwt/JwtAuthorizationFilter.java
@@ -1,65 +1,68 @@
 package com.m3pro.groundflip.jwt;
 
-import jakarta.servlet.FilterChain;
-import jakarta.servlet.ServletException;
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
-import lombok.RequiredArgsConstructor;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
-import java.io.IOException;
-import java.util.Collections;
-import java.util.List;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
 
 @Component
 @RequiredArgsConstructor
 public class JwtAuthorizationFilter extends OncePerRequestFilter {
-    private final JwtProvider jwtProvider;
-    private static final List<String> WHITE_LIST = List.of(
-            "/api/auth",
-            "/api/docs",
-            "/v3/api-docs",
-            "/api/swagger-ui");
+	private static final List<String> WHITE_LIST = List.of(
+		"/api/auth",
+		"/api/docs",
+		"/v3/api-docs",
+		"/api/swagger-ui");
+	private static final List<String> WHITE_LIST_TMP = List.of(
+		"/api",
+		"/api/docs",
+		"/v3/api-docs",
+		"/api/swagger-ui");
+	private final JwtProvider jwtProvider;
 
-    private static final List<String> WHITE_LIST_TMP = List.of(
-            "/api",
-            "/api/docs",
-            "/v3/api-docs",
-            "/api/swagger-ui");
+	@Override
+	protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+		FilterChain filterChain) throws ServletException, IOException {
+		String token = parseBearerToken(request);
+		if (jwtProvider.isTokenValid(token)) {
+			setAuthentication(token);
+		}
 
-    @Override
-    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
-        String token = parseBearerToken(request);
-        if (jwtProvider.isTokenValid(token)) {
-            setAuthentication(token);
-        }
+		filterChain.doFilter(request, response);
+	}
 
-        filterChain.doFilter(request, response);
-    }
+	private void setAuthentication(String accessToken) {
+		Long userId = jwtProvider.parseUserId(accessToken);
+		UsernamePasswordAuthenticationToken authenticationToken =
+			new UsernamePasswordAuthenticationToken(userId, "",
+				Collections.singletonList(new SimpleGrantedAuthority("ROLE_USER")));
+		SecurityContextHolder.getContext().setAuthentication(authenticationToken);
+	}
 
-    private void setAuthentication(String accessToken) {
-        Long userId = jwtProvider.parseUserId(accessToken);
-        UsernamePasswordAuthenticationToken authenticationToken =
-                new UsernamePasswordAuthenticationToken(userId, "", Collections.singletonList(new SimpleGrantedAuthority("ROLE_USER")));
-        SecurityContextHolder.getContext().setAuthentication(authenticationToken);
-    }
+	@Override
+	protected boolean shouldNotFilter(HttpServletRequest request) {
+		String path = request.getRequestURI();
+		return WHITE_LIST_TMP.stream().anyMatch(path::startsWith);
+	}
 
-    @Override
-    protected boolean shouldNotFilter(HttpServletRequest request) {
-        String path = request.getRequestURI();
-        return WHITE_LIST_TMP.stream().anyMatch(path::startsWith);
-    }
+	private String parseBearerToken(HttpServletRequest request) {
+		String bearerToken = request.getHeader("Authorization");
 
-    private String parseBearerToken(HttpServletRequest request) {
-        String bearerToken = request.getHeader("Authorization");
-
-        if (bearerToken != null && bearerToken.startsWith("Bearer")) {
-            return bearerToken.substring(7);
-        }
-        return null;
-    }
+		if (bearerToken != null && bearerToken.startsWith("Bearer")) {
+			return bearerToken.substring(7);
+		}
+		return null;
+	}
 }
+

--- a/src/main/java/com/m3pro/groundflip/jwt/JwtAuthorizationFilter.java
+++ b/src/main/java/com/m3pro/groundflip/jwt/JwtAuthorizationFilter.java
@@ -53,7 +53,7 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
 	@Override
 	protected boolean shouldNotFilter(HttpServletRequest request) {
 		String path = request.getRequestURI();
-		return WHITE_LIST_TMP.stream().anyMatch(path::startsWith);
+		return WHITE_LIST.stream().anyMatch(path::startsWith);
 	}
 
 	private String parseBearerToken(HttpServletRequest request) {

--- a/src/main/java/com/m3pro/groundflip/jwt/JwtExceptionFilter.java
+++ b/src/main/java/com/m3pro/groundflip/jwt/JwtExceptionFilter.java
@@ -1,41 +1,46 @@
 package com.m3pro.groundflip.jwt;
 
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.m3pro.groundflip.exception.AppException;
+
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.AllArgsConstructor;
-import org.springframework.stereotype.Component;
-import org.springframework.web.filter.OncePerRequestFilter;
-
-import java.io.IOException;
-import java.util.HashMap;
-import java.util.Map;
 
 @Component
 @AllArgsConstructor
 public class JwtExceptionFilter extends OncePerRequestFilter {
-    @Override
-    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
-        try {
-            filterChain.doFilter(request, response);
-        } catch (AppException e) {
-            setErrorResponse(request, response, e);
-        }
-    }
+	@Override
+	protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+		FilterChain filterChain) throws ServletException, IOException {
+		try {
+			filterChain.doFilter(request, response);
+		} catch (AppException e) {
+			setErrorResponse(request, response, e);
+		}
+	}
 
-    public void setErrorResponse(HttpServletRequest request, HttpServletResponse response, AppException ex) throws IOException {
-        final Map<String, Object> body = new HashMap<>();
-        final ObjectMapper mapper = new ObjectMapper();
+	public void setErrorResponse(HttpServletRequest request, HttpServletResponse response, AppException ex) throws
+		IOException {
+		final Map<String, Object> body = new HashMap<>();
+		final ObjectMapper mapper = new ObjectMapper();
 
-        body.put("result", "error");
-        body.put("message", ex.getErrorCode().getMessage());
-        body.put("data", null);
+		body.put("result", "error");
+		body.put("message", ex.getErrorCode().getMessage());
+		body.put("data", null);
 
-        response.setContentType("application/json; charset=UTF-8");
-        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
-        response.getWriter().write(mapper.writeValueAsString(body));
-    }
+		response.setContentType("application/json; charset=UTF-8");
+		response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+		response.getWriter().write(mapper.writeValueAsString(body));
+	}
 }
+

--- a/src/main/java/com/m3pro/groundflip/jwt/JwtProvider.java
+++ b/src/main/java/com/m3pro/groundflip/jwt/JwtProvider.java
@@ -1,57 +1,65 @@
 package com.m3pro.groundflip.jwt;
 
-import com.m3pro.groundflip.exception.AppException;
-import com.m3pro.groundflip.exception.ErrorCode;
-import io.jsonwebtoken.*;
+import java.util.Date;
+
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 
-import java.util.Date;
+import com.m3pro.groundflip.exception.AppException;
+import com.m3pro.groundflip.exception.ErrorCode;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.SignatureException;
 
 @Component
 public class JwtProvider {
-    @Value("${jwt.secret}")
-    private String jwtSecretKey;
-    @Value("${jwt.access-token-time}")
-    private long accessTokenTime;
-    @Value("${jwt.refresh-token-time}")
-    private long refreshTokenTime;
+	@Value("${jwt.secret}")
+	private String jwtSecretKey;
+	@Value("${jwt.access-token-time}")
+	private long accessTokenTime;
+	@Value("${jwt.refresh-token-time}")
+	private long refreshTokenTime;
 
-    public String createAccessToken(Long userId) {
-        return createToken(userId, accessTokenTime);
-    }
+	public String createAccessToken(Long userId) {
+		return createToken(userId, accessTokenTime);
+	}
 
-    public String createRefreshToken(Long userId) {
-        return createToken(userId, refreshTokenTime);
-    }
+	public String createRefreshToken(Long userId) {
+		return createToken(userId, refreshTokenTime);
+	}
 
-    private String createToken(Long userId, long validTime) {
-        Date now = new Date();
-        return Jwts.builder()
-                .setIssuedAt(now)
-                .setExpiration(new Date(now.getTime() + validTime))
-                .claim("userId", userId)
-                .signWith(SignatureAlgorithm.HS256, jwtSecretKey)
-                .compact();
-    }
+	private String createToken(Long userId, long validTime) {
+		Date now = new Date();
+		return Jwts.builder()
+			.setIssuedAt(now)
+			.setExpiration(new Date(now.getTime() + validTime))
+			.claim("userId", userId)
+			.signWith(SignatureAlgorithm.HS256, jwtSecretKey)
+			.compact();
+	}
 
-    public boolean isTokenValid(String token) {
-        if (!StringUtils.hasText(token)) {
-            throw new AppException(ErrorCode.JWT_NOT_EXISTS);
-        }
-        try {
-            Jwts.parser().setSigningKey(jwtSecretKey).parseClaimsJws(token).getBody();
-        } catch (SignatureException | MalformedJwtException e) {
-            throw new AppException(ErrorCode.INVALID_JWT);
-        } catch (ExpiredJwtException e ) {
-            throw new AppException(ErrorCode.JWT_EXPIRED);
-        }
-        return true;
-    }
+	public boolean isTokenValid(String token) {
+		if (!StringUtils.hasText(token)) {
+			throw new AppException(ErrorCode.JWT_NOT_EXISTS);
+		}
+		try {
+			Jwts.parser().setSigningKey(jwtSecretKey).parseClaimsJws(token).getBody();
+		} catch (SignatureException | MalformedJwtException e) {
+			throw new AppException(ErrorCode.INVALID_JWT);
+		} catch (ExpiredJwtException e) {
+			throw new AppException(ErrorCode.JWT_EXPIRED);
+		}
+		return true;
+	}
 
-    public Long parseUserId(String token) {
-        Claims claims = Jwts.parser().setSigningKey(jwtSecretKey).parseClaimsJws(token).getBody();
-        return claims.get("userId", Long.class);
-    }
+	public Long parseUserId(String token) {
+		Claims claims = Jwts.parser().setSigningKey(jwtSecretKey).parseClaimsJws(token).getBody();
+		return claims.get("userId", Long.class);
+	}
 }
+

--- a/src/main/java/com/m3pro/groundflip/repository/PixelRepository.java
+++ b/src/main/java/com/m3pro/groundflip/repository/PixelRepository.java
@@ -3,13 +3,13 @@ package com.m3pro.groundflip.repository;
 import java.util.List;
 import java.util.Optional;
 
-import com.m3pro.groundflip.domain.dto.pixel.IndividualHistoryPixelResponse;
-import com.m3pro.groundflip.domain.dto.pixel.IndividualModePixelResponse;
 import org.locationtech.jts.geom.Point;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import com.m3pro.groundflip.domain.dto.pixel.IndividualHistoryPixelResponse;
+import com.m3pro.groundflip.domain.dto.pixel.IndividualModePixelResponse;
 import com.m3pro.groundflip.domain.entity.Pixel;
 
 public interface PixelRepository extends JpaRepository<Pixel, Long> {

--- a/src/main/java/com/m3pro/groundflip/repository/PixelUserRepository.java
+++ b/src/main/java/com/m3pro/groundflip/repository/PixelUserRepository.java
@@ -2,8 +2,6 @@ package com.m3pro.groundflip.repository;
 
 import java.util.List;
 
-import com.m3pro.groundflip.domain.entity.Pixel;
-import com.m3pro.groundflip.domain.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -11,19 +9,21 @@ import org.springframework.data.repository.query.Param;
 import com.m3pro.groundflip.domain.dto.pixelUser.PixelCount;
 import com.m3pro.groundflip.domain.dto.pixelUser.PixelOwnerUser;
 import com.m3pro.groundflip.domain.dto.pixelUser.VisitedUser;
+import com.m3pro.groundflip.domain.entity.Pixel;
 import com.m3pro.groundflip.domain.entity.PixelUser;
+import com.m3pro.groundflip.domain.entity.User;
 
 public interface PixelUserRepository extends JpaRepository<PixelUser, Long> {
 	@Query(value = """
-			SELECT pu.pixel_id AS pixelId,
-			       pu.user_id AS userId,
-			       u.nickname AS nickname,
-			       u.profile_image AS profileImage 
-			FROM pixel_user pu
-			JOIN user u ON pu.user_id = u.user_id 
-			WHERE pu.pixel_id = :pixel_id AND pu.created_at >= current_date() 
-			GROUP BY pu.user_id;
-			""", nativeQuery = true)
+		SELECT pu.pixel_id AS pixelId,
+		       pu.user_id AS userId,
+		       u.nickname AS nickname,
+		       u.profile_image AS profileImage 
+		FROM pixel_user pu
+		JOIN user u ON pu.user_id = u.user_id 
+		WHERE pu.pixel_id = :pixel_id AND pu.created_at >= current_date() 
+		GROUP BY pu.user_id;
+		""", nativeQuery = true)
 	List<VisitedUser> findAllVisitedUserByPixelId(
 		@Param("pixel_id") Long pixelId);
 
@@ -49,26 +49,26 @@ public interface PixelUserRepository extends JpaRepository<PixelUser, Long> {
 		@Param("user_id") Long userId);
 
 	@Query(value = """
-        SELECT COUNT(*) AS count
-        FROM pixel_user pu
-        JOIN (
-            SELECT MAX(pixel_user_id) AS latest_pixel_user_id
-            FROM pixel_user
-            GROUP BY pixel_id
-        ) latest_visits
-        ON
-        pu.pixel_user_id = latest_visits.latest_pixel_user_id
-        WHERE pu.user_id = :user_id
-        """, nativeQuery = true)
+		SELECT COUNT(*) AS count
+		FROM pixel_user pu
+		JOIN (
+		    SELECT MAX(pixel_user_id) AS latest_pixel_user_id
+		    FROM pixel_user
+		    GROUP BY pixel_id
+		) latest_visits
+		ON
+		pu.pixel_user_id = latest_visits.latest_pixel_user_id
+		WHERE pu.user_id = :user_id
+		""", nativeQuery = true)
 	PixelCount findCurrentPixelCountByUserId(
 		@Param("user_id") Long userId);
 
 	@Query(value = """
-		SELECT pu
-		FROM PixelUser pu
-		WHERE pu.pixel = :pixel AND pu.user = :user
-		GROUP BY DATE(pu.createdAt)
-		ORDER BY pu.createdAt DESC
-	""")
+			SELECT pu
+			FROM PixelUser pu
+			WHERE pu.pixel = :pixel AND pu.user = :user
+			GROUP BY DATE(pu.createdAt)
+			ORDER BY pu.createdAt DESC
+		""")
 	List<PixelUser> findAllVisitHistoryByPixelAndUser(@Param("pixel") Pixel pixel, @Param("user") User user);
 }

--- a/src/main/java/com/m3pro/groundflip/repository/UserRepository.java
+++ b/src/main/java/com/m3pro/groundflip/repository/UserRepository.java
@@ -1,12 +1,12 @@
 package com.m3pro.groundflip.repository;
 
-import com.m3pro.groundflip.enums.Provider;
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.m3pro.groundflip.domain.entity.User;
-
-import java.util.Optional;
+import com.m3pro.groundflip.enums.Provider;
 
 public interface UserRepository extends JpaRepository<User, Long> {
-    Optional<User> findByProviderAndEmail(Provider provider, String email);
+	Optional<User> findByProviderAndEmail(Provider provider, String email);
 }

--- a/src/main/java/com/m3pro/groundflip/service/AuthService.java
+++ b/src/main/java/com/m3pro/groundflip/service/AuthService.java
@@ -36,7 +36,7 @@ public class AuthService {
 
 		if (loginUser.isPresent()) {
 			userId = loginUser.get().getId();
-			isSignUp = false;
+			isSignUp = loginUser.get().getStatus() == UserStatus.PENDING;
 		} else {
 			userId = registerUser(provider, oauthUserInfo.getEmail()).getId();
 			isSignUp = true;

--- a/src/main/java/com/m3pro/groundflip/service/AuthService.java
+++ b/src/main/java/com/m3pro/groundflip/service/AuthService.java
@@ -10,6 +10,7 @@ import com.m3pro.groundflip.domain.dto.auth.OauthUserInfoResponse;
 import com.m3pro.groundflip.domain.dto.auth.Tokens;
 import com.m3pro.groundflip.domain.entity.User;
 import com.m3pro.groundflip.enums.Provider;
+import com.m3pro.groundflip.enums.UserStatus;
 import com.m3pro.groundflip.jwt.JwtProvider;
 import com.m3pro.groundflip.repository.UserRepository;
 import com.m3pro.groundflip.service.oauth.OauthService;
@@ -50,6 +51,7 @@ public class AuthService {
 		User registerUser = User.builder()
 			.email(email)
 			.provider(provider)
+			.status(UserStatus.PENDING)
 			.build();
 		return userRepository.save(registerUser);
 	}

--- a/src/main/java/com/m3pro/groundflip/service/AuthService.java
+++ b/src/main/java/com/m3pro/groundflip/service/AuthService.java
@@ -1,54 +1,56 @@
 package com.m3pro.groundflip.service;
 
+import java.util.Optional;
+
+import org.springframework.stereotype.Service;
+
 import com.m3pro.groundflip.domain.dto.auth.LoginRequest;
 import com.m3pro.groundflip.domain.dto.auth.LoginResponse;
 import com.m3pro.groundflip.domain.dto.auth.OauthUserInfoResponse;
 import com.m3pro.groundflip.domain.entity.User;
 import com.m3pro.groundflip.enums.Provider;
-import com.m3pro.groundflip.exception.AppException;
-import com.m3pro.groundflip.exception.ErrorCode;
 import com.m3pro.groundflip.jwt.JwtProvider;
 import com.m3pro.groundflip.repository.UserRepository;
 import com.m3pro.groundflip.service.oauth.OauthService;
+
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
-
-import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
 public class AuthService {
-    private final OauthService oauthUserInfoService;
-    private final JwtProvider jwtProvider;
-    private final UserRepository userRepository;
+	private final OauthService oauthUserInfoService;
+	private final JwtProvider jwtProvider;
+	private final UserRepository userRepository;
 
-    @Transactional
-    public LoginResponse login(Provider provider, LoginRequest loginRequest) {
-        Long userId;
-        boolean isSignUp;
+	@Transactional
+	public LoginResponse login(Provider provider, LoginRequest loginRequest) {
+		Long userId;
+		boolean isSignUp;
 
-        OauthUserInfoResponse oauthUserInfo = oauthUserInfoService.requestUserInfo(provider, loginRequest.getAccessToken());
-        Optional<User> loginUser = userRepository.findByProviderAndEmail(provider, oauthUserInfo.getEmail());
+		OauthUserInfoResponse oauthUserInfo = oauthUserInfoService.requestUserInfo(provider,
+			loginRequest.getAccessToken());
+		Optional<User> loginUser = userRepository.findByProviderAndEmail(provider, oauthUserInfo.getEmail());
 
-        if (loginUser.isPresent()) {
-            userId = loginUser.get().getId();
-            isSignUp = false;
-        } else {
-            userId = registerUser(provider, oauthUserInfo.getEmail()).getId();
-            isSignUp = true;
-        }
+		if (loginUser.isPresent()) {
+			userId = loginUser.get().getId();
+			isSignUp = false;
+		} else {
+			userId = registerUser(provider, oauthUserInfo.getEmail()).getId();
+			isSignUp = true;
+		}
 
-        String accessToken = jwtProvider.createAccessToken(userId);
-        String refreshToken = jwtProvider.createRefreshToken(userId);
-        return new LoginResponse(accessToken, refreshToken, isSignUp);
-    }
+		String accessToken = jwtProvider.createAccessToken(userId);
+		String refreshToken = jwtProvider.createRefreshToken(userId);
+		return new LoginResponse(accessToken, refreshToken, isSignUp);
+	}
 
-    private User registerUser(Provider provider, String email) {
-        User registerUser = User.builder()
-                .email(email)
-                .provider(provider)
-                .build();
-        return userRepository.save(registerUser);
-    }
+	private User registerUser(Provider provider, String email) {
+		User registerUser = User.builder()
+			.email(email)
+			.provider(provider)
+			.build();
+		return userRepository.save(registerUser);
+	}
 }
+

--- a/src/main/java/com/m3pro/groundflip/service/AuthService.java
+++ b/src/main/java/com/m3pro/groundflip/service/AuthService.java
@@ -7,6 +7,7 @@ import org.springframework.stereotype.Service;
 import com.m3pro.groundflip.domain.dto.auth.LoginRequest;
 import com.m3pro.groundflip.domain.dto.auth.LoginResponse;
 import com.m3pro.groundflip.domain.dto.auth.OauthUserInfoResponse;
+import com.m3pro.groundflip.domain.dto.auth.Tokens;
 import com.m3pro.groundflip.domain.entity.User;
 import com.m3pro.groundflip.enums.Provider;
 import com.m3pro.groundflip.jwt.JwtProvider;
@@ -52,5 +53,12 @@ public class AuthService {
 			.build();
 		return userRepository.save(registerUser);
 	}
-}
 
+	public Tokens reissueToken(String refreshToken) {
+		jwtProvider.isTokenValid(refreshToken);
+		Long parsedUserId = jwtProvider.parseUserId(refreshToken);
+		String reissuedAccessToken = jwtProvider.createAccessToken(parsedUserId);
+		String reissuedRefreshToken = jwtProvider.createRefreshToken(parsedUserId);
+		return new Tokens(reissuedAccessToken, reissuedRefreshToken);
+	}
+}

--- a/src/main/java/com/m3pro/groundflip/service/AuthService.java
+++ b/src/main/java/com/m3pro/groundflip/service/AuthService.java
@@ -7,7 +7,7 @@ import org.springframework.stereotype.Service;
 import com.m3pro.groundflip.domain.dto.auth.LoginRequest;
 import com.m3pro.groundflip.domain.dto.auth.LoginResponse;
 import com.m3pro.groundflip.domain.dto.auth.OauthUserInfoResponse;
-import com.m3pro.groundflip.domain.dto.auth.Tokens;
+import com.m3pro.groundflip.domain.dto.auth.ReissueReponse;
 import com.m3pro.groundflip.domain.entity.User;
 import com.m3pro.groundflip.enums.Provider;
 import com.m3pro.groundflip.enums.UserStatus;
@@ -56,11 +56,11 @@ public class AuthService {
 		return userRepository.save(registerUser);
 	}
 
-	public Tokens reissueToken(String refreshToken) {
+	public ReissueReponse reissueToken(String refreshToken) {
 		jwtProvider.isTokenValid(refreshToken);
 		Long parsedUserId = jwtProvider.parseUserId(refreshToken);
 		String reissuedAccessToken = jwtProvider.createAccessToken(parsedUserId);
 		String reissuedRefreshToken = jwtProvider.createRefreshToken(parsedUserId);
-		return new Tokens(reissuedAccessToken, reissuedRefreshToken);
+		return new ReissueReponse(reissuedAccessToken, reissuedRefreshToken);
 	}
 }


### PR DESCRIPTION
## 작업 내용*
- 토큰 재발급 api 구현
- user pending 상태 처리
- 스웨거에 인증 인가 설정

## 고민한 내용*
### 토큰 재발급
- refresh token 을 보내면 access token 과 refresh token 까지 전부 재 발급 하도록 수정

### 사용자 상태
- 사용자는 두가지 상태가 있다.
  - Pending : 최초 로그인 하여 프로바이더 id 와 이메일만 등록된 상태 -> 회원가입을 하지 않은 상태
  - Complete : 로그인 하고 회원가입까지 완료한 상태

따라서 위 두 상태로 분리하고 최초 로그인시 Pending 상태로 저장 하였다. 로그인 할 때 마다 User 의 status 컬럼을 보고 Pending 상태이면 isSignUp이 true 로 반환하도록 하였다.

### swagger security
<img width="1465" alt="스크린샷 2024-07-11 오후 1 10 52" src="https://github.com/SWM-M3PRO/GroundFlip-BE/assets/62103197/c05bf436-7e5c-47de-bd9f-5d806d239fc9">

인증이 필요한 api 에는 자물쇠 표시를 달았다. 

인증이 필요한 컨트롤러에는 `@SecurityRequirement(name = "Authorization")` 어노테이션을 반드시 붙여준다

## 리뷰 요구사항

- 리뷰할 때 중점적으로 봐줬으면 하는 내용들

## 스크린샷