### PR TITLE
M3-229 회원 탈퇴

### DIFF
--- a/src/main/java/com/m3pro/groundflip/controller/UserController.java
+++ b/src/main/java/com/m3pro/groundflip/controller/UserController.java
@@ -2,15 +2,18 @@ package com.m3pro.groundflip.controller;
 
 import java.io.IOException;
 
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
 import com.m3pro.groundflip.domain.dto.Response;
+import com.m3pro.groundflip.domain.dto.user.UserDeleteRequest;
 import com.m3pro.groundflip.domain.dto.user.UserInfoRequest;
 import com.m3pro.groundflip.domain.dto.user.UserInfoResponse;
 import com.m3pro.groundflip.service.UserService;
@@ -50,4 +53,13 @@ public class UserController {
 		return Response.createSuccessWithNoData();
 	}
 
+	@Operation(summary = "사용자 탈퇴", description = "회원을 탈퇴한다.")
+	@DeleteMapping("/{userId}")
+	public Response<?> putUserInfo(
+		@Parameter(description = "찾고자 하는 userId", required = true) @PathVariable Long userId,
+		@RequestBody UserDeleteRequest userDeleteRequest
+	) {
+		userService.deleteUser(userId, userDeleteRequest);
+		return Response.createSuccessWithNoData();
+	}
 }

--- a/src/main/java/com/m3pro/groundflip/domain/dto/user/UserDeleteRequest.java
+++ b/src/main/java/com/m3pro/groundflip/domain/dto/user/UserDeleteRequest.java
@@ -1,0 +1,17 @@
+package com.m3pro.groundflip.domain.dto.user;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Schema(title = "사용자 탈퇴")
+public class UserDeleteRequest {
+	private String accessToken;
+	private String refreshToken;
+}

--- a/src/main/java/com/m3pro/groundflip/domain/entity/User.java
+++ b/src/main/java/com/m3pro/groundflip/domain/entity/User.java
@@ -76,4 +76,7 @@ public class User extends BaseTimeEntity {
 		this.status = status;
 	}
 
+	public void updateEmail(String email) {
+		this.email = email;
+	}
 }

--- a/src/test/java/com/m3pro/groundflip/service/PixelServiceTest.java
+++ b/src/test/java/com/m3pro/groundflip/service/PixelServiceTest.java
@@ -221,7 +221,7 @@ class PixelServiceTest {
 
 		// Given
 		Long pixelId = 10000L;
-		String address = "은평구";
+		String address = "서울특별시 은평구 녹번동";
 		int addressNumber = 1;
 
 		Pixel pixel = Pixel.builder()


### PR DESCRIPTION
## 작업 내용*

- 회원 탈퇴 구현
- 테스트 코드 작성

## 고민한 내용*

- 일종의 soft delete를 구현하기 위해 유저의 정보를 null 값 등으로 masking하였다.
- 애플 회원탈퇴는 추후 구현 요망
