### PR TITLE
M3-157 db역정규화 - 구민분량

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
           mysql user: 'root'
 
       - name: 테스트를 위한 Redis 구동
-        run: sudo docker run -d --name redis -p 6379:6379 redis:latest
+        run: sudo docker run -d --name redis -p 6378:6379 redis:latest
 
       - name: JDK 17 설치
         uses: actions/setup-java@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,7 @@ jobs:
           title: 📝 테스트 커버리지 리포트
           paths: ${{ github.workspace }}/build/jacocoReport/test/jacocoTestReport.xml
           token: ${{ secrets.GITHUB_TOKEN }}
+          update-comment: true
 
   qodana:
     runs-on: ubuntu-latest

--- a/src/main/java/com/m3pro/groundflip/controller/PixelController.java
+++ b/src/main/java/com/m3pro/groundflip/controller/PixelController.java
@@ -78,7 +78,7 @@ public class PixelController {
 		@Parameter(description = "찾고자 하는 pixelId", required = true)
 		@PathVariable Long pixelId) {
 		return Response.createSuccess(
-			pixelService.getIndividualPixelInfo(pixelId)
+			pixelService.getIndividualModePixelInfo(pixelId)
 		);
 	}
 

--- a/src/main/java/com/m3pro/groundflip/domain/dto/pixel/PixelCountResponse.java
+++ b/src/main/java/com/m3pro/groundflip/domain/dto/pixel/PixelCountResponse.java
@@ -13,7 +13,7 @@ import lombok.NoArgsConstructor;
 @Schema(title = "픽셀 개수")
 public class PixelCountResponse {
 	@Schema(description = "현재 차지하고 있는 픽셀 개수", example = "5")
-	private Integer currentPixelCount;
+	private Long currentPixelCount;
 
 	@Schema(description = "지금까지 차지한 픽셀 개수", example = "5")
 	private Long accumulatePixelCount;

--- a/src/main/java/com/m3pro/groundflip/domain/dto/pixel/PixelCountResponse.java
+++ b/src/main/java/com/m3pro/groundflip/domain/dto/pixel/PixelCountResponse.java
@@ -16,5 +16,5 @@ public class PixelCountResponse {
 	private Integer currentPixelCount;
 
 	@Schema(description = "지금까지 차지한 픽셀 개수", example = "5")
-	private Integer accumulatePixelCount;
+	private Long accumulatePixelCount;
 }

--- a/src/main/java/com/m3pro/groundflip/domain/dto/pixel/PixelOwnerUserResponse.java
+++ b/src/main/java/com/m3pro/groundflip/domain/dto/pixel/PixelOwnerUserResponse.java
@@ -1,6 +1,5 @@
 package com.m3pro.groundflip.domain.dto.pixel;
 
-import com.m3pro.groundflip.domain.dto.pixelUser.PixelCount;
 import com.m3pro.groundflip.domain.entity.User;
 
 import lombok.AllArgsConstructor;
@@ -16,10 +15,10 @@ public class PixelOwnerUserResponse {
 	private Long userId;
 	private String nickname;
 	private String profileImageUrl;
-	private Integer currentPixelCount;
+	private Long currentPixelCount;
 	private Long accumulatePixelCount;
 
-	public static PixelOwnerUserResponse from(User pixelOwnerUser, PixelCount currentPixelCount,
+	public static PixelOwnerUserResponse from(User pixelOwnerUser, Long currentPixelCount,
 		Long accumulatePixelCount) {
 		if (pixelOwnerUser == null) {
 			return null;
@@ -29,7 +28,7 @@ public class PixelOwnerUserResponse {
 				.nickname(pixelOwnerUser.getNickname())
 				.profileImageUrl(pixelOwnerUser.getProfileImage())
 				.accumulatePixelCount(accumulatePixelCount)
-				.currentPixelCount(currentPixelCount.getCount())
+				.currentPixelCount(currentPixelCount)
 				.build();
 		}
 	}

--- a/src/main/java/com/m3pro/groundflip/domain/dto/pixel/PixelOwnerUserResponse.java
+++ b/src/main/java/com/m3pro/groundflip/domain/dto/pixel/PixelOwnerUserResponse.java
@@ -17,10 +17,10 @@ public class PixelOwnerUserResponse {
 	private String nickname;
 	private String profileImageUrl;
 	private Integer currentPixelCount;
-	private Integer accumulatePixelCount;
+	private Long accumulatePixelCount;
 
 	public static PixelOwnerUserResponse from(User pixelOwnerUser, PixelCount currentPixelCount,
-		PixelCount accumulatePixelCount) {
+		Long accumulatePixelCount) {
 		if (pixelOwnerUser == null) {
 			return null;
 		} else {
@@ -28,7 +28,7 @@ public class PixelOwnerUserResponse {
 				.userId(pixelOwnerUser.getId())
 				.nickname(pixelOwnerUser.getNickname())
 				.profileImageUrl(pixelOwnerUser.getProfileImage())
-				.accumulatePixelCount(accumulatePixelCount.getCount())
+				.accumulatePixelCount(accumulatePixelCount)
 				.currentPixelCount(currentPixelCount.getCount())
 				.build();
 		}

--- a/src/main/java/com/m3pro/groundflip/domain/dto/pixel/PixelOwnerUserResponse.java
+++ b/src/main/java/com/m3pro/groundflip/domain/dto/pixel/PixelOwnerUserResponse.java
@@ -1,7 +1,7 @@
 package com.m3pro.groundflip.domain.dto.pixel;
 
 import com.m3pro.groundflip.domain.dto.pixelUser.PixelCount;
-import com.m3pro.groundflip.domain.dto.pixelUser.PixelOwnerUser;
+import com.m3pro.groundflip.domain.entity.User;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -19,13 +19,13 @@ public class PixelOwnerUserResponse {
 	private Integer currentPixelCount;
 	private Integer accumulatePixelCount;
 
-	public static PixelOwnerUserResponse from(PixelOwnerUser pixelOwnerUser, PixelCount currentPixelCount,
+	public static PixelOwnerUserResponse from(User pixelOwnerUser, PixelCount currentPixelCount,
 		PixelCount accumulatePixelCount) {
 		if (pixelOwnerUser == null) {
 			return null;
 		} else {
 			return PixelOwnerUserResponse.builder()
-				.userId(pixelOwnerUser.getUserId())
+				.userId(pixelOwnerUser.getId())
 				.nickname(pixelOwnerUser.getNickname())
 				.profileImageUrl(pixelOwnerUser.getProfileImage())
 				.accumulatePixelCount(accumulatePixelCount.getCount())

--- a/src/main/java/com/m3pro/groundflip/repository/PixelRepository.java
+++ b/src/main/java/com/m3pro/groundflip/repository/PixelRepository.java
@@ -10,7 +10,6 @@ import org.springframework.data.repository.query.Param;
 
 import com.m3pro.groundflip.domain.dto.pixel.IndividualHistoryPixelResponse;
 import com.m3pro.groundflip.domain.dto.pixel.IndividualModePixelResponse;
-import com.m3pro.groundflip.domain.dto.pixelUser.PixelCount;
 import com.m3pro.groundflip.domain.entity.Pixel;
 
 public interface PixelRepository extends JpaRepository<Pixel, Long> {
@@ -62,11 +61,5 @@ public interface PixelRepository extends JpaRepository<Pixel, Long> {
 
 	Optional<Pixel> findByXAndY(Long x, Long y);
 
-	@Query(value = """
-		SELECT COUNT(*) AS count
-		FROM pixel p
-		WHERE p.user_id = :user_id
-		""", nativeQuery = true)
-	PixelCount findCurrentPixelCountByUserId(
-		@Param("user_id") Long userId);
+	Long countCurrentPixelByUserId(Long userId);
 }

--- a/src/main/java/com/m3pro/groundflip/repository/PixelRepository.java
+++ b/src/main/java/com/m3pro/groundflip/repository/PixelRepository.java
@@ -15,16 +15,16 @@ import com.m3pro.groundflip.domain.entity.Pixel;
 public interface PixelRepository extends JpaRepository<Pixel, Long> {
 	@Query(value = """
 		SELECT
-		    pixel.pixel_id AS pixelId,
-		    ST_LATITUDE(pixel.coordinate) AS latitude,
-		    ST_LONGITUDE(pixel.coordinate) AS longitude,
-		    pixel.user_id AS userId,
-		    pixel.x,
-		    pixel.y
+			pixel.pixel_id AS pixelId,
+			ST_LATITUDE(pixel.coordinate) AS latitude,
+			ST_LONGITUDE(pixel.coordinate) AS longitude,
+			pixel.user_id AS userId,
+			pixel.x,
+			pixel.y
 		FROM
-		    pixel
+			pixel
 		WHERE
-		    ST_CONTAINS((ST_Buffer(:center, :radius)), pixel.coordinate) AND pixel.user_id IS NOT NULL
+			ST_CONTAINS((ST_Buffer(:center, :radius)), pixel.coordinate) AND pixel.user_id IS NOT NULL
 		""", nativeQuery = true)
 	List<IndividualModePixelResponse> findAllIndividualModePixelsByCoordinate(
 		@Param("center") Point center,
@@ -32,22 +32,22 @@ public interface PixelRepository extends JpaRepository<Pixel, Long> {
 
 	@Query(value = """
 		WITH PixelsInRange AS (
-		    SELECT
-		        p.pixel_id,
-		        p.coordinate,
-		        p.x,
-		        p.y
-		    FROM
-		        pixel p
-		    WHERE
-		        ST_CONTAINS((ST_Buffer(:center, :radius)), p.coordinate)
+				SELECT
+				p.pixel_id,
+				p.coordinate,
+				p.x,
+				p.y
+			FROM
+				pixel p
+			WHERE
+				ST_CONTAINS((ST_Buffer(:center, :radius)), p.coordinate)
 		)
-		 SELECT
+		SELECT
 			DISTINCT (pu.pixel_id) AS pixelId,
 			ST_LATITUDE(pir.coordinate) AS latitude,
 			ST_LONGITUDE(pir.coordinate) AS longitude,
 			pir.x,
-		    pir.y
+			pir.y
 		FROM
 			pixel_user pu
 		JOIN

--- a/src/main/java/com/m3pro/groundflip/repository/PixelUserRepository.java
+++ b/src/main/java/com/m3pro/groundflip/repository/PixelUserRepository.java
@@ -6,7 +6,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-import com.m3pro.groundflip.domain.dto.pixelUser.PixelCount;
 import com.m3pro.groundflip.domain.dto.pixelUser.VisitedUser;
 import com.m3pro.groundflip.domain.entity.Pixel;
 import com.m3pro.groundflip.domain.entity.PixelUser;
@@ -14,25 +13,24 @@ import com.m3pro.groundflip.domain.entity.User;
 
 public interface PixelUserRepository extends JpaRepository<PixelUser, Long> {
 	@Query(value = """
-		SELECT pu.pixel_id AS pixelId,
-		       pu.user_id AS userId,
-		       u.nickname AS nickname,
-		       u.profile_image AS profileImage 
-		FROM pixel_user pu
-		JOIN user u ON pu.user_id = u.user_id 
-		WHERE pu.pixel_id = :pixel_id AND pu.created_at >= current_date() 
-		GROUP BY pu.user_id;
+			SELECT pu.pixel_id AS pixelId,
+				pu.user_id AS userId,
+				u.nickname AS nickname,
+				u.profile_image AS profileImage
+			FROM pixel_user pu
+			JOIN user u ON pu.user_id = u.user_id
+			WHERE pu.pixel_id = :pixel_id AND pu.created_at >= current_date()
+			GROUP BY pu.user_id;
 		""", nativeQuery = true)
 	List<VisitedUser> findAllVisitedUserByPixelId(
 		@Param("pixel_id") Long pixelId);
 
 	@Query(value = """
-		SELECT COUNT(DISTINCT pu.pixel_id) AS count 
-		FROM pixel_user pu 
-		WHERE pu.user_id = :user_id
-		""", nativeQuery = true)
-	PixelCount findAccumulatePixelCountByUserId(
-		@Param("user_id") Long userId);
+		SELECT COUNT(DISTINCT pu.pixel.id) AS count
+		FROM PixelUser pu
+		WHERE pu.user.id = :userId
+		""")
+	Long countAccumulatePixelByUserId(@Param("userId") Long userId);
 
 	@Query(value = """
 			SELECT pu

--- a/src/main/java/com/m3pro/groundflip/repository/PixelUserRepository.java
+++ b/src/main/java/com/m3pro/groundflip/repository/PixelUserRepository.java
@@ -7,7 +7,6 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import com.m3pro.groundflip.domain.dto.pixelUser.PixelCount;
-import com.m3pro.groundflip.domain.dto.pixelUser.PixelOwnerUser;
 import com.m3pro.groundflip.domain.dto.pixelUser.VisitedUser;
 import com.m3pro.groundflip.domain.entity.Pixel;
 import com.m3pro.groundflip.domain.entity.PixelUser;
@@ -25,19 +24,6 @@ public interface PixelUserRepository extends JpaRepository<PixelUser, Long> {
 		GROUP BY pu.user_id;
 		""", nativeQuery = true)
 	List<VisitedUser> findAllVisitedUserByPixelId(
-		@Param("pixel_id") Long pixelId);
-
-	@Query(value = """
-		SELECT pu.user_id AS userId,
-		       u.nickname AS nickname,
-		       u.profile_image AS profileImage 
-		FROM pixel_user pu 
-		JOIN user u ON pu.user_id = u.user_id 
-		WHERE pu.pixel_id = :pixel_id 
-		ORDER BY pu.created_at DESC 
-		LIMIT 1
-		""", nativeQuery = true)
-	PixelOwnerUser findCurrentOwnerByPixelId(
 		@Param("pixel_id") Long pixelId);
 
 	@Query(value = """

--- a/src/main/java/com/m3pro/groundflip/service/PixelService.java
+++ b/src/main/java/com/m3pro/groundflip/service/PixelService.java
@@ -2,6 +2,7 @@ package com.m3pro.groundflip.service;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.GeometryFactory;
@@ -80,11 +81,7 @@ public class PixelService {
 
 	@Transactional
 	public void occupyPixel(PixelOccupyRequest pixelOccupyRequest) {
-		Long communityId = pixelOccupyRequest.getCommunityId();
-
-		if (pixelOccupyRequest.getCommunityId() == null) {
-			communityId = -1L;
-		}
+		Long communityId = Optional.ofNullable(pixelOccupyRequest.getCommunityId()).orElse(-1L);
 
 		Pixel targetPixel = pixelRepository.findByXAndY(pixelOccupyRequest.getX(), pixelOccupyRequest.getY())
 			.orElseThrow(() -> new AppException(ErrorCode.PIXEL_NOT_FOUND));
@@ -102,7 +99,7 @@ public class PixelService {
 		pixelUserRepository.save(pixelUser);
 	}
 
-	public void updatePixelAddress(Pixel targetPixel) {
+	private void updatePixelAddress(Pixel targetPixel) {
 		if (targetPixel.getAddress() == null) {
 			String address = reverseGeoCodingService.getAddressFromCoordinates(targetPixel.getCoordinate().getX(),
 				targetPixel.getCoordinate().getY());

--- a/src/main/java/com/m3pro/groundflip/service/PixelService.java
+++ b/src/main/java/com/m3pro/groundflip/service/PixelService.java
@@ -18,7 +18,6 @@ import com.m3pro.groundflip.domain.dto.pixel.PixelOccupyRequest;
 import com.m3pro.groundflip.domain.dto.pixel.PixelOwnerUserResponse;
 import com.m3pro.groundflip.domain.dto.pixel.VisitedUserInfo;
 import com.m3pro.groundflip.domain.dto.pixelUser.IndividualHistoryPixelInfoResponse;
-import com.m3pro.groundflip.domain.dto.pixelUser.PixelCount;
 import com.m3pro.groundflip.domain.dto.pixelUser.VisitedUser;
 import com.m3pro.groundflip.domain.entity.Pixel;
 import com.m3pro.groundflip.domain.entity.PixelUser;
@@ -123,7 +122,7 @@ public class PixelService {
 
 	public PixelCountResponse getPixelCount(Long userId) {
 		return PixelCountResponse.builder()
-			.currentPixelCount(pixelRepository.findCurrentPixelCountByUserId(userId).getCount())
+			.currentPixelCount(pixelRepository.countCurrentPixelByUserId(userId))
 			.accumulatePixelCount(pixelUserRepository.countAccumulatePixelByUserId(userId))
 			.build();
 	}
@@ -134,7 +133,7 @@ public class PixelService {
 			return null;
 		} else {
 			Long accumulatePixelCount = pixelUserRepository.countAccumulatePixelByUserId(ownerUserId);
-			PixelCount currentPixelCount = pixelRepository.findCurrentPixelCountByUserId(ownerUserId);
+			Long currentPixelCount = pixelRepository.countCurrentPixelByUserId(ownerUserId);
 			User ownerUser = userRepository.findById(ownerUserId)
 				.orElseThrow(() -> {
 					log.error("pixel {} 의 소유자가 {} 인데 존재하지 않음.", pixel.getId(), ownerUserId);

--- a/src/main/java/com/m3pro/groundflip/service/PixelService.java
+++ b/src/main/java/com/m3pro/groundflip/service/PixelService.java
@@ -124,7 +124,7 @@ public class PixelService {
 	public PixelCountResponse getPixelCount(Long userId) {
 		return PixelCountResponse.builder()
 			.currentPixelCount(pixelRepository.findCurrentPixelCountByUserId(userId).getCount())
-			.accumulatePixelCount(pixelUserRepository.findAccumulatePixelCountByUserId(userId).getCount())
+			.accumulatePixelCount(pixelUserRepository.countAccumulatePixelByUserId(userId))
 			.build();
 	}
 
@@ -133,7 +133,7 @@ public class PixelService {
 		if (ownerUserId == null) {
 			return null;
 		} else {
-			PixelCount accumulatePixelCount = pixelUserRepository.findAccumulatePixelCountByUserId(ownerUserId);
+			Long accumulatePixelCount = pixelUserRepository.countAccumulatePixelByUserId(ownerUserId);
 			PixelCount currentPixelCount = pixelRepository.findCurrentPixelCountByUserId(ownerUserId);
 			User ownerUser = userRepository.findById(ownerUserId)
 				.orElseThrow(() -> {

--- a/src/main/java/com/m3pro/groundflip/service/ReverseGeoCodingService.java
+++ b/src/main/java/com/m3pro/groundflip/service/ReverseGeoCodingService.java
@@ -1,0 +1,55 @@
+package com.m3pro.groundflip.service;
+
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import com.m3pro.groundflip.domain.dto.pixel.NaverAPI.NaverReverseGeoCodingApiResult;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class ReverseGeoCodingService {
+	private static final String NAVER_API_URL = "https://naveropenapi.apigw.ntruss.com/map-reversegeocode/v2/gc";
+	private final RestClient restClient;
+	@Value("${naver.apiKeyId}")
+	private String apiKeyId;
+	@Value("${naver.apiKey}")
+	private String apiKey;
+
+	public String getAddressFromCoordinates(double longitude, double latitude) {
+		NaverReverseGeoCodingApiResult naverReverseGeoCodingApiResult =
+			fetchNaverReverseGeoCodingApiResult(longitude, latitude);
+
+		if (naverReverseGeoCodingApiResult != null) {
+			List<String> areaNames = naverReverseGeoCodingApiResult.getAreaNames();
+			return String.join(" ", areaNames);
+		} else {
+			return null;
+		}
+	}
+
+	private NaverReverseGeoCodingApiResult fetchNaverReverseGeoCodingApiResult(double longitude, double latitude) {
+		String coordinate = String.format("%f, %f", longitude, latitude);
+		URI uri = UriComponentsBuilder.fromHttpUrl(NAVER_API_URL)
+			.queryParam("coords", coordinate)
+			.queryParam("orders", "admcode")
+			.queryParam("output", "json")
+			.encode(StandardCharsets.UTF_8)
+			.build()
+			.toUri();
+
+		return restClient.get()
+			.uri(uri)
+			.header("X-NCP-APIGW-API-KEY-ID", apiKeyId)
+			.header("X-NCP-APIGW-API-KEY", apiKey)
+			.retrieve()
+			.body(NaverReverseGeoCodingApiResult.class);
+	}
+}

--- a/src/main/java/com/m3pro/groundflip/service/oauth/KakaoApiClient.java
+++ b/src/main/java/com/m3pro/groundflip/service/oauth/KakaoApiClient.java
@@ -1,61 +1,60 @@
 package com.m3pro.groundflip.service.oauth;
 
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+
 import com.m3pro.groundflip.domain.dto.auth.KaKaoUserInfoResponse;
 import com.m3pro.groundflip.domain.dto.auth.KakaoTokenValidationResponse;
 import com.m3pro.groundflip.domain.dto.auth.OauthUserInfoResponse;
 import com.m3pro.groundflip.enums.Provider;
 import com.m3pro.groundflip.exception.AppException;
 import com.m3pro.groundflip.exception.ErrorCode;
+
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.http.HttpStatusCode;
-import org.springframework.stereotype.Component;
-import org.springframework.web.client.RestClient;
 
 @Component
 @RequiredArgsConstructor
 public class KakaoApiClient implements OauthApiClient {
-    @Value("${oauth.kakao.url.user}")
-    private String kakaoUserInfoUrl;
+	private final RestClient restClient;
+	@Value("${oauth.kakao.url.user}")
+	private String kakaoUserInfoUrl;
+	@Value("${oauth.kakao.url.validation}")
+	private String kakaoTokenValidationUrl;
+	@Value("${oauth.kakao.app.id}")
+	private Integer kakaoAppId;
 
-    @Value("${oauth.kakao.url.validation}")
-    private String kakaoTokenValidationUrl;
+	@Override
+	public Provider oAuthProvider() {
+		return Provider.KAKAO;
+	}
 
-    @Value("${oauth.kakao.app.id}")
-    private Integer kakaoAppId;
+	@Override
+	public OauthUserInfoResponse requestOauthUserInfo(String accessToken) {
+		return restClient.get()
+			.uri(kakaoUserInfoUrl)
+			.header("Authorization", "Bearer " + accessToken)
+			.header("Content-Type", "application/x-www-form-urlencoded;charset=utf-8")
+			.retrieve()
+			.body(KaKaoUserInfoResponse.class);
+	}
 
-    private final RestClient restClient;
+	@Override
+	public boolean isOauthTokenValid(String accessToken) {
+		KakaoTokenValidationResponse validationResponse = restClient.get()
+			.uri(kakaoTokenValidationUrl)
+			.header("Authorization", "Bearer " + accessToken)
+			.retrieve()
+			.onStatus(HttpStatusCode::is4xxClientError, (req, res) -> {
+				throw new AppException(ErrorCode.UNAUTHORIZED);
+			})
+			.body(KakaoTokenValidationResponse.class);
 
-    @Override
-    public Provider oAuthProvider() {
-        return Provider.KAKAO;
-    }
+		if (validationResponse == null) {
+			throw new AppException(ErrorCode.UNAUTHORIZED);
+		}
 
-    @Override
-    public OauthUserInfoResponse requestOauthUserInfo(String accessToken) {
-        return restClient.get()
-                .uri(kakaoUserInfoUrl)
-                .header("Authorization", "Bearer " + accessToken)
-                .header("Content-Type", "application/x-www-form-urlencoded;charset=utf-8")
-                .retrieve()
-                .body(KaKaoUserInfoResponse.class);
-    }
-
-    @Override
-    public boolean isOauthTokenValid(String accessToken) {
-        KakaoTokenValidationResponse validationResponse = restClient.get()
-                .uri(kakaoTokenValidationUrl)
-                .header("Authorization", "Bearer " + accessToken)
-                .retrieve()
-                .onStatus(HttpStatusCode::is4xxClientError, (req, res) -> {
-                    throw new AppException(ErrorCode.UNAUTHORIZED);
-                })
-                .body(KakaoTokenValidationResponse.class);
-
-        if (validationResponse == null) {
-            throw new AppException(ErrorCode.UNAUTHORIZED);
-        }
-
-        return validationResponse.getAppId().intValue() == kakaoAppId.intValue();
-    }
+		return validationResponse.getAppId().intValue() == kakaoAppId.intValue();
+	}
 }

--- a/src/main/java/com/m3pro/groundflip/service/oauth/OauthApiClient.java
+++ b/src/main/java/com/m3pro/groundflip/service/oauth/OauthApiClient.java
@@ -4,7 +4,9 @@ import com.m3pro.groundflip.domain.dto.auth.OauthUserInfoResponse;
 import com.m3pro.groundflip.enums.Provider;
 
 public interface OauthApiClient {
-    Provider oAuthProvider();
-    OauthUserInfoResponse requestOauthUserInfo(String accessToken);
-    boolean isOauthTokenValid(String accessToken);
+	Provider oAuthProvider();
+
+	OauthUserInfoResponse requestOauthUserInfo(String accessToken);
+
+	boolean isOauthTokenValid(String accessToken);
 }

--- a/src/main/java/com/m3pro/groundflip/service/oauth/OauthService.java
+++ b/src/main/java/com/m3pro/groundflip/service/oauth/OauthService.java
@@ -1,36 +1,37 @@
 package com.m3pro.groundflip.service.oauth;
 
-import com.m3pro.groundflip.domain.dto.auth.OauthUserInfoResponse;
-import com.m3pro.groundflip.enums.Provider;
-import com.m3pro.groundflip.exception.AppException;
-import com.m3pro.groundflip.exception.ErrorCode;
-import org.springframework.stereotype.Component;
-
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+import org.springframework.stereotype.Component;
+
+import com.m3pro.groundflip.domain.dto.auth.OauthUserInfoResponse;
+import com.m3pro.groundflip.enums.Provider;
+import com.m3pro.groundflip.exception.AppException;
+import com.m3pro.groundflip.exception.ErrorCode;
+
 @Component
 public class OauthService {
-    private final Map<Provider, OauthApiClient> clients;
+	private final Map<Provider, OauthApiClient> clients;
 
-    public OauthService(List<OauthApiClient> clients) {
-        this.clients = clients.stream().collect(
-                Collectors.toUnmodifiableMap(OauthApiClient::oAuthProvider, Function.identity())
-        );
-    }
+	public OauthService(List<OauthApiClient> clients) {
+		this.clients = clients.stream().collect(
+			Collectors.toUnmodifiableMap(OauthApiClient::oAuthProvider, Function.identity())
+		);
+	}
 
-    public OauthUserInfoResponse requestUserInfo(Provider provider, String accessToken) {
-        if (!isOauthTokenValid(provider, accessToken)) {
-            throw new AppException(ErrorCode.UNAUTHORIZED);
-        }
-        OauthApiClient oauthApiClient = clients.get(provider);
-        return oauthApiClient.requestOauthUserInfo(accessToken);
-    }
+	public OauthUserInfoResponse requestUserInfo(Provider provider, String accessToken) {
+		if (!isOauthTokenValid(provider, accessToken)) {
+			throw new AppException(ErrorCode.UNAUTHORIZED);
+		}
+		OauthApiClient oauthApiClient = clients.get(provider);
+		return oauthApiClient.requestOauthUserInfo(accessToken);
+	}
 
-    private boolean isOauthTokenValid(Provider provider, String accessToken) {
-        OauthApiClient oauthApiClient = clients.get(provider);
-        return oauthApiClient.isOauthTokenValid(accessToken);
-    }
+	private boolean isOauthTokenValid(Provider provider, String accessToken) {
+		OauthApiClient oauthApiClient = clients.get(provider);
+		return oauthApiClient.isOauthTokenValid(accessToken);
+	}
 }

--- a/src/test/java/com/m3pro/groundflip/repository/PixelRepositoryTest.java
+++ b/src/test/java/com/m3pro/groundflip/repository/PixelRepositoryTest.java
@@ -16,7 +16,6 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 
 import com.m3pro.groundflip.domain.dto.pixel.IndividualModePixelResponse;
-import com.m3pro.groundflip.domain.dto.pixelUser.PixelCount;
 import com.m3pro.groundflip.domain.entity.Pixel;
 
 import jakarta.transaction.Transactional;
@@ -59,15 +58,15 @@ public class PixelRepositoryTest {
 	@Test
 	@DisplayName("[findCurrentPixelCountByUserId] 자신의 현재 픽셀 개수를 정확히 가져오는지 확인")
 	@Transactional
-	void findCurrentPixelCountByUserIdIsCorrect() {
+	void countCurrentPixelByUserIdIsCorrect() {
 		savePixel(LATITUDE_50M_AWAY, LONGITUDE_50M_AWAY, 0L, 0L, 1L);
 		savePixel(LATITUDE_50M_AWAY, LONGITUDE_50M_AWAY, 0L, 0L, 2L);
 		savePixel(LATITUDE_50M_AWAY, LONGITUDE_50M_AWAY, 0L, 0L, 2L);
 		savePixel(LATITUDE_50M_AWAY, LONGITUDE_50M_AWAY, 0L, 0L, null);
 
-		PixelCount pixelCount = pixelRepository.findCurrentPixelCountByUserId(1L);
+		Long pixelCount = pixelRepository.countCurrentPixelByUserId(1L);
 
-		assertThat(pixelCount.getCount()).isEqualTo(1);
+		assertThat(pixelCount).isEqualTo(1);
 	}
 
 	@Test

--- a/src/test/java/com/m3pro/groundflip/service/PixelServiceTest.java
+++ b/src/test/java/com/m3pro/groundflip/service/PixelServiceTest.java
@@ -123,8 +123,7 @@ class PixelServiceTest {
 		when(pixelRepository.findById(pixelId)).thenReturn(Optional.of(pixel));
 		when(pixelUserRepository.findAllVisitedUserByPixelId(pixelId)).thenReturn(visitedUsers);
 		when(userRepository.findById(ownerId)).thenReturn(Optional.of(ownerUser));
-		when(pixelUserRepository.findAccumulatePixelCountByUserId(ownerId)).thenReturn(
-			accumulatePixelCount);
+		when(pixelUserRepository.countAccumulatePixelByUserId(ownerId)).thenReturn(10L);
 		when(pixelRepository.findCurrentPixelCountByUserId(ownerId)).thenReturn(
 			currentPixelCount);
 
@@ -302,14 +301,14 @@ class PixelServiceTest {
 		PixelCount accumulatePixelCount = () -> 5;
 
 		when(pixelRepository.findCurrentPixelCountByUserId(userId)).thenReturn(currentPixelCount);
-		when(pixelUserRepository.findAccumulatePixelCountByUserId(userId)).thenReturn(accumulatePixelCount);
+		when(pixelUserRepository.countAccumulatePixelByUserId(userId)).thenReturn(5L);
 
 		// When
 		PixelCountResponse pixelCount = pixelService.getPixelCount(userId);
 
 		// Then
 		assertEquals(pixelCount.getCurrentPixelCount(), currentPixelCount.getCount());
-		assertEquals(pixelCount.getAccumulatePixelCount(), accumulatePixelCount.getCount());
+		assertEquals(pixelCount.getAccumulatePixelCount(), 5L);
 	}
 
 	@Test

--- a/src/test/java/com/m3pro/groundflip/service/PixelServiceTest.java
+++ b/src/test/java/com/m3pro/groundflip/service/PixelServiceTest.java
@@ -124,8 +124,7 @@ class PixelServiceTest {
 		when(pixelUserRepository.findAllVisitedUserByPixelId(pixelId)).thenReturn(visitedUsers);
 		when(userRepository.findById(ownerId)).thenReturn(Optional.of(ownerUser));
 		when(pixelUserRepository.countAccumulatePixelByUserId(ownerId)).thenReturn(10L);
-		when(pixelRepository.findCurrentPixelCountByUserId(ownerId)).thenReturn(
-			currentPixelCount);
+		when(pixelRepository.countCurrentPixelByUserId(ownerId)).thenReturn(5L);
 
 		// When
 		IndividualPixelInfoResponse response = pixelService.getIndividualModePixelInfo(pixelId);
@@ -135,7 +134,7 @@ class PixelServiceTest {
 		assertThat(response.getAddressNumber()).isEqualTo(addressNumber);
 		assertThat(response.getVisitCount()).isEqualTo(visitedUsers.size());
 		assertThat(response.getVisitList().get(0).getNickname()).isEqualTo("JohnDoe");
-		assertThat(response.getPixelOwnerUser().getCurrentPixelCount()).isEqualTo(currentPixelCount.getCount());
+		assertThat(response.getPixelOwnerUser().getCurrentPixelCount()).isEqualTo(5L);
 		assertThat(response.getPixelOwnerUser().getNickname()).isEqualTo("test");
 	}
 
@@ -300,14 +299,14 @@ class PixelServiceTest {
 
 		PixelCount accumulatePixelCount = () -> 5;
 
-		when(pixelRepository.findCurrentPixelCountByUserId(userId)).thenReturn(currentPixelCount);
+		when(pixelRepository.countCurrentPixelByUserId(userId)).thenReturn(3L);
 		when(pixelUserRepository.countAccumulatePixelByUserId(userId)).thenReturn(5L);
 
 		// When
 		PixelCountResponse pixelCount = pixelService.getPixelCount(userId);
 
 		// Then
-		assertEquals(pixelCount.getCurrentPixelCount(), currentPixelCount.getCount());
+		assertEquals(pixelCount.getCurrentPixelCount(), 3L);
 		assertEquals(pixelCount.getAccumulatePixelCount(), 5L);
 	}
 

--- a/src/test/java/com/m3pro/groundflip/service/PixelServiceTest.java
+++ b/src/test/java/com/m3pro/groundflip/service/PixelServiceTest.java
@@ -19,6 +19,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.m3pro.groundflip.domain.dto.pixel.IndividualPixelInfoResponse;
 import com.m3pro.groundflip.domain.dto.pixel.PixelCountResponse;
+import com.m3pro.groundflip.domain.dto.pixel.PixelOccupyRequest;
 import com.m3pro.groundflip.domain.dto.pixelUser.IndividualHistoryPixelInfoResponse;
 import com.m3pro.groundflip.domain.dto.pixelUser.PixelCount;
 import com.m3pro.groundflip.domain.dto.pixelUser.PixelOwnerUser;
@@ -28,6 +29,7 @@ import com.m3pro.groundflip.domain.entity.PixelUser;
 import com.m3pro.groundflip.domain.entity.User;
 import com.m3pro.groundflip.exception.AppException;
 import com.m3pro.groundflip.exception.ErrorCode;
+import com.m3pro.groundflip.repository.CommunityRepository;
 import com.m3pro.groundflip.repository.PixelRepository;
 import com.m3pro.groundflip.repository.PixelUserRepository;
 import com.m3pro.groundflip.repository.UserRepository;
@@ -41,6 +43,8 @@ class PixelServiceTest {
 	private PixelUserRepository pixelUserRepository;
 	@Mock
 	private UserRepository userRepository;
+	@Mock
+	private CommunityRepository communityRepository;
 	@InjectMocks
 	private PixelService pixelService;
 
@@ -68,7 +72,7 @@ class PixelServiceTest {
 	}
 
 	@Test
-	@DisplayName("[getIndividualPixelModeInfo] 정상적으로 픽셀에 대한 정보가 있는 경우")
+	@DisplayName("[getIndividualModePixelInfo] 정상적으로 픽셀에 대한 정보가 있는 경우")
 	void getIndividualModePixelInfoSuccess() {
 		// Given
 		Long pixelId = 1L;
@@ -288,7 +292,7 @@ class PixelServiceTest {
 	}
 
 	@Test
-	@DisplayName("픽셀 갯수가 정상적으로 불러와지는지 확인")
+	@DisplayName("[getPixelCount] 픽셀 갯수가 정상적으로 불러와지는지 확인")
 	void getPixelCountSuccess() {
 		// Given
 		Long userId = 1L;
@@ -306,5 +310,22 @@ class PixelServiceTest {
 		// Then
 		assertEquals(pixelCount.getCurrentPixelCount(), currentPixelCount.getCount());
 		assertEquals(pixelCount.getAccumulatePixelCount(), accumulatePixelCount.getCount());
+	}
+
+	@Test
+	@DisplayName("[occupyPixel] 픽셀을 정상적으로 차지한다.")
+	void occupyPixel() {
+		// Given
+		PixelOccupyRequest pixelOccupyRequest = new PixelOccupyRequest(5L, 78611L, 222L, 233L);
+		Pixel pixel = Pixel.builder()
+			.x(222L)
+			.y(233L)
+			.address("대한민국")
+			.build();
+		when(pixelRepository.findByXAndY(222L, 233L)).thenReturn(Optional.of(pixel));
+		// When
+		pixelService.occupyPixel(pixelOccupyRequest);
+		//Then
+		verify(pixelUserRepository, times(1)).save(any());
 	}
 }

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -19,7 +19,7 @@ spring:
   data:
     redis:
       host: localhost
-      port: 6379
+      port: 6378
 logging:
   level:
     sql: debug


### PR DESCRIPTION
## 작업 내용*

- getIndividualModePixelInfo 에서 역정규화된 pixel을 활용하도록 수정
- ReverseGeoCodingService 분리
- 픽셀 수를 세는 레파지토리 코드를 Jpql 로 수정
- 테스트용 redis 포트를 6378로 변경
- Jacoco 커버리지 리포트를 ci 마다 새로 생성하는 것이 아니라 기존 리포트를 수정하도록 변경

## 고민한 내용*
### getPixelOwnerUserInfo
```
	private PixelOwnerUserResponse getPixelOwnerUserInfo(Pixel pixel) {
		Long ownerUserId = pixel.getUserId();
		if (ownerUserId == null) {
			return null;
		} else {
			PixelCount accumulatePixelCount = pixelUserRepository.findAccumulatePixelCountByUserId(ownerUserId);
			PixelCount currentPixelCount = pixelRepository.findCurrentPixelCountByUserId(ownerUserId);
			User ownerUser = userRepository.findById(ownerUserId)
				.orElseThrow(() -> {
					log.error("pixel {} 의 소유자가 {} 인데 존재하지 않음.", pixel.getId(), ownerUserId);
					return new AppException(ErrorCode.INTERNAL_SERVER_ERROR);
				});
			return PixelOwnerUserResponse.from(ownerUser, currentPixelCount, accumulatePixelCount);
		}
	}
```
기존에는 소유자를 pixelUserTable 에서 받아오도록 구현 하였는데 역정규화 하여서 로직을 간단하게 수정했다. Pixel 테이블에 있는 userId를 사용해서 소유자를 판단하고 userId로 User 테이블에서 데이터를 조회한다.

이때 Pixel의 userId 컬럼에 값이 있는데 `userRepository.findById(ownerUserId)` 를 했을때 null 이면 정합성이 문제가 생긴 것이기에 서버 오류를 반환하게 했다.

### ReverseGeoCodingService
PixelService 에서 외부 api 콜을 쏴서 주소를 얻어오는 것은 너무 많은 책임을 가지고 있다고 판단하여 따로 클래스를 분리했다. 또한 테스트 할때 외부 api 콜하는 부분을 실제 콜하지 않고 테스트 해야하기에 모킹 할 수 있게 분리했다.

### 픽셀 수를 세는 레파지토리 코드를 Jpql 로 수정
기존에 nativeQuery 를 사용해서 개수를 세다 보니 반환값을 PixelCount 라는 인터페이스 감아서 사용했다. 이렇게 되면 단순 count 값 하나를 가져오는데 객체로 감싸서 가져오게 되고 getCount 를 호풀 해야 가져올 수 있어서 Long 타입을 반환하는 Jpql 로 변경했다.

### 테스트용 redis 포트를 6378로 변경
로컬에서 서버를 실행시킬때 6379 번 포트로 redis 를 돌리고 있다. 같은 포트로 테스트 할 경우 기존 돌고 있는 redis를 지우거나 껐다가 다시 켜야되는 불편함이 있다. 따라서 테스트 용 redis를 6378 번 포트에 할당 함으로써 로컬에서 돌아가는 redis 는 그대로 두고 테스트 가능하게 수정 했다.

### Jacoco
기존에는 PR을 작성후 새로 푸시 할 때 마다 CI action 이 돌고 action 이 돌 때 마다 Jacoco 리포트가 새로 댓글로 달려 한 pr 에 여러개의 리포트가 달리게 되는 불편한 상황이었다. 그래서 새로운 댓글이 아니라 기존 댓글에 수정하도록 변경했다.

## 리뷰 요구사항

- 역정규화 한 부분들을 다 수정했나 검사해주시면 감사하겠습니다

## 스크린샷