### PR TITLE
M3-230 애플 계정 탈퇴 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,10 +44,13 @@ dependencies {
 
     // 클라우드 워치를 위한 의존성
     implementation 'ca.pjer:logback-awslogs-appender:1.6.0'
-    
+
     implementation "javax.xml.bind:jaxb-api:2.3.0"
 
     implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
+
+    implementation 'org.bouncycastle:bcpkix-jdk15on:1.69'
+    implementation 'org.bouncycastle:bcprov-jdk15on:1.69'
 
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'

--- a/src/main/java/com/m3pro/groundflip/controller/AuthController.java
+++ b/src/main/java/com/m3pro/groundflip/controller/AuthController.java
@@ -6,6 +6,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.m3pro.groundflip.domain.dto.Response;
+import com.m3pro.groundflip.domain.dto.auth.AppleLoginRequest;
 import com.m3pro.groundflip.domain.dto.auth.LoginRequest;
 import com.m3pro.groundflip.domain.dto.auth.LoginResponse;
 import com.m3pro.groundflip.domain.dto.auth.LogoutRequest;
@@ -33,8 +34,8 @@ public class AuthController {
 
 	@Operation(summary = "애플 로그인", description = "애플에서 받은 identity token을 통해 회원가입 또는 로그인하는 API")
 	@PostMapping("/kakao/apple")
-	public Response<LoginResponse> loginApple(@RequestBody LoginRequest loginRequest) {
-		return Response.createSuccess(authService.login(Provider.APPLE, loginRequest));
+	public Response<LoginResponse> loginApple(@RequestBody AppleLoginRequest appleLoginRequest) {
+		return Response.createSuccess(authService.loginWithApple(appleLoginRequest));
 	}
 
 	@Operation(summary = "access token 재발급", description = "만료된 access token 을 refresh token으로 재발급 하는 API")

--- a/src/main/java/com/m3pro/groundflip/domain/dto/auth/AppleLoginRequest.java
+++ b/src/main/java/com/m3pro/groundflip/domain/dto/auth/AppleLoginRequest.java
@@ -1,0 +1,21 @@
+package com.m3pro.groundflip.domain.dto.auth;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Data
+@Builder
+@Schema(title = "애플 로그인 요청 Body")
+public class AppleLoginRequest {
+	// Todo: access token 을 클라이언트와 같이 identity token 으로 변경해야함
+	@Schema(description = "애플 identity token", example = "dslafjkdsrtjlejldfkajlasljdf")
+	private String accessToken;
+
+	@Schema(description = "애플 authorization code", example = "dslafjkdsrtjlejldfkajlasljdf")
+	private String authorizationCode;
+}

--- a/src/main/java/com/m3pro/groundflip/domain/dto/auth/AppleTokenResponse.java
+++ b/src/main/java/com/m3pro/groundflip/domain/dto/auth/AppleTokenResponse.java
@@ -1,0 +1,19 @@
+package com.m3pro.groundflip.domain.dto.auth;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.Getter;
+import lombok.Setter;
+
+@Data
+@Getter
+@Setter
+@AllArgsConstructor
+public class AppleTokenResponse {
+	private String access_token;
+	private String expires_in;
+	private String id_token;
+	private String refresh_token;
+	private String token_type;
+	private String error;
+}

--- a/src/main/java/com/m3pro/groundflip/domain/entity/AppleRefreshToken.java
+++ b/src/main/java/com/m3pro/groundflip/domain/entity/AppleRefreshToken.java
@@ -1,0 +1,32 @@
+package com.m3pro.groundflip.domain.entity;
+
+import com.m3pro.groundflip.domain.entity.global.BaseTimeEntity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "apple_refresh_token")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class AppleRefreshToken extends BaseTimeEntity {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "apple_refresh_token_id")
+	private Long id;
+
+	private Long userId;
+
+	private String refreshToken;
+}

--- a/src/main/java/com/m3pro/groundflip/repository/AppleRefreshTokenRepository.java
+++ b/src/main/java/com/m3pro/groundflip/repository/AppleRefreshTokenRepository.java
@@ -1,0 +1,11 @@
+package com.m3pro.groundflip.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.m3pro.groundflip.domain.entity.AppleRefreshToken;
+
+public interface AppleRefreshTokenRepository extends JpaRepository<AppleRefreshToken, Long> {
+	Optional<AppleRefreshToken> findByUserId(Long userId);
+}

--- a/src/main/java/com/m3pro/groundflip/service/AuthService.java
+++ b/src/main/java/com/m3pro/groundflip/service/AuthService.java
@@ -10,10 +10,12 @@ import com.m3pro.groundflip.domain.dto.auth.LoginResponse;
 import com.m3pro.groundflip.domain.dto.auth.LogoutRequest;
 import com.m3pro.groundflip.domain.dto.auth.OauthUserInfoResponse;
 import com.m3pro.groundflip.domain.dto.auth.ReissueReponse;
+import com.m3pro.groundflip.domain.entity.AppleRefreshToken;
 import com.m3pro.groundflip.domain.entity.User;
 import com.m3pro.groundflip.enums.Provider;
 import com.m3pro.groundflip.enums.UserStatus;
 import com.m3pro.groundflip.jwt.JwtProvider;
+import com.m3pro.groundflip.repository.AppleRefreshTokenRepository;
 import com.m3pro.groundflip.repository.UserRepository;
 import com.m3pro.groundflip.service.oauth.OauthService;
 
@@ -26,6 +28,7 @@ public class AuthService {
 	private final OauthService oauthUserInfoService;
 	private final JwtProvider jwtProvider;
 	private final UserRepository userRepository;
+	private final AppleRefreshTokenRepository appleRefreshTokenRepository;
 
 	/**
 	 * Oauth Provider를 사용해 로그인을 진행한다.
@@ -123,5 +126,11 @@ public class AuthService {
 
 	private void registerAppleRefreshToken(Long userId, String authorizationCode) {
 		String refreshToken = oauthUserInfoService.getAppleRefreshToken(authorizationCode);
+		appleRefreshTokenRepository.save(
+			AppleRefreshToken.builder()
+				.userId(userId)
+				.refreshToken(refreshToken)
+				.build()
+		);
 	}
 }

--- a/src/main/java/com/m3pro/groundflip/service/UserService.java
+++ b/src/main/java/com/m3pro/groundflip/service/UserService.java
@@ -12,15 +12,19 @@ import org.springframework.web.multipart.MultipartFile;
 import com.m3pro.groundflip.domain.dto.user.UserDeleteRequest;
 import com.m3pro.groundflip.domain.dto.user.UserInfoRequest;
 import com.m3pro.groundflip.domain.dto.user.UserInfoResponse;
+import com.m3pro.groundflip.domain.entity.AppleRefreshToken;
 import com.m3pro.groundflip.domain.entity.User;
 import com.m3pro.groundflip.domain.entity.UserCommunity;
+import com.m3pro.groundflip.enums.Provider;
 import com.m3pro.groundflip.enums.UserStatus;
 import com.m3pro.groundflip.exception.AppException;
 import com.m3pro.groundflip.exception.ErrorCode;
 import com.m3pro.groundflip.jwt.JwtProvider;
+import com.m3pro.groundflip.repository.AppleRefreshTokenRepository;
 import com.m3pro.groundflip.repository.RankingRedisRepository;
 import com.m3pro.groundflip.repository.UserCommunityRepository;
 import com.m3pro.groundflip.repository.UserRepository;
+import com.m3pro.groundflip.service.oauth.AppleApiClient;
 import com.m3pro.groundflip.util.S3Uploader;
 
 import jakarta.transaction.Transactional;
@@ -31,9 +35,11 @@ import lombok.RequiredArgsConstructor;
 public class UserService {
 	private final RankingRedisRepository rankingRedisRepository;
 	private final UserRepository userRepository;
+	private final AppleRefreshTokenRepository appleRefreshTokenRepository;
 	private final UserCommunityRepository userCommunityRepository;
 	private final S3Uploader s3Uploader;
 	private final JwtProvider jwtProvider;
+	private final AppleApiClient appleApiClient;
 
 	/**
 	 * 유저의 정보를 반환한다.
@@ -58,7 +64,7 @@ public class UserService {
 		}
 	}
 
-	/*
+	/**
 	 * 유저의 정보를 수정한다
 	 * @Param 유저id
 	 * @Param 유저정보dto (gender, year, nickname)
@@ -112,7 +118,9 @@ public class UserService {
 	public void deleteUser(Long userId, UserDeleteRequest userDeleteRequest) {
 		User deletedUser = userRepository.findById(userId)
 			.orElseThrow(() -> new AppException(ErrorCode.USER_NOT_FOUND));
-
+		if (deletedUser.getProvider() == Provider.APPLE) {
+			revokeAppleToken(deletedUser.getId());
+		}
 		deletedUser.updateBirthYear(convertToDate(1900));
 		deletedUser.updateNickName(null);
 		deletedUser.updateProfileImage(null);
@@ -120,5 +128,10 @@ public class UserService {
 
 		jwtProvider.expireToken(userDeleteRequest.getAccessToken());
 		jwtProvider.expireToken(userDeleteRequest.getRefreshToken());
+	}
+
+	private void revokeAppleToken(Long userId) {
+		AppleRefreshToken appleRefreshToken = appleRefreshTokenRepository.findByUserId(userId).orElseThrow();
+		appleApiClient.revokeToken(appleRefreshToken.getRefreshToken());
 	}
 }

--- a/src/main/java/com/m3pro/groundflip/service/oauth/AppleApiClient.java
+++ b/src/main/java/com/m3pro/groundflip/service/oauth/AppleApiClient.java
@@ -97,7 +97,7 @@ public class AppleApiClient implements OauthApiClient {
 	 * @return apple 에서 발행하는 refresh token
 	 * @throws IOException
 	 */
-	public String getAppleRefreshToken(String authorizationCode) throws IOException {
+	public String getAppleRefreshToken(String authorizationCode) {
 		MultiValueMap<String, String> body = getCreateTokenBody(authorizationCode);
 
 		AppleTokenResponse appleTokenResponse = restClient.post()
@@ -110,7 +110,7 @@ public class AppleApiClient implements OauthApiClient {
 		return Objects.requireNonNull(appleTokenResponse).getRefresh_token();
 	}
 
-	private MultiValueMap<String, String> getCreateTokenBody(String authorizationCode) throws IOException {
+	private MultiValueMap<String, String> getCreateTokenBody(String authorizationCode) {
 		MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
 		body.add("code", authorizationCode);
 		body.add("client_id", clientId);
@@ -119,7 +119,7 @@ public class AppleApiClient implements OauthApiClient {
 		return body;
 	}
 
-	public void revokeToken(String refreshToken) throws IOException {
+	public void revokeToken(String refreshToken) {
 		MultiValueMap<String, String> body = getRevokeTokenBody(refreshToken);
 
 		restClient.post()
@@ -130,7 +130,7 @@ public class AppleApiClient implements OauthApiClient {
 			.toBodilessEntity();
 	}
 
-	private MultiValueMap<String, String> getRevokeTokenBody(String refreshToken) throws IOException {
+	private MultiValueMap<String, String> getRevokeTokenBody(String refreshToken) {
 		MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
 		body.add("client_id", clientId);
 		body.add("token", refreshToken);

--- a/src/main/java/com/m3pro/groundflip/service/oauth/AppleApiClient.java
+++ b/src/main/java/com/m3pro/groundflip/service/oauth/AppleApiClient.java
@@ -113,4 +113,19 @@ public class AppleApiClient implements OauthApiClient {
 
 		return Objects.requireNonNull(appleTokenResponse).getRefresh_token();
 	}
+
+	public void revokeToken(String refreshToken) throws IOException {
+		MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
+		body.add("client_id", clientId);
+		body.add("token", refreshToken);
+		body.add("client_secret", appleKeyGenerator.getClientSecret());
+		body.add("token_type_hint", "refresh_token");
+
+		restClient.post()
+			.uri("https://appleid.apple.com/auth/revoke")
+			.contentType(MediaType.APPLICATION_FORM_URLENCODED)
+			.body(body)
+			.retrieve()
+			.toBodilessEntity();
+	}
 }

--- a/src/main/java/com/m3pro/groundflip/service/oauth/AppleApiClient.java
+++ b/src/main/java/com/m3pro/groundflip/service/oauth/AppleApiClient.java
@@ -98,11 +98,7 @@ public class AppleApiClient implements OauthApiClient {
 	 * @throws IOException
 	 */
 	public String getAppleRefreshToken(String authorizationCode) throws IOException {
-		MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
-		body.add("code", authorizationCode);
-		body.add("client_id", clientId);
-		body.add("client_secret", appleKeyGenerator.getClientSecret());
-		body.add("grant_type", "authorization_code");
+		MultiValueMap<String, String> body = getCreateTokenBody(authorizationCode);
 
 		AppleTokenResponse appleTokenResponse = restClient.post()
 			.uri("https://appleid.apple.com/auth/token")
@@ -114,12 +110,17 @@ public class AppleApiClient implements OauthApiClient {
 		return Objects.requireNonNull(appleTokenResponse).getRefresh_token();
 	}
 
-	public void revokeToken(String refreshToken) throws IOException {
+	private MultiValueMap<String, String> getCreateTokenBody(String authorizationCode) throws IOException {
 		MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
+		body.add("code", authorizationCode);
 		body.add("client_id", clientId);
-		body.add("token", refreshToken);
 		body.add("client_secret", appleKeyGenerator.getClientSecret());
-		body.add("token_type_hint", "refresh_token");
+		body.add("grant_type", "authorization_code");
+		return body;
+	}
+
+	public void revokeToken(String refreshToken) throws IOException {
+		MultiValueMap<String, String> body = getRevokeTokenBody(refreshToken);
 
 		restClient.post()
 			.uri("https://appleid.apple.com/auth/revoke")
@@ -127,5 +128,14 @@ public class AppleApiClient implements OauthApiClient {
 			.body(body)
 			.retrieve()
 			.toBodilessEntity();
+	}
+
+	private MultiValueMap<String, String> getRevokeTokenBody(String refreshToken) throws IOException {
+		MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
+		body.add("client_id", clientId);
+		body.add("token", refreshToken);
+		body.add("client_secret", appleKeyGenerator.getClientSecret());
+		body.add("token_type_hint", "refresh_token");
+		return body;
 	}
 }

--- a/src/main/java/com/m3pro/groundflip/service/oauth/AppleKeyGenerator.java
+++ b/src/main/java/com/m3pro/groundflip/service/oauth/AppleKeyGenerator.java
@@ -1,14 +1,24 @@
 package com.m3pro.groundflip.service.oauth;
 
+import java.io.IOException;
+import java.io.Reader;
+import java.io.StringReader;
 import java.math.BigInteger;
 import java.security.KeyFactory;
 import java.security.NoSuchAlgorithmException;
+import java.security.PrivateKey;
 import java.security.PublicKey;
 import java.security.spec.InvalidKeySpecException;
 import java.security.spec.RSAPublicKeySpec;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.Base64;
+import java.util.Date;
 import java.util.Map;
 
+import org.bouncycastle.asn1.pkcs.PrivateKeyInfo;
+import org.bouncycastle.openssl.PEMParser;
+import org.bouncycastle.openssl.jcajce.JcaPEMKeyConverter;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestClient;
@@ -16,14 +26,24 @@ import org.springframework.web.client.RestClient;
 import com.m3pro.groundflip.domain.dto.auth.apple.ApplePublicKey;
 import com.m3pro.groundflip.domain.dto.auth.apple.ApplePublicKeyResponse;
 
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
 import lombok.RequiredArgsConstructor;
 
 @Component
 @RequiredArgsConstructor
-public class ApplePublicKeyGenerator {
+public class AppleKeyGenerator {
 	private final RestClient restClient;
 	@Value("${oauth.apple.url.public-keys}")
 	private String applePublicKeysUrl;
+	@Value("${oauth.apple.app.keyId}")
+	private String kid;
+	@Value("${oauth.apple.app.teamId}")
+	private String teamId;
+	@Value("${oauth.apple.app.id}")
+	private String appId;
+	@Value("${oauth.apple.app.privateKey}")
+	private String privateKey;
 
 	/**
 	 * identity token을 검증할 public key를 반환한다.
@@ -70,5 +90,39 @@ public class ApplePublicKeyGenerator {
 
 		KeyFactory keyFactory = KeyFactory.getInstance(publicKey.kty());
 		return keyFactory.generatePublic(publicKeySpec);
+	}
+
+	/**
+	 * apple client secret 을 생성한다.
+	 * @return
+	 * @throws IOException
+	 */
+	public String getClientSecret() throws IOException {
+		Date expirationDate = Date.from(LocalDateTime.now().plusDays(30).atZone(ZoneId.systemDefault()).toInstant());
+
+		return Jwts.builder()
+			.setHeaderParam("kid", kid)
+			.setHeaderParam("alg", "ES256")
+			.setIssuer(teamId)
+			.setIssuedAt(new Date(System.currentTimeMillis()))
+			.setExpiration(expirationDate)
+			.setAudience("https://appleid.apple.com")
+			.setSubject(appId)
+			.signWith(SignatureAlgorithm.ES256, getPrivateKey())
+			.compact();
+	}
+
+	/**
+	 * apple private 키를 반환한다.
+	 * @return
+	 * @throws IOException
+	 */
+	private PrivateKey getPrivateKey() throws
+		IOException {
+		Reader pemReader = new StringReader(privateKey.replace("\\n", "\n"));
+		PEMParser pemParser = new PEMParser(pemReader);
+		JcaPEMKeyConverter converter = new JcaPEMKeyConverter();
+		PrivateKeyInfo object = (PrivateKeyInfo)pemParser.readObject();
+		return converter.getPrivateKey(object);
 	}
 }

--- a/src/main/java/com/m3pro/groundflip/service/oauth/AppleKeyGenerator.java
+++ b/src/main/java/com/m3pro/groundflip/service/oauth/AppleKeyGenerator.java
@@ -25,6 +25,8 @@ import org.springframework.web.client.RestClient;
 
 import com.m3pro.groundflip.domain.dto.auth.apple.ApplePublicKey;
 import com.m3pro.groundflip.domain.dto.auth.apple.ApplePublicKeyResponse;
+import com.m3pro.groundflip.exception.AppException;
+import com.m3pro.groundflip.exception.ErrorCode;
 
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
@@ -97,7 +99,7 @@ public class AppleKeyGenerator {
 	 * @return
 	 * @throws IOException
 	 */
-	public String getClientSecret() throws IOException {
+	public String getClientSecret() {
 		Date expirationDate = Date.from(LocalDateTime.now().plusDays(30).atZone(ZoneId.systemDefault()).toInstant());
 
 		return Jwts.builder()
@@ -117,12 +119,16 @@ public class AppleKeyGenerator {
 	 * @return
 	 * @throws IOException
 	 */
-	private PrivateKey getPrivateKey() throws
-		IOException {
-		Reader pemReader = new StringReader(privateKey.replace("\\n", "\n"));
-		PEMParser pemParser = new PEMParser(pemReader);
-		JcaPEMKeyConverter converter = new JcaPEMKeyConverter();
-		PrivateKeyInfo object = (PrivateKeyInfo)pemParser.readObject();
-		return converter.getPrivateKey(object);
+	private PrivateKey getPrivateKey() {
+		try {
+			Reader pemReader = new StringReader(privateKey.replace("\\n", "\n"));
+			PEMParser pemParser = new PEMParser(pemReader);
+			JcaPEMKeyConverter converter = new JcaPEMKeyConverter();
+			PrivateKeyInfo object = (PrivateKeyInfo)pemParser.readObject();
+			return converter.getPrivateKey(object);
+		} catch (IOException e) {
+			throw new AppException(ErrorCode.INTERNAL_SERVER_ERROR);
+		}
+
 	}
 }

--- a/src/main/java/com/m3pro/groundflip/service/oauth/OauthService.java
+++ b/src/main/java/com/m3pro/groundflip/service/oauth/OauthService.java
@@ -48,4 +48,9 @@ public class OauthService {
 		OauthApiClient oauthApiClient = clients.get(provider);
 		return oauthApiClient.isOauthTokenValid(accessToken);
 	}
+
+	public String getAppleRefreshToken(String authorizationCode) {
+		AppleApiClient appleApiClient = (AppleApiClient)clients.get(Provider.APPLE);
+		return appleApiClient.getAppleRefreshToken(authorizationCode);
+	}
 }

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -45,6 +45,9 @@ oauth:
   apple:
     app:
       id: ${APPLE_APP_ID}
+      teamId: ${APPLE_TEAM_ID}
+      keyId: ${APPLE_KEY_ID}
+      privateKey: ${APPLE_PRIVATE_KEY}
     url:
       public-keys: https://appleid.apple.com/auth/keys
       issuer: https://appleid.apple.com

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -41,6 +41,9 @@ oauth:
   apple:
     app:
       id: ${APPLE_APP_ID}
+      teamId: ${APPLE_TEAM_ID}
+      keyId: ${APPLE_KEY_ID}
+      privateKey: ${APPLE_PRIVATE_KEY}
     url:
       public-keys: https://appleid.apple.com/auth/keys
       issuer: https://appleid.apple.com

--- a/src/test/java/com/m3pro/groundflip/service/AuthServiceTest.java
+++ b/src/test/java/com/m3pro/groundflip/service/AuthServiceTest.java
@@ -13,15 +13,18 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import com.m3pro.groundflip.domain.dto.auth.AppleLoginRequest;
 import com.m3pro.groundflip.domain.dto.auth.LoginRequest;
 import com.m3pro.groundflip.domain.dto.auth.LoginResponse;
 import com.m3pro.groundflip.domain.dto.auth.LogoutRequest;
 import com.m3pro.groundflip.domain.dto.auth.OauthUserInfoResponse;
 import com.m3pro.groundflip.domain.dto.auth.ReissueReponse;
+import com.m3pro.groundflip.domain.entity.AppleRefreshToken;
 import com.m3pro.groundflip.domain.entity.User;
 import com.m3pro.groundflip.enums.Provider;
 import com.m3pro.groundflip.enums.UserStatus;
 import com.m3pro.groundflip.jwt.JwtProvider;
+import com.m3pro.groundflip.repository.AppleRefreshTokenRepository;
 import com.m3pro.groundflip.repository.RankingRedisRepository;
 import com.m3pro.groundflip.repository.UserRepository;
 import com.m3pro.groundflip.service.oauth.OauthService;
@@ -36,11 +39,14 @@ class AuthServiceTest {
 	private UserRepository userRepository;
 	@Mock
 	private RankingRedisRepository rankingRedisRepository;
+	@Mock
+	private AppleRefreshTokenRepository appleRefreshTokenRepository;
 	@InjectMocks
 	private AuthService authService;
 
 	private Provider provider;
 	private LoginRequest loginRequest;
+	private AppleLoginRequest appleLoginRequest;
 	private OauthUserInfoResponse oauthUserInfo;
 	private User existingUser;
 	private User newUser;
@@ -53,6 +59,7 @@ class AuthServiceTest {
 		reset(userRepository);
 		provider = Provider.GOOGLE; // Example provider
 		loginRequest = new LoginRequest("validAccessToken");
+		appleLoginRequest = new AppleLoginRequest("validAccessToken", "validAuthorizationCode");
 		oauthUserInfo = new OauthUserInfoResponse() {
 			@Override
 			public String getEmail() {
@@ -198,5 +205,83 @@ class AuthServiceTest {
 		assertNotNull(response);
 		assertEquals(newAccessToken, response.getAccessToken());
 		assertEquals(newRefreshToken, response.getRefreshToken());
+	}
+
+	@Test
+	@DisplayName("[loginWithApple] user 가 존재하지 않는 경우 DB 저장하고 토큰을 반환, apple refresh token 저장, isSignup은 true")
+	public void testLoginWithApple_NewUser() {
+		when(oauthUserInfoService.requestUserInfo(Provider.APPLE, appleLoginRequest.getAccessToken())).thenReturn(
+			oauthUserInfo);
+		when(oauthUserInfoService.getAppleRefreshToken(appleLoginRequest.getAuthorizationCode())).thenReturn(
+			"refresh token");
+		when(userRepository.findByProviderAndEmail(Provider.APPLE, oauthUserInfo.getEmail())).thenReturn(
+			Optional.empty());
+		when(userRepository.save(any(User.class))).thenReturn(newUser);
+		when(appleRefreshTokenRepository.save(any(AppleRefreshToken.class))).thenReturn(null);
+		when(jwtProvider.createAccessToken(newUser.getId())).thenReturn("accessToken");
+		when(jwtProvider.createRefreshToken(newUser.getId())).thenReturn("refreshToken");
+
+		LoginResponse response = authService.loginWithApple(appleLoginRequest);
+
+		assertNotNull(response);
+		assertEquals("accessToken", response.getAccessToken());
+		assertEquals("refreshToken", response.getRefreshToken());
+		assertTrue(response.getIsSignUp());
+
+		verify(oauthUserInfoService, times(1)).requestUserInfo(Provider.APPLE, appleLoginRequest.getAccessToken());
+		verify(userRepository, times(1)).findByProviderAndEmail(Provider.APPLE, oauthUserInfo.getEmail());
+		verify(userRepository, times(1)).save(any(User.class));
+		verify(appleRefreshTokenRepository, times(1)).save(any(AppleRefreshToken.class));
+		verify(jwtProvider, times(1)).createAccessToken(newUser.getId());
+		verify(jwtProvider, times(1)).createRefreshToken(newUser.getId());
+		verifyNoMoreInteractions(oauthUserInfoService, userRepository, jwtProvider, rankingRedisRepository);
+	}
+
+	@Test
+	@DisplayName("[loginWithApple] DB에 user 가 존재하고 회원가입이 끝났다면 login 성공과 isSignup 은 false")
+	public void testLoginWithApple_ExistingUser_Signup() {
+		when(oauthUserInfoService.requestUserInfo(Provider.APPLE, appleLoginRequest.getAccessToken())).thenReturn(
+			oauthUserInfo);
+		when(userRepository.findByProviderAndEmail(Provider.APPLE, oauthUserInfo.getEmail())).thenReturn(
+			Optional.of(existingUser));
+		when(jwtProvider.createAccessToken(existingUser.getId())).thenReturn("accessToken");
+		when(jwtProvider.createRefreshToken(existingUser.getId())).thenReturn("refreshToken");
+
+		LoginResponse response = authService.loginWithApple(appleLoginRequest);
+
+		assertNotNull(response);
+		assertEquals("accessToken", response.getAccessToken());
+		assertEquals("refreshToken", response.getRefreshToken());
+		assertFalse(response.getIsSignUp());
+
+		verify(oauthUserInfoService, times(1)).requestUserInfo(Provider.APPLE, appleLoginRequest.getAccessToken());
+		verify(userRepository, times(1)).findByProviderAndEmail(Provider.APPLE, oauthUserInfo.getEmail());
+		verify(jwtProvider, times(1)).createAccessToken(existingUser.getId());
+		verify(jwtProvider, times(1)).createRefreshToken(existingUser.getId());
+		verifyNoMoreInteractions(oauthUserInfoService, userRepository, jwtProvider);
+	}
+
+	@Test
+	@DisplayName("[loginWithApple] DB에 user 가 존재하지만 회원가입이 끝나지 않았다면 login 성공과 isSignup 은 true")
+	public void testLoginWithApple_ExistingUser_NoSignup() {
+		when(oauthUserInfoService.requestUserInfo(Provider.APPLE, appleLoginRequest.getAccessToken())).thenReturn(
+			oauthUserInfo);
+		when(userRepository.findByProviderAndEmail(Provider.APPLE, oauthUserInfo.getEmail())).thenReturn(
+			Optional.of(existingUserNoSignup));
+		when(jwtProvider.createAccessToken(existingUser.getId())).thenReturn("accessToken");
+		when(jwtProvider.createRefreshToken(existingUser.getId())).thenReturn("refreshToken");
+
+		LoginResponse response = authService.loginWithApple(appleLoginRequest);
+
+		assertNotNull(response);
+		assertEquals("accessToken", response.getAccessToken());
+		assertEquals("refreshToken", response.getRefreshToken());
+		assertTrue(response.getIsSignUp());
+
+		verify(oauthUserInfoService, times(1)).requestUserInfo(Provider.APPLE, appleLoginRequest.getAccessToken());
+		verify(userRepository, times(1)).findByProviderAndEmail(Provider.APPLE, oauthUserInfo.getEmail());
+		verify(jwtProvider, times(1)).createAccessToken(existingUser.getId());
+		verify(jwtProvider, times(1)).createRefreshToken(existingUser.getId());
+		verifyNoMoreInteractions(oauthUserInfoService, userRepository, jwtProvider);
 	}
 }

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -41,6 +41,9 @@ oauth:
   apple:
     app:
       id: 123456
+      teamId: 123456
+      keyId: 123456
+      privateKey: 123456
     url:
       public-keys: https://appleid.apple.com/auth/keys
       issuer: https://appleid.apple.com


### PR DESCRIPTION
## 작업 내용*

- 애플로 회원가입 시 리프레시 토큰을 받도록 함
- 애플 계정의 회원탈퇴시 애플과 연결된 토큰을 만료시키는 기능 구현

## 고민한 내용*
### 회원탈퇴
- 애플의 서버에서 자원을 가져올 필요가 없었기에 애플의 access token과 refresh token 을 발급 받지 않았었다.
- 하지만 애플 에서 애플 로그인을 한경우 회원탈퇴시 애플과 연결을 끊어주어야한다.
- 끊으려면 token 이 필요하다. 그렇기 때문에 애플 로그인시 토큰을 발급 받는 로직을 추가했고 RDB에 저장하였다.
- 회원 탈퇴시 RDB에 저장되어있던 토큰을 활용하여 연결을 끊어준다.

### 소셜로그인 인터페이스 
- 기존에는 access token 하나만 받았지만 애플은 authorization code 를 받았어야 했기에 인터페이스를 맞출수가 없었다.
- 일부 인터페이스는 유지 했지만 authService의 login 메서드는 분리되게 되었다.

## 스크린샷
### 탈퇴시 메일로 오는 내용
<img width="695" alt="스크린샷 2024-07-28 오후 8 00 21" src="https://github.com/user-attachments/assets/94cba561-d9b0-4cf6-b393-b004f7c4ec74">
