### PR TITLE
M3-167 유저정보 수정

### DIFF
--- a/src/main/java/com/m3pro/groundflip/controller/TestController.java
+++ b/src/main/java/com/m3pro/groundflip/controller/TestController.java
@@ -21,6 +21,6 @@ public class TestController {
 	@GetMapping("/exception")
 	@ResponseStatus(HttpStatus.ACCEPTED)
 	public Response<String> exception() {
-		throw new AppException(ErrorCode.DUPLICATED_USER);
+		throw new AppException(ErrorCode.DUPLICATED_NICKNAME);
 	}
 }

--- a/src/main/java/com/m3pro/groundflip/controller/UserController.java
+++ b/src/main/java/com/m3pro/groundflip/controller/UserController.java
@@ -35,7 +35,7 @@ public class UserController {
 		return Response.createSuccess(userService.getUserInfo(userId));
 	}
 
-	@Operation(summary = "사용자 정보 수정", description = "닉네임, id, 출생년도, 성별, 프로필 사진, 그룹이름, 그룹 id 를 수정한다.")
+	@Operation(summary = "사용자 정보 수정", description = "닉네임, id, 출생년도, 성별, 프로필 사진을 수정한다.")
 	@PutMapping("/{userId}")
 	public Response<?> putUserInfo(
 		@Parameter(description = "찾고자 하는 userId", required = true)

--- a/src/main/java/com/m3pro/groundflip/controller/UserController.java
+++ b/src/main/java/com/m3pro/groundflip/controller/UserController.java
@@ -2,10 +2,13 @@ package com.m3pro.groundflip.controller;
 
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.m3pro.groundflip.domain.dto.Response;
+import com.m3pro.groundflip.domain.dto.user.UserInfoRequest;
 import com.m3pro.groundflip.domain.dto.user.UserInfoResponse;
 import com.m3pro.groundflip.service.UserService;
 
@@ -31,4 +34,17 @@ public class UserController {
 	) {
 		return Response.createSuccess(userService.getUserInfo(userId));
 	}
+
+	@Operation(summary = "사용자 정보 수정", description = "닉네임, id, 출생년도, 성별, 프로필 사진, 그룹이름, 그룹 id 를 수정한다.")
+	@PutMapping("/{userId}")
+	public Response<?> putUserInfo(
+		@Parameter(description = "찾고자 하는 userId", required = true)
+		@PathVariable Long userId,
+		@RequestBody UserInfoRequest userInfoRequest
+	) {
+		userService.putUserInfo(userId, userInfoRequest);
+		return Response.createSuccessWithNoData();
+	}
+
+
 }

--- a/src/main/java/com/m3pro/groundflip/domain/dto/user/UserInfoRequest.java
+++ b/src/main/java/com/m3pro/groundflip/domain/dto/user/UserInfoRequest.java
@@ -1,7 +1,5 @@
 package com.m3pro.groundflip.domain.dto.user;
 
-import java.util.Date;
-
 import com.m3pro.groundflip.enums.Gender;
 
 import io.swagger.v3.oas.annotations.media.Schema;

--- a/src/main/java/com/m3pro/groundflip/domain/dto/user/UserInfoRequest.java
+++ b/src/main/java/com/m3pro/groundflip/domain/dto/user/UserInfoRequest.java
@@ -1,0 +1,32 @@
+package com.m3pro.groundflip.domain.dto.user;
+
+import java.util.Date;
+
+import com.m3pro.groundflip.enums.Gender;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Schema(title = "사용자 정보 수정")
+public class UserInfoRequest {
+
+	@Schema(description = "사용자 닉네임", example = "홍길동")
+	private String nickname;
+
+	@Schema(description = "사용자 프로필 사진 주소", example = "http://www.test.com")
+	private String profileImageUrl;
+
+	@Schema(description = "사용자 출생년도", example = "2000")
+	private Date birthYear;
+
+	@Schema(description = "사용자 성별 (MALE, FEMALE)", example = "MALE")
+	private Gender gender;
+
+}

--- a/src/main/java/com/m3pro/groundflip/domain/dto/user/UserInfoRequest.java
+++ b/src/main/java/com/m3pro/groundflip/domain/dto/user/UserInfoRequest.java
@@ -24,7 +24,7 @@ public class UserInfoRequest {
 	private String profileImageUrl;
 
 	@Schema(description = "사용자 출생년도", example = "2000")
-	private Date birthYear;
+	private int birthYear;
 
 	@Schema(description = "사용자 성별 (MALE, FEMALE)", example = "MALE")
 	private Gender gender;

--- a/src/main/java/com/m3pro/groundflip/domain/entity/StepRecord.java
+++ b/src/main/java/com/m3pro/groundflip/domain/entity/StepRecord.java
@@ -6,6 +6,7 @@ import com.m3pro.groundflip.domain.entity.global.BaseTimeEntity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -34,7 +35,7 @@ public class StepRecord extends BaseTimeEntity {
 
 	private Integer steps;
 
-	@ManyToOne
+	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "user_id")
 	private User user;
 }

--- a/src/main/java/com/m3pro/groundflip/domain/entity/User.java
+++ b/src/main/java/com/m3pro/groundflip/domain/entity/User.java
@@ -56,4 +56,14 @@ public class User extends BaseTimeEntity {
 
 	private Date deletedAt;
 
+	public void updateNickName(String nickname) {this.nickname = nickname;}
+
+	public void updateProfileImage(String profileImage) {this.profileImage = profileImage;}
+
+	public void updateBirthYear(Date birthYear) {this.birthYear = birthYear;}
+
+	public void updateGender(Gender gender) {this.gender = gender;}
+
+	public void updateStatus(UserStatus status) {this.status = status;}
+
 }

--- a/src/main/java/com/m3pro/groundflip/exception/ErrorCode.java
+++ b/src/main/java/com/m3pro/groundflip/exception/ErrorCode.java
@@ -8,7 +8,7 @@ import lombok.Getter;
 @AllArgsConstructor
 @Getter
 public enum ErrorCode {
-	DUPLICATED_USER(HttpStatus.BAD_REQUEST, "중복된 회원입니다."),
+	DUPLICATED_NICKNAME(HttpStatus.BAD_REQUEST, "중복된 회원입니다."),
 	USER_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 사용자입니다."),
 	PIXEL_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 픽셀입니다."),
 	INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 에러 입니다"),

--- a/src/main/java/com/m3pro/groundflip/exception/ErrorCode.java
+++ b/src/main/java/com/m3pro/groundflip/exception/ErrorCode.java
@@ -8,7 +8,7 @@ import lombok.Getter;
 @AllArgsConstructor
 @Getter
 public enum ErrorCode {
-	DUPLICATED_NICKNAME(HttpStatus.BAD_REQUEST, "중복된 회원입니다."),
+	DUPLICATED_NICKNAME(HttpStatus.BAD_REQUEST, "중복된 닉네임입니다."),
 	USER_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 사용자입니다."),
 	PIXEL_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 픽셀입니다."),
 	INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 에러 입니다"),

--- a/src/main/java/com/m3pro/groundflip/repository/UserRepository.java
+++ b/src/main/java/com/m3pro/groundflip/repository/UserRepository.java
@@ -1,5 +1,6 @@
 package com.m3pro.groundflip.repository;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -9,4 +10,5 @@ import com.m3pro.groundflip.enums.Provider;
 
 public interface UserRepository extends JpaRepository<User, Long> {
 	Optional<User> findByProviderAndEmail(Provider provider, String email);
+	Optional<User> findByNickname(String nickname);
 }

--- a/src/main/java/com/m3pro/groundflip/service/UserService.java
+++ b/src/main/java/com/m3pro/groundflip/service/UserService.java
@@ -4,9 +4,11 @@ import java.util.List;
 
 import org.springframework.stereotype.Service;
 
+import com.m3pro.groundflip.domain.dto.user.UserInfoRequest;
 import com.m3pro.groundflip.domain.dto.user.UserInfoResponse;
 import com.m3pro.groundflip.domain.entity.User;
 import com.m3pro.groundflip.domain.entity.UserCommunity;
+import com.m3pro.groundflip.enums.UserStatus;
 import com.m3pro.groundflip.exception.AppException;
 import com.m3pro.groundflip.exception.ErrorCode;
 import com.m3pro.groundflip.repository.UserCommunityRepository;
@@ -33,6 +35,23 @@ public class UserService {
 			String communityName = userCommunity.get(0).getCommunity().getName();
 			return UserInfoResponse.from(user, communityId, communityName);
 		}
+	}
+
+	public void putUserInfo(Long userId, UserInfoRequest userInfoRequest) {
+		User user = userRepository.findById(userId)
+			.orElseThrow(() -> new AppException(ErrorCode.USER_NOT_FOUND));
+		String updateNickname = userInfoRequest.getNickname();
+
+		if (!user.getNickname().equals(updateNickname) && userRepository.findByNickname(updateNickname).isPresent()) {
+			throw new AppException(ErrorCode.DUPLICATED_USER);
+		}
+
+		user.updateGender(userInfoRequest.getGender());
+		user.updateBirthYear(userInfoRequest.getBirthYear());
+		user.updateNickName(userInfoRequest.getNickname());
+		//user.updateProfileImage(userInfoRequest.getProfileImageUrl());
+		user.updateStatus(UserStatus.COMPLETE);
+		userRepository.save(user);
 	}
 
 }

--- a/src/main/java/com/m3pro/groundflip/service/UserService.java
+++ b/src/main/java/com/m3pro/groundflip/service/UserService.java
@@ -44,7 +44,7 @@ public class UserService {
 		User user = userRepository.findById(userId)
 			.orElseThrow(() -> new AppException(ErrorCode.USER_NOT_FOUND));
 
-		if(checkNicknameExists(userInfoRequest, user)){
+		if (checkNicknameExists(userInfoRequest, user)) {
 			throw new AppException(ErrorCode.DUPLICATED_NICKNAME);
 		}
 
@@ -58,19 +58,14 @@ public class UserService {
 
 	public Date convertToDate(int year) {
 		LocalDate localDate = LocalDate.of(year, 1, 1);
-		Date updateDate = Date.from(localDate.atStartOfDay(ZoneId.systemDefault()).toInstant());
-		return updateDate;
+		return Date.from(localDate.atStartOfDay(ZoneId.systemDefault()).toInstant());
 	}
 
 	public boolean checkNicknameExists(UserInfoRequest userInfoRequest, User user) {
 		boolean duplicate = false;
-		if(userInfoRequest.getNickname().equals(user.getNickname())) {
-			duplicate = true;
-		}
 		if(userRepository.findByNickname(userInfoRequest.getNickname()).isPresent()) {
 			duplicate = true;
 		}
 		return duplicate;
-
 	}
 }

--- a/src/main/java/com/m3pro/groundflip/service/UserService.java
+++ b/src/main/java/com/m3pro/groundflip/service/UserService.java
@@ -44,7 +44,7 @@ public class UserService {
 		User user = userRepository.findById(userId)
 			.orElseThrow(() -> new AppException(ErrorCode.USER_NOT_FOUND));
 
-		if (checkNicknameExists(userInfoRequest, user)) {
+		if (checkNicknameExists(userInfoRequest)) {
 			throw new AppException(ErrorCode.DUPLICATED_NICKNAME);
 		}
 
@@ -61,11 +61,7 @@ public class UserService {
 		return Date.from(localDate.atStartOfDay(ZoneId.systemDefault()).toInstant());
 	}
 
-	public boolean checkNicknameExists(UserInfoRequest userInfoRequest, User user) {
-		boolean duplicate = false;
-		if(userRepository.findByNickname(userInfoRequest.getNickname()).isPresent()) {
-			duplicate = true;
-		}
-		return duplicate;
+	public boolean checkNicknameExists(UserInfoRequest userInfoRequest) {
+		return userRepository.findByNickname(userInfoRequest.getNickname()).isPresent();
 	}
 }

--- a/src/main/java/com/m3pro/groundflip/service/UserService.java
+++ b/src/main/java/com/m3pro/groundflip/service/UserService.java
@@ -43,7 +43,7 @@ public class UserService {
 		String updateNickname = userInfoRequest.getNickname();
 
 		if (!user.getNickname().equals(updateNickname) && userRepository.findByNickname(updateNickname).isPresent()) {
-			throw new AppException(ErrorCode.DUPLICATED_USER);
+			throw new AppException(ErrorCode.DUPLICATED_NICKNAME);
 		}
 
 		user.updateGender(userInfoRequest.getGender());


### PR DESCRIPTION
## 작업 내용*

- 유저 닉네임, 성별, 생년 수정
- 중복 닉네임이면 에러반환
- 완료 후 status complete

## 고민한 내용*

- 닉네임 중복을 확인하기 위해서 현재 닉네임과 업데이트 닉네임이 다르고, 업데이트 닉네임이 테이블에 없으면 수정하도록 했다.

## 리뷰 요구사항

- 함수, 클래스, 변수명, 로직

## 스크린샷