### PR TITLE
M3-171 elastic cache 연결

### DIFF
--- a/.github/workflows/cd_dev.yml
+++ b/.github/workflows/cd_dev.yml
@@ -28,6 +28,7 @@ jobs:
           echo "X-NCP-APIGW-API-KEY=${{ secrets.NAVER_APIKEY }}" >> .env
           echo "JWT_SECRET_KEY=${{ secrets.JWT_SECRET_KEY }}" >> .env
           echo "KAKAO_APP_ID=${{ secrets.KAKAO_APP_ID }}" >> .env
+          echo "REDIS_HOST=${{ secrets.REDIS_HOST }}" >> .env
 
       - name: gradlew에 실행 권한 부여
         run: chmod +x ./gradlew

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,9 @@ jobs:
           mysql root password: 'root'
           mysql user: 'root'
 
+      - name: 테스트를 위한 Redis 구동
+        run: sudo docker run -d --name redis -p 6379:6379 redis:latest
+
       - name: JDK 17 설치
         uses: actions/setup-java@v3
         with:

--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
     // 스웨거 기본 설정을 위한 의존성
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'

--- a/src/main/java/com/m3pro/groundflip/config/RedisConfig.java
+++ b/src/main/java/com/m3pro/groundflip/config/RedisConfig.java
@@ -1,0 +1,20 @@
+package com.m3pro.groundflip.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+
+@Configuration
+public class RedisConfig {
+	@Value("${spring.data.redis.host}")
+	private String host;
+	@Value("${spring.data.redis.port}")
+	private int port;
+
+	@Bean
+	public RedisConnectionFactory redisConnectionFactory() {
+		return new LettuceConnectionFactory(host, port);
+	}
+}

--- a/src/main/java/com/m3pro/groundflip/config/RedisConfig.java
+++ b/src/main/java/com/m3pro/groundflip/config/RedisConfig.java
@@ -5,6 +5,8 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 @Configuration
 public class RedisConfig {
@@ -16,5 +18,21 @@ public class RedisConfig {
 	@Bean
 	public RedisConnectionFactory redisConnectionFactory() {
 		return new LettuceConnectionFactory(host, port);
+	}
+
+	@Bean
+	public RedisTemplate<String, Object> redisTemplate() {
+		RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+		redisTemplate.setConnectionFactory(redisConnectionFactory());
+
+		redisTemplate.setKeySerializer(new StringRedisSerializer());
+		redisTemplate.setValueSerializer(new StringRedisSerializer());
+
+		redisTemplate.setHashKeySerializer(new StringRedisSerializer());
+		redisTemplate.setHashValueSerializer(new StringRedisSerializer());
+
+		redisTemplate.setDefaultSerializer(new StringRedisSerializer());
+
+		return redisTemplate;
 	}
 }

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -17,6 +17,11 @@ spring:
       hibernate:
         format_sql: true
 
+  data:
+    redis:
+      host: ${REDIS_HOST}
+      port: 6379
+
 logging:
   level:
     sql: debug

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -5,7 +5,7 @@ spring:
 
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
-    url:  jdbc:mysql://localhost:3306/groundflip_test
+    url: jdbc:mysql://localhost:3306/groundflip_test
     username: root
     password: root
 
@@ -16,7 +16,10 @@ spring:
     properties:
       hibernate:
         format_sql: true
-
+  data:
+    redis:
+      host: localhost
+      port: 6379
 logging:
   level:
     sql: debug


### PR DESCRIPTION
## 작업 내용*

- 엘라스틱 캐시 생성 완료
- 스프링 레디스 연결

## 고민한 내용*

### 테스트 환경 문제
- 레디스도 외부 레디스를 연결해야하는 부분이라 SpringBootTest 를 실행할 때 에러가 발생한다. 로컬에서는 상관없지만 GitHub action 에서는 매번 레디스를 실행시켜주어야한다.
- 따라서 ci 스크립트에 도커로 레디스를 실행하는 명령어를 삽입하여 항상 레디스가 실행되도록 했다

## 리뷰 요구사항
- 혹시 추후 사용할 일이 있을수도 있을 것 같아 redisTemplate도 넣어두었습니다.
## 스크린샷