### PR TITLE
M3-165 로그아웃 api 및 블랙 리스트

### DIFF
--- a/src/main/java/com/m3pro/groundflip/controller/AuthController.java
+++ b/src/main/java/com/m3pro/groundflip/controller/AuthController.java
@@ -8,6 +8,7 @@ import org.springframework.web.bind.annotation.RestController;
 import com.m3pro.groundflip.domain.dto.Response;
 import com.m3pro.groundflip.domain.dto.auth.LoginRequest;
 import com.m3pro.groundflip.domain.dto.auth.LoginResponse;
+import com.m3pro.groundflip.domain.dto.auth.LogoutRequest;
 import com.m3pro.groundflip.domain.dto.auth.ReissueReponse;
 import com.m3pro.groundflip.domain.dto.auth.ReissueRequest;
 import com.m3pro.groundflip.enums.Provider;
@@ -34,6 +35,12 @@ public class AuthController {
 	@PostMapping("/reissue")
 	public Response<ReissueReponse> reissueToken(@RequestBody ReissueRequest reissueRequest) {
 		return Response.createSuccess(authService.reissueToken(reissueRequest.getRefreshToken()));
+	}
+
+	@Operation(summary = "로그아웃", description = "로그아웃 하는 API access token과 refresh token 을 body에 담아 보내고 서버에서 토큰을 만료시킨다.")
+	@PostMapping("/reissue")
+	public Response<?> logout(@RequestBody LogoutRequest logoutRequest) {
+		return Response.createSuccessWithNoData();
 	}
 }
 

--- a/src/main/java/com/m3pro/groundflip/controller/AuthController.java
+++ b/src/main/java/com/m3pro/groundflip/controller/AuthController.java
@@ -38,8 +38,9 @@ public class AuthController {
 	}
 
 	@Operation(summary = "로그아웃", description = "로그아웃 하는 API access token과 refresh token 을 body에 담아 보내고 서버에서 토큰을 만료시킨다.")
-	@PostMapping("/reissue")
+	@PostMapping("/logout")
 	public Response<?> logout(@RequestBody LogoutRequest logoutRequest) {
+		authService.logout(logoutRequest);
 		return Response.createSuccessWithNoData();
 	}
 }

--- a/src/main/java/com/m3pro/groundflip/domain/dto/auth/LogoutRequest.java
+++ b/src/main/java/com/m3pro/groundflip/domain/dto/auth/LogoutRequest.java
@@ -1,0 +1,20 @@
+package com.m3pro.groundflip.domain.dto.auth;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Data
+@Builder
+@Schema(title = "로그아웃 요청 Body")
+public class LogoutRequest {
+	@Schema(description = "access token", example = "dslafjkdsrtjlejldfkajlasljdf")
+	private String accessToken;
+
+	@Schema(description = "refresh token", example = "dslafjkdsrtjlejldfkajlasljdf")
+	private String refreshToken;
+}

--- a/src/main/java/com/m3pro/groundflip/domain/entity/redis/BlacklistedToken.java
+++ b/src/main/java/com/m3pro/groundflip/domain/entity/redis/BlacklistedToken.java
@@ -1,9 +1,9 @@
 package com.m3pro.groundflip.domain.entity.redis;
 
+import org.springframework.data.annotation.Id;
 import org.springframework.data.redis.core.RedisHash;
 import org.springframework.data.redis.core.TimeToLive;
 
-import jakarta.persistence.Id;
 import lombok.AllArgsConstructor;
 import lombok.NoArgsConstructor;
 

--- a/src/main/java/com/m3pro/groundflip/domain/entity/redis/BlacklistedToken.java
+++ b/src/main/java/com/m3pro/groundflip/domain/entity/redis/BlacklistedToken.java
@@ -1,0 +1,25 @@
+package com.m3pro.groundflip.domain.entity.redis;
+
+import org.springframework.data.redis.core.RedisHash;
+import org.springframework.data.redis.core.TimeToLive;
+
+import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+
+@RedisHash("token")
+@AllArgsConstructor
+public class BlacklistedToken {
+	@Id
+	private String id;
+
+	private String token;
+
+	@TimeToLive
+	private Long timeToLive;
+
+	public BlacklistedToken(String token, Long timeToLive) {
+		this.id = token;
+		this.token = "logout";
+		this.timeToLive = timeToLive;
+	}
+}

--- a/src/main/java/com/m3pro/groundflip/domain/entity/redis/BlacklistedToken.java
+++ b/src/main/java/com/m3pro/groundflip/domain/entity/redis/BlacklistedToken.java
@@ -12,16 +12,16 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class BlacklistedToken {
 	@Id
-	private String id;
-
 	private String token;
+
+	private String status;
 
 	@TimeToLive
 	private Long timeToLive;
 
 	public BlacklistedToken(String token, Long timeToLive) {
-		this.id = token;
-		this.token = "logout";
+		this.token = token;
+		this.status = "logout";
 		this.timeToLive = timeToLive;
 	}
 }

--- a/src/main/java/com/m3pro/groundflip/domain/entity/redis/BlacklistedToken.java
+++ b/src/main/java/com/m3pro/groundflip/domain/entity/redis/BlacklistedToken.java
@@ -5,9 +5,11 @@ import org.springframework.data.redis.core.TimeToLive;
 
 import jakarta.persistence.Id;
 import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
 
 @RedisHash("token")
 @AllArgsConstructor
+@NoArgsConstructor
 public class BlacklistedToken {
 	@Id
 	private String id;

--- a/src/main/java/com/m3pro/groundflip/jwt/JwtAuthorizationFilter.java
+++ b/src/main/java/com/m3pro/groundflip/jwt/JwtAuthorizationFilter.java
@@ -35,9 +35,8 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
 	protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
 		FilterChain filterChain) throws ServletException, IOException {
 		String token = parseBearerToken(request);
-		if (jwtProvider.isTokenValid(token)) {
-			setAuthentication(token);
-		}
+		jwtProvider.validateToken(token);
+		setAuthentication(token);
 
 		filterChain.doFilter(request, response);
 	}

--- a/src/main/java/com/m3pro/groundflip/jwt/JwtProvider.java
+++ b/src/main/java/com/m3pro/groundflip/jwt/JwtProvider.java
@@ -59,6 +59,9 @@ public class JwtProvider {
 		} catch (ExpiredJwtException e) {
 			throw new AppException(ErrorCode.JWT_EXPIRED);
 		}
+		if (isTokenBlackListed(token)) {
+			throw new AppException(ErrorCode.INVALID_JWT);
+		}
 		return true;
 	}
 
@@ -67,7 +70,7 @@ public class JwtProvider {
 		return claims.get("userId", Long.class);
 	}
 
-	public Long parseExpirationSecs(String token) {
+	private Long parseExpirationSecs(String token) {
 		long expirationTimeMillis = Jwts.parser()
 			.setSigningKey(jwtSecretKey)
 			.parseClaimsJws(token)
@@ -75,6 +78,10 @@ public class JwtProvider {
 			.getExpiration()
 			.getTime();
 		return (expirationTimeMillis - System.currentTimeMillis()) / 1000;
+	}
+
+	private boolean isTokenBlackListed(String token) {
+		return blackListedTokenRepository.existsById(token);
 	}
 
 	public void expireToken(String token) {

--- a/src/main/java/com/m3pro/groundflip/jwt/JwtProvider.java
+++ b/src/main/java/com/m3pro/groundflip/jwt/JwtProvider.java
@@ -48,7 +48,7 @@ public class JwtProvider {
 			.compact();
 	}
 
-	public boolean isTokenValid(String token) {
+	public void validateToken(String token) {
 		if (!StringUtils.hasText(token)) {
 			throw new AppException(ErrorCode.JWT_NOT_EXISTS);
 		}
@@ -62,7 +62,6 @@ public class JwtProvider {
 		if (isTokenBlackListed(token)) {
 			throw new AppException(ErrorCode.INVALID_JWT);
 		}
-		return true;
 	}
 
 	public Long parseUserId(String token) {
@@ -86,7 +85,7 @@ public class JwtProvider {
 
 	public void expireToken(String token) {
 		try {
-			isTokenValid(token);
+			validateToken(token);
 			blackListedTokenRepository.save(new BlacklistedToken(token, parseExpirationSecs(token)));
 		} catch (Exception ignored) {
 		}

--- a/src/main/java/com/m3pro/groundflip/jwt/JwtProvider.java
+++ b/src/main/java/com/m3pro/groundflip/jwt/JwtProvider.java
@@ -85,9 +85,10 @@ public class JwtProvider {
 	}
 
 	public void expireToken(String token) {
-		Long expirationSecs = parseExpirationSecs(token);
-		if (expirationSecs > 0) {
+		try {
+			isTokenValid(token);
 			blackListedTokenRepository.save(new BlacklistedToken(token, parseExpirationSecs(token)));
+		} catch (Exception ignored) {
 		}
 	}
 }

--- a/src/main/java/com/m3pro/groundflip/repository/BlackListedTokenRepository.java
+++ b/src/main/java/com/m3pro/groundflip/repository/BlackListedTokenRepository.java
@@ -1,0 +1,10 @@
+package com.m3pro.groundflip.repository;
+
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+import com.m3pro.groundflip.domain.entity.redis.BlacklistedToken;
+
+@Repository
+public interface BlackListedTokenRepository extends CrudRepository<BlacklistedToken, String> {
+}

--- a/src/main/java/com/m3pro/groundflip/service/AuthService.java
+++ b/src/main/java/com/m3pro/groundflip/service/AuthService.java
@@ -6,6 +6,7 @@ import org.springframework.stereotype.Service;
 
 import com.m3pro.groundflip.domain.dto.auth.LoginRequest;
 import com.m3pro.groundflip.domain.dto.auth.LoginResponse;
+import com.m3pro.groundflip.domain.dto.auth.LogoutRequest;
 import com.m3pro.groundflip.domain.dto.auth.OauthUserInfoResponse;
 import com.m3pro.groundflip.domain.dto.auth.ReissueReponse;
 import com.m3pro.groundflip.domain.entity.User;
@@ -58,9 +59,18 @@ public class AuthService {
 
 	public ReissueReponse reissueToken(String refreshToken) {
 		jwtProvider.isTokenValid(refreshToken);
+		jwtProvider.expireToken(refreshToken);
 		Long parsedUserId = jwtProvider.parseUserId(refreshToken);
 		String reissuedAccessToken = jwtProvider.createAccessToken(parsedUserId);
 		String reissuedRefreshToken = jwtProvider.createRefreshToken(parsedUserId);
 		return new ReissueReponse(reissuedAccessToken, reissuedRefreshToken);
+	}
+
+	public void logout(LogoutRequest logoutRequest) {
+		String accessToken = logoutRequest.getAccessToken();
+		String refreshToken = logoutRequest.getRefreshToken();
+
+		jwtProvider.expireToken(accessToken);
+		jwtProvider.expireToken(refreshToken);
 	}
 }

--- a/src/main/java/com/m3pro/groundflip/service/AuthService.java
+++ b/src/main/java/com/m3pro/groundflip/service/AuthService.java
@@ -58,7 +58,7 @@ public class AuthService {
 	}
 
 	public ReissueReponse reissueToken(String refreshToken) {
-		jwtProvider.isTokenValid(refreshToken);
+		jwtProvider.validateToken(refreshToken);
 		jwtProvider.expireToken(refreshToken);
 		Long parsedUserId = jwtProvider.parseUserId(refreshToken);
 		String reissuedAccessToken = jwtProvider.createAccessToken(parsedUserId);

--- a/src/test/java/com/m3pro/groundflip/jwt/JwtProviderTest.java
+++ b/src/test/java/com/m3pro/groundflip/jwt/JwtProviderTest.java
@@ -1,0 +1,141 @@
+package com.m3pro.groundflip.jwt;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.util.Date;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import com.m3pro.groundflip.domain.entity.redis.BlacklistedToken;
+import com.m3pro.groundflip.exception.AppException;
+import com.m3pro.groundflip.exception.ErrorCode;
+import com.m3pro.groundflip.repository.BlackListedTokenRepository;
+
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+
+class JwtProviderTest {
+	@InjectMocks
+	private JwtProvider jwtProvider;
+	@Mock
+	private BlackListedTokenRepository blackListedTokenRepository;
+
+	@BeforeEach
+	void setUp() {
+		MockitoAnnotations.openMocks(this);
+		ReflectionTestUtils.setField(jwtProvider, "jwtSecretKey", "testSecretKey");
+		ReflectionTestUtils.setField(jwtProvider, "accessTokenTime", 3600000L); // 1 hour
+		ReflectionTestUtils.setField(jwtProvider, "refreshTokenTime", 86400000L); // 1 day
+	}
+
+	@Test
+	@DisplayName("[createAccessToken] 엑세스 토큰을 생성한다")
+	void createAccessTokenTest() {
+		Long userId = 1L;
+		String token = jwtProvider.createAccessToken(userId);
+		System.out.println(token);
+		assertNotNull(token);
+	}
+
+	@Test
+	@DisplayName("[createRefreshToken] 리프레시 토큰을 생성한다")
+	void createRefreshToken() {
+		Long userId = 1L;
+		String token = jwtProvider.createRefreshToken(userId);
+		assertNotNull(token);
+	}
+
+	@Test
+	@DisplayName("[validateToken] 토큰을 검증한다.")
+	void validateToken_ValidToken() {
+		Long userId = 1L;
+		String token = jwtProvider.createAccessToken(userId);
+
+		doReturn(false).when(blackListedTokenRepository).existsById(token);
+
+		assertDoesNotThrow(() -> jwtProvider.validateToken(token));
+	}
+
+	@Test
+	@DisplayName("[validateToken] 토큰이 없으면 AppException을 발생")
+	void validateToken_NoToken() {
+		String token = null;
+
+		AppException exception = assertThrows(AppException.class, () -> jwtProvider.validateToken(token));
+		assertEquals(exception.getErrorCode(), ErrorCode.JWT_NOT_EXISTS);
+	}
+
+	@Test
+	@DisplayName("[validateToken] 잘못된 형식의 토큰은 AppException을 발생")
+	void validateToken_InvalidToken() {
+		String token = "invalidToken";
+
+		AppException exception = assertThrows(AppException.class, () -> jwtProvider.validateToken(token));
+		assertEquals(exception.getErrorCode(), ErrorCode.INVALID_JWT);
+	}
+
+	@Test
+	@DisplayName("[validateToken] 만료된 토큰은 AppException을 발생")
+	void validateToken_ExpiredToken() {
+		String token = Jwts.builder()
+			.setIssuedAt(new Date(System.currentTimeMillis() - 10000))
+			.setExpiration(new Date(System.currentTimeMillis() - 5000))
+			.signWith(SignatureAlgorithm.HS256, "testSecretKey")
+			.compact();
+
+		AppException exception = assertThrows(AppException.class, () -> jwtProvider.validateToken(token));
+		assertEquals(exception.getErrorCode(), ErrorCode.JWT_EXPIRED);
+	}
+
+	@Test
+	@DisplayName("[validateToken] 블랙리스트에 들어있는 토큰은 AppException을 발생")
+	void validateToken_BlackListedToken() {
+		Long userId = 1L;
+		String token = jwtProvider.createAccessToken(userId);
+
+		doReturn(true).when(blackListedTokenRepository).existsById(token);
+
+		AppException exception = assertThrows(AppException.class, () -> jwtProvider.validateToken(token));
+		assertEquals(exception.getErrorCode(), ErrorCode.INVALID_JWT);
+	}
+
+	@Test
+	@DisplayName("[parseUserId] 토큰에서 userId를 파싱한다.")
+	void parseUserIdTest() {
+		Long userId = 1L;
+		String token = jwtProvider.createAccessToken(userId);
+
+		Long parsedUserId = jwtProvider.parseUserId(token);
+		assertEquals(userId, parsedUserId);
+	}
+
+	@Test
+	@DisplayName("[expireToken] 올바른 토큰이면 블랙리스트에 토큰을 집어 넣는다.")
+	void expireToken_ValidToken() {
+		Long userId = 1L;
+		String token = jwtProvider.createAccessToken(userId);
+
+		doReturn(false).when(blackListedTokenRepository).existsById(token);
+
+		jwtProvider.expireToken(token);
+
+		verify(blackListedTokenRepository, times(1)).save(any(BlacklistedToken.class));
+	}
+
+	@Test
+	@DisplayName("[expireToken] 올바른 토큰이 아니면 블랙리스트에 넣지 않는다.")
+	void expireToken_InvalidToken() {
+		String token = "invalidToken";
+
+		jwtProvider.expireToken(token);
+
+		verify(blackListedTokenRepository, never()).save(any(BlacklistedToken.class));
+	}
+}

--- a/src/test/java/com/m3pro/groundflip/service/AuthServiceTest.java
+++ b/src/test/java/com/m3pro/groundflip/service/AuthServiceTest.java
@@ -1,0 +1,83 @@
+package com.m3pro.groundflip.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.m3pro.groundflip.domain.dto.auth.LogoutRequest;
+import com.m3pro.groundflip.domain.dto.auth.ReissueReponse;
+import com.m3pro.groundflip.jwt.JwtProvider;
+import com.m3pro.groundflip.repository.UserRepository;
+import com.m3pro.groundflip.service.oauth.OauthService;
+
+@ExtendWith(MockitoExtension.class)
+class AuthServiceTest {
+	@Mock
+	private OauthService oauthUserInfoService;
+	@Mock
+	private JwtProvider jwtProvider;
+	@Mock
+	private UserRepository userRepository;
+	@InjectMocks
+	private AuthService authService;
+
+	@BeforeEach
+	void init() {
+		reset(jwtProvider);
+		reset(oauthUserInfoService);
+		reset(userRepository);
+	}
+
+	@Test
+	@DisplayName("[logout] 정상적으로 로그아웃 실행")
+	void logoutTest() {
+		// Given
+		String accessToken = "accessToken";
+		String refreshToken = "refreshToken";
+		LogoutRequest logoutRequest = new LogoutRequest(accessToken, refreshToken);
+
+		// When
+		authService.logout(logoutRequest);
+
+		// Then
+		verify(jwtProvider, times(1)).expireToken(accessToken);
+		verify(jwtProvider, times(1)).expireToken(refreshToken);
+	}
+
+	@Test
+	@DisplayName("[reissueToken] 정상적으로 토큰 재발급")
+	public void reissueTokenTest() {
+		// Given
+		String refreshToken = "validRefreshToken";
+		Long userId = 123L;
+		String newAccessToken = "newAccessToken";
+		String newRefreshToken = "newRefreshToken";
+
+		doNothing().when(jwtProvider).validateToken(refreshToken);
+		doNothing().when(jwtProvider).expireToken(refreshToken);
+		when(jwtProvider.parseUserId(refreshToken)).thenReturn(userId);
+		when(jwtProvider.createAccessToken(userId)).thenReturn(newAccessToken);
+		when(jwtProvider.createRefreshToken(userId)).thenReturn(newRefreshToken);
+
+		// When
+		ReissueReponse response = authService.reissueToken(refreshToken);
+
+		// Then
+		verify(jwtProvider, times(1)).validateToken(refreshToken);
+		verify(jwtProvider, times(1)).expireToken(refreshToken);
+		verify(jwtProvider, times(1)).parseUserId(refreshToken);
+		verify(jwtProvider, times(1)).createAccessToken(userId);
+		verify(jwtProvider, times(1)).createRefreshToken(userId);
+
+		assertNotNull(response);
+		assertEquals(newAccessToken, response.getAccessToken());
+		assertEquals(newRefreshToken, response.getRefreshToken());
+	}
+}


### PR DESCRIPTION
## 작업 내용*

- 로그아웃 api 구현
- 블랙 리스트 구현
- 토큰 검증시 블랙 리스트 확인
- 테스트 코드 작성

## 고민한 내용*
### 블랙리스트
- access token 과 refresh token 모두 동일하게 저장했다. 로그아웃 요청이 오면 블랙리스트에 두 토큰을 넣는 방식으로 구현했다.
- 잘못된 토큰이 로그아웃 요청으로 오면 저장하지 않게 했다. 어차피 필요없는 토큰에 저장공간을 낭비할 필요는 없다고 생각했다.
#### 고민점
access token 이 재발급 될 때 마다 기존에 쓰던 refresh token은 블랙리스트에 들어간다. 하지만 리프레시 토큰은 저장기간이 2주이기 때문에 오랜시간 블랙리스트에 남아 있게 되서 용량을 많이 잡아 먹을 수 있을 것 같다는 생각이 들었다.

추후에 리프레시 토큰은 블랙리스트가 아니라 화이트리스트를 만들어서 user 한명당 하나의 리프레시 토큰을 저장 시켜두고 해당 토큰만 사용가능하게 하면 개선되지 않을까 하는 생각을 해보았다.

## 리뷰 요구사항

- 리뷰할 때 중점적으로 봐줬으면 하는 내용들

## 스크린샷