### PR TITLE
M3-184 현재 랭킹을 반환하는 api 구현

### DIFF
--- a/src/main/java/com/m3pro/groundflip/controller/RankingController.java
+++ b/src/main/java/com/m3pro/groundflip/controller/RankingController.java
@@ -1,0 +1,34 @@
+package com.m3pro.groundflip.controller;
+
+import java.util.List;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.m3pro.groundflip.domain.dto.Response;
+import com.m3pro.groundflip.domain.dto.ranking.UserRankingResponse;
+import com.m3pro.groundflip.service.RankingService;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@RestController
+@RequiredArgsConstructor
+@Slf4j
+@RequestMapping("/api/ranking")
+@Tag(name = "ranking", description = "랭킹 API")
+@SecurityRequirement(name = "Authorization")
+public class RankingController {
+	private final RankingService rankingService;
+
+	@Operation(summary = "개인전 랭킹 조회", description = "현재 개인전 유저들의 차지 중인 픽셀 기준으로 상위 30명의 랭킹을 반환한다.")
+	@GetMapping("/user")
+	public Response<List<UserRankingResponse>> getAllUserRanking() {
+		return Response.createSuccess(
+			rankingService.getAllUserRanking());
+	}
+}

--- a/src/main/java/com/m3pro/groundflip/controller/RankingController.java
+++ b/src/main/java/com/m3pro/groundflip/controller/RankingController.java
@@ -3,6 +3,7 @@ package com.m3pro.groundflip.controller;
 import java.util.List;
 
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -11,6 +12,7 @@ import com.m3pro.groundflip.domain.dto.ranking.UserRankingResponse;
 import com.m3pro.groundflip.service.RankingService;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
@@ -25,10 +27,20 @@ import lombok.extern.slf4j.Slf4j;
 public class RankingController {
 	private final RankingService rankingService;
 
-	@Operation(summary = "개인전 랭킹 조회", description = "현재 개인전 유저들의 차지 중인 픽셀 기준으로 상위 30명의 랭킹을 반환한다.")
+	@Operation(summary = "개인전 전체 랭킹 조회", description = "현재 개인전 유저들의 차지 중인 픽셀 기준으로 상위 30명의 랭킹을 반환한다.")
 	@GetMapping("/user")
 	public Response<List<UserRankingResponse>> getAllUserRanking() {
 		return Response.createSuccess(
 			rankingService.getAllUserRanking());
+	}
+
+	@Operation(summary = "개인전 개인 랭킹 조회", description = "특정 유저의 현재 순위를 반환한다.")
+	@GetMapping("/user/{userId}")
+	public Response<UserRankingResponse> getUserRank(
+		@Parameter(description = "찾고자 하는 userID", required = true)
+		@PathVariable Long userId
+	) {
+		return Response.createSuccess(
+			rankingService.getUserRankInfo(userId));
 	}
 }

--- a/src/main/java/com/m3pro/groundflip/domain/dto/ranking/Ranking.java
+++ b/src/main/java/com/m3pro/groundflip/domain/dto/ranking/Ranking.java
@@ -14,11 +14,13 @@ import lombok.NoArgsConstructor;
 public class Ranking {
 	private Long userId;
 	private Long currentPixelCount;
+	private Long rank;
 
-	public static Ranking from(ZSetOperations.TypedTuple<String> typedTuple) {
+	public static Ranking from(ZSetOperations.TypedTuple<String> typedTuple, Long rank) {
 		return new Ranking(
 			Long.parseLong(Objects.requireNonNull(typedTuple.getValue())),
-			Objects.requireNonNull(typedTuple.getScore()).longValue()
+			Objects.requireNonNull(typedTuple.getScore()).longValue(),
+			rank
 		);
 	}
 }

--- a/src/main/java/com/m3pro/groundflip/domain/dto/ranking/UserRankingResponse.java
+++ b/src/main/java/com/m3pro/groundflip/domain/dto/ranking/UserRankingResponse.java
@@ -1,0 +1,29 @@
+package com.m3pro.groundflip.domain.dto.ranking;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Data
+@Builder
+@Schema(title = "사용자 랭킹")
+public class UserRankingResponse {
+	@Schema(description = "사용자 ID", example = "1234")
+	private Long userId;
+
+	@Schema(description = "사용자 닉네임", example = "홍길동")
+	private String nickname;
+
+	@Schema(description = "사용자 프로필 사진 주소", example = "http://www.test.com")
+	private Long profileImageUrl;
+
+	@Schema(description = "현재 차지하고 있는 픽셀 개수", example = "5")
+	private Long currentPixelCount;
+
+	@Schema(description = "순위", example = "4")
+	private Long rank;
+}

--- a/src/main/java/com/m3pro/groundflip/domain/dto/ranking/UserRankingResponse.java
+++ b/src/main/java/com/m3pro/groundflip/domain/dto/ranking/UserRankingResponse.java
@@ -1,5 +1,7 @@
 package com.m3pro.groundflip.domain.dto.ranking;
 
+import com.m3pro.groundflip.domain.entity.User;
+
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -19,11 +21,21 @@ public class UserRankingResponse {
 	private String nickname;
 
 	@Schema(description = "사용자 프로필 사진 주소", example = "http://www.test.com")
-	private Long profileImageUrl;
+	private String profileImageUrl;
 
 	@Schema(description = "현재 차지하고 있는 픽셀 개수", example = "5")
 	private Long currentPixelCount;
 
 	@Schema(description = "순위", example = "4")
 	private Long rank;
+
+	public static UserRankingResponse from(User user, Long rank, Long currentPixelCount) {
+		return UserRankingResponse.builder()
+			.userId(user.getId())
+			.nickname(user.getNickname())
+			.profileImageUrl(user.getProfileImage())
+			.currentPixelCount(currentPixelCount)
+			.rank(rank)
+			.build();
+	}
 }

--- a/src/main/java/com/m3pro/groundflip/domain/entity/User.java
+++ b/src/main/java/com/m3pro/groundflip/domain/entity/User.java
@@ -56,14 +56,24 @@ public class User extends BaseTimeEntity {
 
 	private Date deletedAt;
 
-	public void updateNickName(String nickname) {this.nickname = nickname;}
+	public void updateNickName(String nickname) {
+		this.nickname = nickname;
+	}
 
-	public void updateProfileImage(String profileImage) {this.profileImage = profileImage;}
+	public void updateProfileImage(String profileImage) {
+		this.profileImage = profileImage;
+	}
 
-	public void updateBirthYear(Date birthYear) {this.birthYear = birthYear;}
+	public void updateBirthYear(Date birthYear) {
+		this.birthYear = birthYear;
+	}
 
-	public void updateGender(Gender gender) {this.gender = gender;}
+	public void updateGender(Gender gender) {
+		this.gender = gender;
+	}
 
-	public void updateStatus(UserStatus status) {this.status = status;}
+	public void updateStatus(UserStatus status) {
+		this.status = status;
+	}
 
 }

--- a/src/main/java/com/m3pro/groundflip/service/PixelService.java
+++ b/src/main/java/com/m3pro/groundflip/service/PixelService.java
@@ -136,7 +136,7 @@ public class PixelService {
 
 	public PixelCountResponse getPixelCount(Long userId) {
 		return PixelCountResponse.builder()
-			.currentPixelCount(pixelRepository.countCurrentPixelByUserId(userId))
+			.currentPixelCount(rankingService.getCurrentPixelCount(userId))
 			.accumulatePixelCount(pixelUserRepository.countAccumulatePixelByUserId(userId))
 			.build();
 	}
@@ -147,7 +147,7 @@ public class PixelService {
 			return null;
 		} else {
 			Long accumulatePixelCount = pixelUserRepository.countAccumulatePixelByUserId(ownerUserId);
-			Long currentPixelCount = pixelRepository.countCurrentPixelByUserId(ownerUserId);
+			Long currentPixelCount = rankingService.getCurrentPixelCount(ownerUserId);
 			User ownerUser = userRepository.findById(ownerUserId)
 				.orElseThrow(() -> {
 					log.error("pixel {} 의 소유자가 {} 인데 존재하지 않음.", pixel.getId(), ownerUserId);

--- a/src/main/java/com/m3pro/groundflip/service/RankingService.java
+++ b/src/main/java/com/m3pro/groundflip/service/RankingService.java
@@ -1,7 +1,11 @@
 package com.m3pro.groundflip.service;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 import org.springframework.stereotype.Service;
 
+import com.m3pro.groundflip.domain.dto.ranking.Ranking;
 import com.m3pro.groundflip.domain.dto.ranking.UserRankingResponse;
 import com.m3pro.groundflip.domain.entity.User;
 import com.m3pro.groundflip.exception.AppException;
@@ -34,6 +38,18 @@ public class RankingService {
 
 	public Long getCurrentPixelCount(Long userId) {
 		return rankingRedisRepository.getUserCurrentPixelCount(userId).orElse(0L);
+	}
+
+	public List<UserRankingResponse> getAllUserRanking() {
+		List<Ranking> rankings = rankingRedisRepository.getRankingsWithCurrentPixelCount();
+
+		return rankings.stream()
+			.map(ranking -> {
+				User user = userRepository.findById(ranking.getUserId())
+					.orElseThrow(() -> new RuntimeException("User not found"));
+				return UserRankingResponse.from(user, ranking.getRank(), ranking.getCurrentPixelCount());
+			})
+			.collect(Collectors.toList());
 	}
 
 	public UserRankingResponse getUserRankInfo(Long userId) {

--- a/src/main/java/com/m3pro/groundflip/service/RankingService.java
+++ b/src/main/java/com/m3pro/groundflip/service/RankingService.java
@@ -2,7 +2,12 @@ package com.m3pro.groundflip.service;
 
 import org.springframework.stereotype.Service;
 
+import com.m3pro.groundflip.domain.dto.ranking.UserRankingResponse;
+import com.m3pro.groundflip.domain.entity.User;
+import com.m3pro.groundflip.exception.AppException;
+import com.m3pro.groundflip.exception.ErrorCode;
 import com.m3pro.groundflip.repository.RankingRedisRepository;
+import com.m3pro.groundflip.repository.UserRepository;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -12,6 +17,7 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class RankingService {
 	private final RankingRedisRepository rankingRedisRepository;
+	private final UserRepository userRepository;
 
 	public void increaseCurrentPixelCount(Long userId) {
 		rankingRedisRepository.increaseCurrentPixelCount(userId);
@@ -28,5 +34,21 @@ public class RankingService {
 
 	public Long getCurrentPixelCount(Long userId) {
 		return rankingRedisRepository.getUserCurrentPixelCount(userId).orElse(0L);
+	}
+
+	public UserRankingResponse getUserRankInfo(Long userId) {
+		User user = userRepository.findById(userId)
+			.orElseThrow(() -> new AppException(ErrorCode.USER_NOT_FOUND));
+		Long rank = getUserRank(userId);
+		Long currentPixelCount = getCurrentPixelCount(userId);
+		return UserRankingResponse.from(user, rank, currentPixelCount);
+	}
+
+	private Long getUserRank(Long userId) {
+		return rankingRedisRepository.getUserRank(userId)
+			.orElseThrow(() -> {
+				log.error("User {} not register at redis", userId);
+				return new AppException(ErrorCode.INTERNAL_SERVER_ERROR);
+			});
 	}
 }

--- a/src/main/java/com/m3pro/groundflip/service/RankingService.java
+++ b/src/main/java/com/m3pro/groundflip/service/RankingService.java
@@ -25,4 +25,8 @@ public class RankingService {
 		increaseCurrentPixelCount(occupyingUserId);
 		decreaseCurrentPixelCount(deprivedUserId);
 	}
+
+	public Long getCurrentPixelCount(Long userId) {
+		return rankingRedisRepository.getUserCurrentPixelCount(userId).orElse(0L);
+	}
 }

--- a/src/main/java/com/m3pro/groundflip/service/RankingService.java
+++ b/src/main/java/com/m3pro/groundflip/service/RankingService.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.m3pro.groundflip.domain.dto.ranking.Ranking;
 import com.m3pro.groundflip.domain.dto.ranking.UserRankingResponse;
@@ -40,6 +41,7 @@ public class RankingService {
 		return rankingRedisRepository.getUserCurrentPixelCount(userId).orElse(0L);
 	}
 
+	@Transactional
 	public List<UserRankingResponse> getAllUserRanking() {
 		List<Ranking> rankings = rankingRedisRepository.getRankingsWithCurrentPixelCount();
 

--- a/src/test/java/com/m3pro/groundflip/repository/RankingRedisRepositoryTest.java
+++ b/src/test/java/com/m3pro/groundflip/repository/RankingRedisRepositoryTest.java
@@ -131,6 +131,9 @@ class RankingRedisRepositoryTest {
 		assertThat(rankings.get(0).getUserId()).isEqualTo(userId3);
 		assertThat(rankings.get(1).getUserId()).isEqualTo(userId1);
 		assertThat(rankings.get(2).getUserId()).isEqualTo(userId2);
+		assertThat(rankings.get(0).getRank()).isEqualTo(1);
+		assertThat(rankings.get(1).getRank()).isEqualTo(2);
+		assertThat(rankings.get(2).getRank()).isEqualTo(3);
 	}
 
 	@Test

--- a/src/test/java/com/m3pro/groundflip/service/PixelServiceTest.java
+++ b/src/test/java/com/m3pro/groundflip/service/PixelServiceTest.java
@@ -122,7 +122,7 @@ class PixelServiceTest {
 		when(pixelUserRepository.findAllVisitedUserByPixelId(pixelId)).thenReturn(visitedUsers);
 		when(userRepository.findById(ownerId)).thenReturn(Optional.of(ownerUser));
 		when(pixelUserRepository.countAccumulatePixelByUserId(ownerId)).thenReturn(10L);
-		when(pixelRepository.countCurrentPixelByUserId(ownerId)).thenReturn(5L);
+		when(rankingService.getCurrentPixelCount(ownerId)).thenReturn(5L);
 
 		// When
 		IndividualPixelInfoResponse response = pixelService.getIndividualModePixelInfo(pixelId);
@@ -293,7 +293,7 @@ class PixelServiceTest {
 		// Given
 		Long userId = 1L;
 
-		when(pixelRepository.countCurrentPixelByUserId(userId)).thenReturn(3L);
+		when(rankingService.getCurrentPixelCount(userId)).thenReturn(3L);
 		when(pixelUserRepository.countAccumulatePixelByUserId(userId)).thenReturn(5L);
 
 		// When

--- a/src/test/java/com/m3pro/groundflip/service/RankingServiceTest.java
+++ b/src/test/java/com/m3pro/groundflip/service/RankingServiceTest.java
@@ -1,6 +1,9 @@
 package com.m3pro.groundflip.service;
 
+import static org.assertj.core.api.Assertions.*;
 import static org.mockito.Mockito.*;
+
+import java.util.Optional;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -54,5 +57,27 @@ class RankingServiceTest {
 
 		verify(rankingRedisRepository, times(1)).decreaseCurrentPixelCount(deprivedUserId);
 		verify(rankingRedisRepository, times(1)).increaseCurrentPixelCount(occupyingUserId);
+	}
+
+	@Test
+	@DisplayName("[getCurrentPixelCount] userId 가 소유한 픽셀의 개수를 반환한다.")
+	void getCurrentPixelCountTest() {
+		Long userId = 1L;
+		when(rankingRedisRepository.getUserCurrentPixelCount(any())).thenReturn(Optional.of(15L));
+
+		Long count = rankingService.getCurrentPixelCount(userId);
+
+		assertThat(count).isEqualTo(15L);
+	}
+
+	@Test
+	@DisplayName("[getCurrentPixelCount] userId가 sortedSet에 없다면 0 반환")
+	void getCurrentPixelCountTestNull() {
+		Long userId = 1L;
+		when(rankingRedisRepository.getUserCurrentPixelCount(any())).thenReturn(Optional.empty());
+
+		Long count = rankingService.getCurrentPixelCount(userId);
+
+		assertThat(count).isEqualTo(0L);
 	}
 }


### PR DESCRIPTION
## 작업 내용*
- 상위 30명 랭킹을 불러오는 api 구현
- 특정 유저의 등수를 불러오는 api 구현

## 고민한 내용*
### 전체 랭킹 조회 최적화
처음에는 
```
public List<UserRankingResponse> getAllUserRanking() {
	List<Ranking> rankings = rankingRedisRepository.getRankingsWithCurrentPixelCount();

	return rankings.stream()
		.map(ranking -> {
			User user = userRepository.findById(ranking.getUserId())
				.orElseThrow(() -> new RuntimeException("User not found"));
			return UserRankingResponse.from(user, ranking.getRank(), ranking.getCurrentPixelCount());
		})
		.collect(Collectors.toList());
}
```
위와 같이 레디스에서 랭킹을 가져오고 랭킹을 map 함수로 변환하면서 user 정보를 하나씩 DB 에서 가져오는 방식을 사용했더니 코드는 간단했지만 api 응답속도가 약 1400ms 로 매우 느렸다. 많은 조회를 해서 오래 걸리는 것 같아 Transsaction 으로 묶었더니 300ms 까지 줄었다.

하지만 생각해보니 DB에서 user 를 가져올 때 한번에 다 가져오면 여러번 요청 보낼 필요가 없으니 더 빨라질 것이라고 생각했다. 그래서 랭킹에 속해있는 id 들을 한번 조회해서 사용하는 방식으로 바꾸었다. (현재 코드에 반영되어있는 코드)

그결과 약 70ms 정도로 처음 구현했을때 1400ms 보다 20배 빨라졌다.




## 리뷰 요구사항

- 리뷰할 때 중점적으로 봐줬으면 하는 내용들

## 스크린샷