### PR TITLE
M3-189 랭킹 구현 후 pixel_user 테이블에 삽입하는 코드를 비동기로 작동하게끔 수정

### DIFF
--- a/src/main/java/com/m3pro/groundflip/GroundFlipApplication.java
+++ b/src/main/java/com/m3pro/groundflip/GroundFlipApplication.java
@@ -5,11 +5,13 @@ import java.util.TimeZone;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableAsync;
 
 import jakarta.annotation.PostConstruct;
 
 @SpringBootApplication
 @EnableJpaAuditing
+@EnableAsync
 public class GroundFlipApplication {
 	@PostConstruct
 	public void started() {

--- a/src/main/java/com/m3pro/groundflip/config/AsyncConfig.java
+++ b/src/main/java/com/m3pro/groundflip/config/AsyncConfig.java
@@ -1,0 +1,20 @@
+package com.m3pro.groundflip.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.event.ApplicationEventMulticaster;
+import org.springframework.context.event.SimpleApplicationEventMulticaster;
+import org.springframework.core.task.SimpleAsyncTaskExecutor;
+
+@Configuration
+public class AsyncConfig {
+	@Bean
+	public ApplicationEventMulticaster simpleApplicationEventMulticaster() {
+		SimpleApplicationEventMulticaster eventMulticaster
+			= new SimpleApplicationEventMulticaster();
+
+		eventMulticaster.setTaskExecutor(new SimpleAsyncTaskExecutor());
+
+		return eventMulticaster;
+	}
+}

--- a/src/main/java/com/m3pro/groundflip/domain/dto/pixel/event/PixelAddressUpdateEvent.java
+++ b/src/main/java/com/m3pro/groundflip/domain/dto/pixel/event/PixelAddressUpdateEvent.java
@@ -1,0 +1,12 @@
+package com.m3pro.groundflip.domain.dto.pixel.event;
+
+import com.m3pro.groundflip.domain.entity.Pixel;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public class PixelAddressUpdateEvent {
+	private Pixel pixel;
+}

--- a/src/main/java/com/m3pro/groundflip/domain/dto/pixel/event/PixelUserInsertEvent.java
+++ b/src/main/java/com/m3pro/groundflip/domain/dto/pixel/event/PixelUserInsertEvent.java
@@ -1,0 +1,12 @@
+package com.m3pro.groundflip.domain.dto.pixel.event;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public class PixelUserInsertEvent {
+	private Long pixelId;
+	private Long userId;
+	private Long communityId;
+}

--- a/src/main/java/com/m3pro/groundflip/repository/PixelUserRepository.java
+++ b/src/main/java/com/m3pro/groundflip/repository/PixelUserRepository.java
@@ -3,6 +3,7 @@ package com.m3pro.groundflip.repository;
 import java.util.List;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -40,4 +41,12 @@ public interface PixelUserRepository extends JpaRepository<PixelUser, Long> {
 			ORDER BY pu.createdAt DESC
 		""")
 	List<PixelUser> findAllVisitHistoryByPixelAndUser(@Param("pixel") Pixel pixel, @Param("user") User user);
+
+	@Modifying
+	@Query(value = """
+			INSERT INTO pixel_user (pixel_id, user_id, community_id)
+			VALUES (:pixel_id, :user_id, :community_id)
+		""", nativeQuery = true)
+	void save(@Param("pixel_id") Long pixelId, @Param("user_id") Long userId,
+		@Param("community_id") Long communityId);
 }

--- a/src/main/java/com/m3pro/groundflip/service/PixelEventListener.java
+++ b/src/main/java/com/m3pro/groundflip/service/PixelEventListener.java
@@ -6,7 +6,10 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.m3pro.groundflip.domain.dto.pixel.event.PixelAddressUpdateEvent;
 import com.m3pro.groundflip.domain.dto.pixel.event.PixelUserInsertEvent;
+import com.m3pro.groundflip.domain.entity.Pixel;
+import com.m3pro.groundflip.repository.PixelRepository;
 import com.m3pro.groundflip.repository.PixelUserRepository;
 
 import lombok.RequiredArgsConstructor;
@@ -15,6 +18,8 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class PixelEventListener {
 	private final PixelUserRepository pixelUserRepository;
+	private final ReverseGeoCodingService reverseGeoCodingService;
+	private final PixelRepository pixelRepository;
 
 	@EventListener
 	@Transactional(propagation = Propagation.REQUIRES_NEW)
@@ -25,5 +30,17 @@ public class PixelEventListener {
 			pixelUserInsertEvent.getUserId(),
 			pixelUserInsertEvent.getCommunityId()
 		);
+	}
+
+	@EventListener
+	@Transactional(propagation = Propagation.REQUIRES_NEW)
+	@Async
+	public void updatePixelAddress(PixelAddressUpdateEvent pixelAddressUpdateEvent) {
+		Pixel targetPixel = pixelAddressUpdateEvent.getPixel();
+		String address = reverseGeoCodingService.getAddressFromCoordinates(targetPixel.getCoordinate().getX(),
+			targetPixel.getCoordinate().getY());
+
+		targetPixel.updateAddress(address);
+		pixelRepository.save(targetPixel);
 	}
 }

--- a/src/main/java/com/m3pro/groundflip/service/PixelEventListener.java
+++ b/src/main/java/com/m3pro/groundflip/service/PixelEventListener.java
@@ -1,0 +1,29 @@
+package com.m3pro.groundflip.service;
+
+import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.m3pro.groundflip.domain.dto.pixel.event.PixelUserInsertEvent;
+import com.m3pro.groundflip.repository.PixelUserRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class PixelEventListener {
+	private final PixelUserRepository pixelUserRepository;
+
+	@EventListener
+	@Transactional(propagation = Propagation.REQUIRES_NEW)
+	@Async
+	public void insertPixelUserHistory(PixelUserInsertEvent pixelUserInsertEvent) {
+		pixelUserRepository.save(
+			pixelUserInsertEvent.getPixelId(),
+			pixelUserInsertEvent.getUserId(),
+			pixelUserInsertEvent.getCommunityId()
+		);
+	}
+}

--- a/src/test/java/com/m3pro/groundflip/repository/PixelUserRepositoryTest.java
+++ b/src/test/java/com/m3pro/groundflip/repository/PixelUserRepositoryTest.java
@@ -1,0 +1,4 @@
+package com.m3pro.groundflip.repository;
+
+public class PixelUserRepositoryTest {
+}

--- a/src/test/java/com/m3pro/groundflip/repository/PixelUserRepositoryTest.java
+++ b/src/test/java/com/m3pro/groundflip/repository/PixelUserRepositoryTest.java
@@ -1,4 +1,70 @@
 package com.m3pro.groundflip.repository;
 
+import java.util.List;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.Point;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import com.m3pro.groundflip.domain.entity.Community;
+import com.m3pro.groundflip.domain.entity.Pixel;
+import com.m3pro.groundflip.domain.entity.PixelUser;
+import com.m3pro.groundflip.domain.entity.User;
+
+import jakarta.transaction.Transactional;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 public class PixelUserRepositoryTest {
+	private static final int WGS84_SRID = 4326;
+
+	@Autowired
+	private PixelUserRepository pixelUserRepository;
+	@Autowired
+	private PixelRepository pixelRepository;
+	@Autowired
+	private UserRepository userRepository;
+	@Autowired
+	CommunityRepository communityRepository;
+	@Autowired
+	GeometryFactory geometryFactory;
+
+	@Test
+	@Transactional
+	@DisplayName("[save] pixel_user가 정상적으로 삽입되는지 확인")
+	void save() {
+		User savedUser = userRepository.save(
+			User.builder()
+				.build()
+		);
+
+		Pixel savedPixel = pixelRepository.save(Pixel.builder()
+			.coordinate(createPoint(37.0, 127.0))
+			.build());
+
+		Community savedCommunity = communityRepository.save(
+			Community.builder()
+				.build()
+		);
+
+		pixelUserRepository.save(savedPixel.getId(), savedUser.getId(), savedCommunity.getId());
+
+		List<PixelUser> pixelUsers = pixelUserRepository.findAll();
+
+		Assertions.assertThat(pixelUsers.size()).isEqualTo(1);
+	}
+
+	private Point createPoint(double longitude, double latitude) {
+		Point point = geometryFactory.createPoint(new Coordinate(longitude, latitude));
+		point.setSRID(WGS84_SRID);
+		return point;
+	}
 }

--- a/src/test/java/com/m3pro/groundflip/service/PixelEventListenerTest.java
+++ b/src/test/java/com/m3pro/groundflip/service/PixelEventListenerTest.java
@@ -11,7 +11,9 @@ import org.springframework.context.ApplicationContext;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.event.RecordApplicationEvents;
 
+import com.m3pro.groundflip.domain.dto.pixel.event.PixelAddressUpdateEvent;
 import com.m3pro.groundflip.domain.dto.pixel.event.PixelUserInsertEvent;
+import com.m3pro.groundflip.domain.entity.Pixel;
 
 import jakarta.transaction.Transactional;
 
@@ -28,10 +30,20 @@ public class PixelEventListenerTest {
 	@Test
 	@Transactional
 	@DisplayName("[insertPixelUserHistory] 픽셀 방문 기록 이벤트가 정상적으로 수신되는지 확인")
-	void insertPixelUserEventPublisher() {
+	void insertPixelUserEventListener() {
 		PixelUserInsertEvent event = new PixelUserInsertEvent(1L, 1L, null);
 		applicationContext.publishEvent(event);
 
 		Mockito.verify(pixelEventListener).insertPixelUserHistory(event);
+	}
+
+	@Test
+	@Transactional
+	@DisplayName("[updatePixelAddress] 픽셀 주소 업데이트 이벤트가 정상적으로 수신되는지 확인")
+	void updatePixelAddressEventListener() {
+		PixelAddressUpdateEvent event = new PixelAddressUpdateEvent(Pixel.builder().build());
+		applicationContext.publishEvent(event);
+
+		Mockito.verify(pixelEventListener).updatePixelAddress(event);
 	}
 }

--- a/src/test/java/com/m3pro/groundflip/service/PixelEventListenerTest.java
+++ b/src/test/java/com/m3pro/groundflip/service/PixelEventListenerTest.java
@@ -1,0 +1,37 @@
+package com.m3pro.groundflip.service;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.ApplicationContext;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.event.RecordApplicationEvents;
+
+import com.m3pro.groundflip.domain.dto.pixel.event.PixelUserInsertEvent;
+
+import jakarta.transaction.Transactional;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@RecordApplicationEvents
+public class PixelEventListenerTest {
+	@Autowired
+	private ApplicationContext applicationContext;
+	@MockBean
+	private PixelEventListener pixelEventListener;
+
+	@Test
+	@Transactional
+	@DisplayName("[insertPixelUserHistory] 픽셀 방문 기록 이벤트가 정상적으로 수신되는지 확인")
+	void insertPixelUserEventPublisher() {
+		PixelUserInsertEvent event = new PixelUserInsertEvent(1L, 1L, null);
+		applicationContext.publishEvent(event);
+
+		Mockito.verify(pixelEventListener).insertPixelUserHistory(event);
+	}
+}

--- a/src/test/java/com/m3pro/groundflip/service/PixelEventListenerTest.java
+++ b/src/test/java/com/m3pro/groundflip/service/PixelEventListenerTest.java
@@ -9,7 +9,6 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.ApplicationContext;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.event.RecordApplicationEvents;
 
 import com.m3pro.groundflip.domain.dto.pixel.event.PixelAddressUpdateEvent;
 import com.m3pro.groundflip.domain.dto.pixel.event.PixelUserInsertEvent;
@@ -20,7 +19,6 @@ import jakarta.transaction.Transactional;
 @SpringBootTest
 @ActiveProfiles("test")
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
-@RecordApplicationEvents
 public class PixelEventListenerTest {
 	@Autowired
 	private ApplicationContext applicationContext;
@@ -46,4 +44,5 @@ public class PixelEventListenerTest {
 
 		Mockito.verify(pixelEventListener).updatePixelAddress(event);
 	}
+
 }

--- a/src/test/java/com/m3pro/groundflip/service/PixelServiceTest.java
+++ b/src/test/java/com/m3pro/groundflip/service/PixelServiceTest.java
@@ -21,6 +21,7 @@ import org.springframework.context.ApplicationEventPublisher;
 import com.m3pro.groundflip.domain.dto.pixel.IndividualPixelInfoResponse;
 import com.m3pro.groundflip.domain.dto.pixel.PixelCountResponse;
 import com.m3pro.groundflip.domain.dto.pixel.PixelOccupyRequest;
+import com.m3pro.groundflip.domain.dto.pixel.event.PixelUserInsertEvent;
 import com.m3pro.groundflip.domain.dto.pixelUser.IndividualHistoryPixelInfoResponse;
 import com.m3pro.groundflip.domain.dto.pixelUser.PixelOwnerUser;
 import com.m3pro.groundflip.domain.dto.pixelUser.VisitedUser;
@@ -43,9 +44,9 @@ class PixelServiceTest {
 	@Mock
 	private UserRepository userRepository;
 	@Mock
-	private ApplicationEventPublisher eventPublisher;
-	@Mock
 	private RankingService rankingService;
+	@Mock
+	private ApplicationEventPublisher applicationEventPublisher;
 	@InjectMocks
 	private PixelService pixelService;
 
@@ -322,5 +323,24 @@ class PixelServiceTest {
 
 		//Then
 		assertEquals(5L, pixel.getUserId());
+	}
+
+	@Test
+	@DisplayName("[occupyPixel] 픽셀을 차지할 때 PixelUserInsertEvent가 발행되는지 확인")
+	void pixelUserInsertEventPublish() {
+		PixelOccupyRequest pixelOccupyRequest = new PixelOccupyRequest(5L, 78611L, 222L, 233L);
+		Pixel pixel = Pixel.builder()
+			.x(222L)
+			.y(233L)
+			.userId(1L)
+			.address("대한민국")
+			.build();
+		when(pixelRepository.findByXAndY(222L, 233L)).thenReturn(Optional.of(pixel));
+
+		// When
+		pixelService.occupyPixel(pixelOccupyRequest);
+
+		// Then
+		verify(applicationEventPublisher, times(1)).publishEvent(any(PixelUserInsertEvent.class));
 	}
 }

--- a/src/test/java/com/m3pro/groundflip/service/PixelServiceTest.java
+++ b/src/test/java/com/m3pro/groundflip/service/PixelServiceTest.java
@@ -16,6 +16,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
 
 import com.m3pro.groundflip.domain.dto.pixel.IndividualPixelInfoResponse;
 import com.m3pro.groundflip.domain.dto.pixel.PixelCountResponse;
@@ -28,7 +29,6 @@ import com.m3pro.groundflip.domain.entity.PixelUser;
 import com.m3pro.groundflip.domain.entity.User;
 import com.m3pro.groundflip.exception.AppException;
 import com.m3pro.groundflip.exception.ErrorCode;
-import com.m3pro.groundflip.repository.CommunityRepository;
 import com.m3pro.groundflip.repository.PixelRepository;
 import com.m3pro.groundflip.repository.PixelUserRepository;
 import com.m3pro.groundflip.repository.UserRepository;
@@ -43,7 +43,7 @@ class PixelServiceTest {
 	@Mock
 	private UserRepository userRepository;
 	@Mock
-	private CommunityRepository communityRepository;
+	private ApplicationEventPublisher eventPublisher;
 	@Mock
 	private RankingService rankingService;
 	@InjectMocks
@@ -305,19 +305,22 @@ class PixelServiceTest {
 	}
 
 	@Test
-	@DisplayName("[occupyPixel] 픽셀을 정상적으로 차지한다.")
+	@DisplayName("[occupyPixel] 픽셀을 정상적으로 차지하여 타겟 픽셀의 userId가 바뀐다.")
 	void occupyPixel() {
 		// Given
 		PixelOccupyRequest pixelOccupyRequest = new PixelOccupyRequest(5L, 78611L, 222L, 233L);
 		Pixel pixel = Pixel.builder()
 			.x(222L)
 			.y(233L)
+			.userId(1L)
 			.address("대한민국")
 			.build();
 		when(pixelRepository.findByXAndY(222L, 233L)).thenReturn(Optional.of(pixel));
+
 		// When
 		pixelService.occupyPixel(pixelOccupyRequest);
+
 		//Then
-		verify(pixelUserRepository, times(1)).save(any());
+		assertEquals(5L, pixel.getUserId());
 	}
 }


### PR DESCRIPTION
## 작업 내용*

- pixelUser record가 비동기적으로 실행되게끔 수정
- updatePixel address가 비동기적으로 실행되게끔 수정
- 테스트 코드 작성

## 고민한 내용*
### 목적
성능 향상과 의존성 낮추기
- 기존의 occupyPixel()은 지나치게 많은 일을 하고 있었음.
- 심지어 이런 많은 일들이 불필요하게 하나의 transaction으로 묶여있었음

<br>

### 생각한 내용
- 따라서 단순히 사용자의 history를 남기는 기능과 픽셀의 주소를 업데이트하는 기능을 Event를 활용하여 비동기로 처리함.
- 하지만 이들 각각에 대해 따로 트랜잭션을 걸어주어야 했고, @Transactional의 옵션을 사용함.

<br>

- 또한 픽셀을 업데이트 하는 함수를 분리할 때, 기존의 주소를 확인하는 과정도 event를 수신하는 측에서 처리하고 싶었으나 그렇게 되면 모든 요청마다 null check를 하기 위해 새로운 스레드가 생기는 문제가 발생하여 null check 후 이벤트를 발행하도록 구현함.
- 그리고 기존의 주소가 null이여서 event를 수신한 경우, 다른 스레드에서 작동하게 되어 영속성 컨텍스트가 비어있게 됨.
- 따라서 픽셀 주소를 update하고 메소드 끝에서 Commit이 일어날 때, select와 update 쿼리가 각각 한 번 씩 일어나게 된다.
- native query를 사용해 select문을 생략할 수 있지만 우선 위의 방식으로 구현함 (추후 논의가 필요할 듯)

<br>

- pixel table에서 user_id를 바꾸는 작업도 비동기로 바꿀 수 있었지만, 
- 1. pk 인덱스를 타는 update 쿼리가 그렇게 느리지 않을 거라는 점.
- 2. 최소한의 정합성은 필요하다고 생각한 점
- 등을 고려해 별도의 이벤트로 분리하지 않음. 

### 결과
- 약간의 성능 향상
- PixelService에서 CommunityRepository와 ReverseGeocodingService에 대한 의존성을 제거

## 리뷰 요구사항

- 주소를 update 하는 과정을 native query로 변환하는 게 좋을까요?
- pixel table의 user_id를 업데이트 하는 과정도 비동기로 빼는 게 좋을까요?
