### PR TITLE
M3-195 애플 로그인 api 구현

### DIFF
--- a/.github/workflows/cd_dev.yml
+++ b/.github/workflows/cd_dev.yml
@@ -32,6 +32,7 @@ jobs:
           echo "AWS_ACCESS_KEY=${{ secrets.AWS_ACCESS_KEY }}" >> .env
           echo "AWS_SECRET_KEY=${{ secrets.AWS_SECRET_KEY }}" >> .env
           echo "AWS_S3_BUCKET=${{ secrets.AWS_S3_BUCKET }}" >> .env
+          echo "APPLE_APP_ID=${{ secrets.APPLE_APP_ID }}" >> .env
           echo "SPRING_PROFILES_ACTIVE=dev" >> .env
 
       - name: gradlew에 실행 권한 부여

--- a/src/main/java/com/m3pro/groundflip/controller/AuthController.java
+++ b/src/main/java/com/m3pro/groundflip/controller/AuthController.java
@@ -31,6 +31,12 @@ public class AuthController {
 		return Response.createSuccess(authService.login(Provider.KAKAO, loginRequest));
 	}
 
+	@Operation(summary = "애플 로그인", description = "애플에서 받은 identity token을 통해 회원가입 또는 로그인하는 API")
+	@PostMapping("/kakao/apple")
+	public Response<LoginResponse> loginApple(@RequestBody LoginRequest loginRequest) {
+		return Response.createSuccess(authService.login(Provider.APPLE, loginRequest));
+	}
+
 	@Operation(summary = "access token 재발급", description = "만료된 access token 을 refresh token으로 재발급 하는 API")
 	@PostMapping("/reissue")
 	public Response<ReissueReponse> reissueToken(@RequestBody ReissueRequest reissueRequest) {

--- a/src/main/java/com/m3pro/groundflip/domain/dto/auth/AppleUserInfoResponse.java
+++ b/src/main/java/com/m3pro/groundflip/domain/dto/auth/AppleUserInfoResponse.java
@@ -1,0 +1,20 @@
+package com.m3pro.groundflip.domain.dto.auth;
+
+import com.m3pro.groundflip.enums.Provider;
+
+import lombok.AllArgsConstructor;
+
+@AllArgsConstructor
+public class AppleUserInfoResponse implements OauthUserInfoResponse {
+	private String email;
+
+	@Override
+	public String getEmail() {
+		return email;
+	}
+
+	@Override
+	public Provider getOAuthProvider() {
+		return Provider.APPLE;
+	}
+}

--- a/src/main/java/com/m3pro/groundflip/domain/dto/auth/apple/ApplePublicKey.java
+++ b/src/main/java/com/m3pro/groundflip/domain/dto/auth/apple/ApplePublicKey.java
@@ -1,0 +1,4 @@
+package com.m3pro.groundflip.domain.dto.auth.apple;
+
+public record ApplePublicKey(String kty, String kid, String alg, String n, String e) {
+}

--- a/src/main/java/com/m3pro/groundflip/domain/dto/auth/apple/ApplePublicKeyResponse.java
+++ b/src/main/java/com/m3pro/groundflip/domain/dto/auth/apple/ApplePublicKeyResponse.java
@@ -1,0 +1,16 @@
+package com.m3pro.groundflip.domain.dto.auth.apple;
+
+import java.util.List;
+
+import com.m3pro.groundflip.exception.AppException;
+import com.m3pro.groundflip.exception.ErrorCode;
+
+public record ApplePublicKeyResponse(List<ApplePublicKey> keys) {
+
+	public ApplePublicKey getMatchedKey(String kid, String alg) throws AppException {
+		return keys.stream()
+			.filter(key -> key.kid().equals(kid) && key.alg().equals(alg))
+			.findAny()
+			.orElseThrow(() -> new AppException(ErrorCode.INVALID_JWT));
+	}
+}

--- a/src/main/java/com/m3pro/groundflip/jwt/JwtProvider.java
+++ b/src/main/java/com/m3pro/groundflip/jwt/JwtProvider.java
@@ -102,7 +102,7 @@ public class JwtProvider {
 		return new ObjectMapper().readValue(decodeHeader(header), Map.class);
 	}
 
-	public String decodeHeader(String token) {
+	private String decodeHeader(String token) {
 		return new String(Base64.getDecoder().decode(token), StandardCharsets.UTF_8);
 	}
 

--- a/src/main/java/com/m3pro/groundflip/service/oauth/AppleApiClient.java
+++ b/src/main/java/com/m3pro/groundflip/service/oauth/AppleApiClient.java
@@ -1,0 +1,83 @@
+package com.m3pro.groundflip.service.oauth;
+
+import java.security.NoSuchAlgorithmException;
+import java.security.PublicKey;
+import java.security.spec.InvalidKeySpecException;
+import java.util.Map;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.m3pro.groundflip.domain.dto.auth.AppleUserInfoResponse;
+import com.m3pro.groundflip.domain.dto.auth.OauthUserInfoResponse;
+import com.m3pro.groundflip.domain.dto.auth.apple.ApplePublicKeyResponse;
+import com.m3pro.groundflip.enums.Provider;
+import com.m3pro.groundflip.exception.AppException;
+import com.m3pro.groundflip.exception.ErrorCode;
+import com.m3pro.groundflip.jwt.JwtProvider;
+
+import io.jsonwebtoken.Claims;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class AppleApiClient implements OauthApiClient {
+	private static final String ISSUER = "https://appleid.apple.com";
+	private final RestClient restClient;
+	private final ApplePublicKeyGenerator applePublicKeyGenerator;
+	private final JwtProvider jwtProvider;
+	@Value("${apple.clientId}")
+	private String clientId;
+
+	@Override
+	public Provider oAuthProvider() {
+		return Provider.APPLE;
+	}
+
+	@Override
+	public OauthUserInfoResponse requestOauthUserInfo(String identityToken) {
+		try {
+			Map<String, String> headers = jwtProvider.parseHeaders(identityToken);
+			PublicKey publicKey = applePublicKeyGenerator.generatePublicKey(headers, getAppleAuthPublicKey());
+			String email = jwtProvider.getTokenClaims(identityToken, publicKey).get("email", String.class);
+			return new AppleUserInfoResponse(email);
+		} catch (Exception e) {
+			throw new AppException(ErrorCode.UNAUTHORIZED);
+		}
+	}
+
+	@Override
+	public boolean isOauthTokenValid(String identityToken) {
+		try {
+			verifyIdentityToken(identityToken);
+			return true;
+		} catch (Exception e) {
+			return false;
+		}
+	}
+
+	private ApplePublicKeyResponse getAppleAuthPublicKey() {
+		return restClient.get()
+			.uri("https://appleid.apple.com/auth/keys")
+			.retrieve()
+			.body(ApplePublicKeyResponse.class);
+	}
+
+	private void verifyIdentityToken(String identityToken) throws
+		JsonProcessingException,
+		NoSuchAlgorithmException,
+		InvalidKeySpecException {
+		Map<String, String> headers = jwtProvider.parseHeaders(identityToken);
+		PublicKey publicKey = applePublicKeyGenerator.generatePublicKey(headers, getAppleAuthPublicKey());
+		Claims tokenClaims = jwtProvider.getTokenClaims(identityToken, publicKey);
+
+		if (!ISSUER.equals(tokenClaims.getIssuer())) {
+			throw new AppException(ErrorCode.INVALID_JWT);
+		}
+		if (!clientId.equals(tokenClaims.getAudience())) {
+			throw new AppException(ErrorCode.INVALID_JWT);
+		}
+	}
+}

--- a/src/main/java/com/m3pro/groundflip/service/oauth/ApplePublicKeyGenerator.java
+++ b/src/main/java/com/m3pro/groundflip/service/oauth/ApplePublicKeyGenerator.java
@@ -9,7 +9,6 @@ import java.security.spec.RSAPublicKeySpec;
 import java.util.Base64;
 import java.util.Map;
 
-import org.springframework.security.core.AuthenticationException;
 import org.springframework.stereotype.Component;
 
 import com.m3pro.groundflip.domain.dto.auth.apple.ApplePublicKey;
@@ -21,8 +20,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class ApplePublicKeyGenerator {
 	public PublicKey generatePublicKey(Map<String, String> tokenHeaders,
-		ApplePublicKeyResponse applePublicKeys)
-		throws AuthenticationException, NoSuchAlgorithmException, InvalidKeySpecException {
+		ApplePublicKeyResponse applePublicKeys) throws NoSuchAlgorithmException, InvalidKeySpecException {
 		ApplePublicKey publicKey = applePublicKeys.getMatchedKey(tokenHeaders.get("kid"),
 			tokenHeaders.get("alg"));
 

--- a/src/main/java/com/m3pro/groundflip/service/oauth/ApplePublicKeyGenerator.java
+++ b/src/main/java/com/m3pro/groundflip/service/oauth/ApplePublicKeyGenerator.java
@@ -1,0 +1,43 @@
+package com.m3pro.groundflip.service.oauth;
+
+import java.math.BigInteger;
+import java.security.KeyFactory;
+import java.security.NoSuchAlgorithmException;
+import java.security.PublicKey;
+import java.security.spec.InvalidKeySpecException;
+import java.security.spec.RSAPublicKeySpec;
+import java.util.Base64;
+import java.util.Map;
+
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.stereotype.Component;
+
+import com.m3pro.groundflip.domain.dto.auth.apple.ApplePublicKey;
+import com.m3pro.groundflip.domain.dto.auth.apple.ApplePublicKeyResponse;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class ApplePublicKeyGenerator {
+	public PublicKey generatePublicKey(Map<String, String> tokenHeaders,
+		ApplePublicKeyResponse applePublicKeys)
+		throws AuthenticationException, NoSuchAlgorithmException, InvalidKeySpecException {
+		ApplePublicKey publicKey = applePublicKeys.getMatchedKey(tokenHeaders.get("kid"),
+			tokenHeaders.get("alg"));
+
+		return getPublicKey(publicKey);
+	}
+
+	private PublicKey getPublicKey(ApplePublicKey publicKey)
+		throws NoSuchAlgorithmException, InvalidKeySpecException {
+		byte[] nBytes = Base64.getUrlDecoder().decode(publicKey.n());
+		byte[] eBytes = Base64.getUrlDecoder().decode(publicKey.e());
+
+		RSAPublicKeySpec publicKeySpec = new RSAPublicKeySpec(new BigInteger(1, nBytes),
+			new BigInteger(1, eBytes));
+
+		KeyFactory keyFactory = KeyFactory.getInstance(publicKey.kty());
+		return keyFactory.generatePublic(publicKeySpec);
+	}
+}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -42,6 +42,12 @@ oauth:
     url:
       validation: https://kapi.kakao.com/v1/user/access_token_info
       user: https://kapi.kakao.com/v2/user/me
+  apple:
+    app:
+      id: ${APPLE_APP_ID}
+    url:
+      public-keys: https://appleid.apple.com/auth/keys
+      issuer: https://appleid.apple.com
 
 naver:
   apiKeyId: ${X-NCP-APIGW-API-KEY-ID}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -38,7 +38,12 @@ oauth:
     url:
       validation: https://kapi.kakao.com/v1/user/access_token_info
       user: https://kapi.kakao.com/v2/user/me
-
+  apple:
+    app:
+      id: ${APPLE_APP_ID}
+    url:
+      public-keys: https://appleid.apple.com/auth/keys
+      issuer: https://appleid.apple.com
 naver:
   apiKeyId: ${X-NCP-APIGW-API-KEY-ID}
   apiKey: ${X-NCP-APIGW-API-KEY}

--- a/src/test/java/com/m3pro/groundflip/jwt/JwtProviderTest.java
+++ b/src/test/java/com/m3pro/groundflip/jwt/JwtProviderTest.java
@@ -3,7 +3,10 @@ package com.m3pro.groundflip.jwt;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
 import java.util.Date;
+import java.util.Map;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -13,6 +16,7 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.springframework.test.util.ReflectionTestUtils;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.m3pro.groundflip.domain.entity.redis.BlacklistedToken;
 import com.m3pro.groundflip.exception.AppException;
 import com.m3pro.groundflip.exception.ErrorCode;
@@ -137,5 +141,19 @@ class JwtProviderTest {
 		jwtProvider.expireToken(token);
 
 		verify(blackListedTokenRepository, never()).save(any(BlacklistedToken.class));
+	}
+
+	@Test
+	@DisplayName("[parseHeaders] jwt 토큰에서 header 부분을 파싱해온다.")
+	public void parseHeadersTest() throws JsonProcessingException {
+		String header = Base64.getEncoder().encodeToString("{\"alg\":\"HS256\",\"typ\":\"JWT\"}".getBytes(
+			StandardCharsets.UTF_8));
+		String token = header + ".payload.signature";
+
+		Map<String, String> headers = jwtProvider.parseHeaders(token);
+
+		assertNotNull(headers);
+		assertEquals("HS256", headers.get("alg"));
+		assertEquals("JWT", headers.get("typ"));
 	}
 }

--- a/src/test/java/com/m3pro/groundflip/service/AuthServiceTest.java
+++ b/src/test/java/com/m3pro/groundflip/service/AuthServiceTest.java
@@ -3,6 +3,8 @@ package com.m3pro.groundflip.service;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
+import java.util.Optional;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -11,9 +13,16 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import com.m3pro.groundflip.domain.dto.auth.LoginRequest;
+import com.m3pro.groundflip.domain.dto.auth.LoginResponse;
 import com.m3pro.groundflip.domain.dto.auth.LogoutRequest;
+import com.m3pro.groundflip.domain.dto.auth.OauthUserInfoResponse;
 import com.m3pro.groundflip.domain.dto.auth.ReissueReponse;
+import com.m3pro.groundflip.domain.entity.User;
+import com.m3pro.groundflip.enums.Provider;
+import com.m3pro.groundflip.enums.UserStatus;
 import com.m3pro.groundflip.jwt.JwtProvider;
+import com.m3pro.groundflip.repository.RankingRedisRepository;
 import com.m3pro.groundflip.repository.UserRepository;
 import com.m3pro.groundflip.service.oauth.OauthService;
 
@@ -25,14 +34,125 @@ class AuthServiceTest {
 	private JwtProvider jwtProvider;
 	@Mock
 	private UserRepository userRepository;
+	@Mock
+	private RankingRedisRepository rankingRedisRepository;
 	@InjectMocks
 	private AuthService authService;
+
+	private Provider provider;
+	private LoginRequest loginRequest;
+	private OauthUserInfoResponse oauthUserInfo;
+	private User existingUser;
+	private User newUser;
+	private User existingUserNoSignup;
 
 	@BeforeEach
 	void init() {
 		reset(jwtProvider);
 		reset(oauthUserInfoService);
 		reset(userRepository);
+		provider = Provider.GOOGLE; // Example provider
+		loginRequest = new LoginRequest("validAccessToken");
+		oauthUserInfo = new OauthUserInfoResponse() {
+			@Override
+			public String getEmail() {
+				return "test@example.com";
+			}
+
+			@Override
+			public Provider getOAuthProvider() {
+				return provider;
+			}
+		};
+		existingUser = User.builder()
+			.id(1L)
+			.email("test@example.com")
+			.provider(provider)
+			.status(UserStatus.COMPLETE)
+			.build();
+		existingUserNoSignup = User.builder()
+			.id(1L)
+			.email("test@example.com")
+			.provider(provider)
+			.status(UserStatus.PENDING)
+			.build();
+		newUser = User.builder()
+			.id(2L)
+			.email("newuser@example.com")
+			.provider(provider)
+			.status(UserStatus.PENDING)
+			.build();
+	}
+
+	@Test
+	@DisplayName("[login] user 가 존재하지 않는 경우 DB 저장하고 토큰을 반환, isSignup은 true")
+	public void testLogin_NewUser() {
+		when(oauthUserInfoService.requestUserInfo(provider, loginRequest.getAccessToken())).thenReturn(oauthUserInfo);
+		when(userRepository.findByProviderAndEmail(provider, oauthUserInfo.getEmail())).thenReturn(Optional.empty());
+		when(userRepository.save(any(User.class))).thenReturn(newUser);
+		when(jwtProvider.createAccessToken(newUser.getId())).thenReturn("accessToken");
+		when(jwtProvider.createRefreshToken(newUser.getId())).thenReturn("refreshToken");
+
+		LoginResponse response = authService.login(provider, loginRequest);
+
+		assertNotNull(response);
+		assertEquals("accessToken", response.getAccessToken());
+		assertEquals("refreshToken", response.getRefreshToken());
+		assertTrue(response.getIsSignUp());
+
+		verify(oauthUserInfoService, times(1)).requestUserInfo(provider, loginRequest.getAccessToken());
+		verify(userRepository, times(1)).findByProviderAndEmail(provider, oauthUserInfo.getEmail());
+		verify(userRepository, times(1)).save(any(User.class));
+		verify(rankingRedisRepository, times(1)).save(newUser.getId());
+		verify(jwtProvider, times(1)).createAccessToken(newUser.getId());
+		verify(jwtProvider, times(1)).createRefreshToken(newUser.getId());
+		verifyNoMoreInteractions(oauthUserInfoService, userRepository, jwtProvider, rankingRedisRepository);
+	}
+
+	@Test
+	@DisplayName("[login] DB에 user 가 존재하고 회원가입이 끝났다면 login 성공과 isSignup 은 false")
+	public void testLogin_ExistingUser_Signup() {
+		when(oauthUserInfoService.requestUserInfo(provider, loginRequest.getAccessToken())).thenReturn(oauthUserInfo);
+		when(userRepository.findByProviderAndEmail(provider, oauthUserInfo.getEmail())).thenReturn(
+			Optional.of(existingUser));
+		when(jwtProvider.createAccessToken(existingUser.getId())).thenReturn("accessToken");
+		when(jwtProvider.createRefreshToken(existingUser.getId())).thenReturn("refreshToken");
+
+		LoginResponse response = authService.login(provider, loginRequest);
+
+		assertNotNull(response);
+		assertEquals("accessToken", response.getAccessToken());
+		assertEquals("refreshToken", response.getRefreshToken());
+		assertFalse(response.getIsSignUp());
+
+		verify(oauthUserInfoService, times(1)).requestUserInfo(provider, loginRequest.getAccessToken());
+		verify(userRepository, times(1)).findByProviderAndEmail(provider, oauthUserInfo.getEmail());
+		verify(jwtProvider, times(1)).createAccessToken(existingUser.getId());
+		verify(jwtProvider, times(1)).createRefreshToken(existingUser.getId());
+		verifyNoMoreInteractions(oauthUserInfoService, userRepository, jwtProvider);
+	}
+
+	@Test
+	@DisplayName("[login] DB에 user 가 존재하지만 회원가입이 끝나지 않았다면 login 성공과 isSignup 은 true")
+	public void testLogin_ExistingUser_NoSignup() {
+		when(oauthUserInfoService.requestUserInfo(provider, loginRequest.getAccessToken())).thenReturn(oauthUserInfo);
+		when(userRepository.findByProviderAndEmail(provider, oauthUserInfo.getEmail())).thenReturn(
+			Optional.of(existingUserNoSignup));
+		when(jwtProvider.createAccessToken(existingUser.getId())).thenReturn("accessToken");
+		when(jwtProvider.createRefreshToken(existingUser.getId())).thenReturn("refreshToken");
+
+		LoginResponse response = authService.login(provider, loginRequest);
+
+		assertNotNull(response);
+		assertEquals("accessToken", response.getAccessToken());
+		assertEquals("refreshToken", response.getRefreshToken());
+		assertTrue(response.getIsSignUp());
+
+		verify(oauthUserInfoService, times(1)).requestUserInfo(provider, loginRequest.getAccessToken());
+		verify(userRepository, times(1)).findByProviderAndEmail(provider, oauthUserInfo.getEmail());
+		verify(jwtProvider, times(1)).createAccessToken(existingUser.getId());
+		verify(jwtProvider, times(1)).createRefreshToken(existingUser.getId());
+		verifyNoMoreInteractions(oauthUserInfoService, userRepository, jwtProvider);
 	}
 
 	@Test

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -38,6 +38,12 @@ oauth:
     url:
       validation: https://kapi.kakao.com/v1/user/access_token_info
       user: https://kapi.kakao.com/v2/user/me
+  apple:
+    app:
+      id: 123456
+    url:
+      public-keys: https://appleid.apple.com/auth/keys
+      issuer: https://appleid.apple.com
 
 naver:
   apiKeyId: test-value


### PR DESCRIPTION
## 작업 내용*
- 애플 로그인 api 구현

## 고민한 내용*
### 애플 로그인 과정
- 클라이언트는 서버에 identity token을 넘겨준다.
  - identity token은 jwt 토큰이다. 이안에 이메일, 식별자 등 필요한 정보가 담겨있다. 따라서 이 토큰을 검증해서 유효한 토큰이면 로그인이나 회원가입 절차를 진행하면 된다.
-  검증하려면 애플로부터 public 키를 받아 jwt 유효성을 확인하면 된다. 이 과정이 좀 복잡해서 컨플루언스에 남기겠다.

## 리뷰 요구사항

- 리뷰할 때 중점적으로 봐줬으면 하는 내용들

## 스크린샷