### PR TITLE
M3-253 픽셀 차지 할 때 따닥 수정

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,7 @@ jobs:
           paths: ${{ github.workspace }}/build/jacocoReport/test/jacocoTestReport.xml
           token: ${{ secrets.GITHUB_TOKEN }}
           update-comment: true
+          min-coverage-overall: 70
 
   qodana:
     runs-on: ubuntu-latest

--- a/build.gradle
+++ b/build.gradle
@@ -92,9 +92,12 @@ jacocoTestReport {
         classDirectories.setFrom(
                 files(classDirectories.files.collect {
                     fileTree(dir: it, excludes: [
-//                            '**/domain/**',
-//                            '**/config/**',
-//                            '**/enums/**',
+                            '**/domain/**',
+                            '**/config/**',
+                            '**/enums/**',
+                            '**/exception/**',
+                            '**/jwt/*Filter*',
+                            '**/oauth/*Client*',
                     ])
                 })
         )

--- a/build.gradle
+++ b/build.gradle
@@ -92,9 +92,9 @@ jacocoTestReport {
         classDirectories.setFrom(
                 files(classDirectories.files.collect {
                     fileTree(dir: it, excludes: [
-                            '**/domain/**',
-                            '**/config/**',
-                            '**/enums/**',
+//                            '**/domain/**',
+//                            '**/config/**',
+//                            '**/enums/**',
                     ])
                 })
         )

--- a/build.gradle
+++ b/build.gradle
@@ -52,6 +52,8 @@ dependencies {
     implementation 'org.bouncycastle:bcpkix-jdk15on:1.69'
     implementation 'org.bouncycastle:bcprov-jdk15on:1.69'
 
+    implementation 'org.redisson:redisson-spring-boot-starter:3.16.3'
+
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     runtimeOnly 'com.mysql:mysql-connector-j'

--- a/src/main/java/com/m3pro/groundflip/config/RedisConfig.java
+++ b/src/main/java/com/m3pro/groundflip/config/RedisConfig.java
@@ -1,5 +1,8 @@
 package com.m3pro.groundflip.config;
 
+import org.redisson.Redisson;
+import org.redisson.api.RedissonClient;
+import org.redisson.config.Config;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -18,6 +21,14 @@ public class RedisConfig {
 	@Bean
 	public RedisConnectionFactory redisConnectionFactory() {
 		return new LettuceConnectionFactory(host, port);
+	}
+
+	@Bean
+	public RedissonClient redissonClient() {
+		Config config = new Config();
+		config.useSingleServer().setAddress("redis://" + host + ":" + port);
+
+		return Redisson.create(config);
 	}
 
 	@Bean

--- a/src/main/java/com/m3pro/groundflip/controller/PixelController.java
+++ b/src/main/java/com/m3pro/groundflip/controller/PixelController.java
@@ -106,7 +106,7 @@ public class PixelController {
 	@Operation(summary = "픽셀 차지", description = "특정 픽셀의 id, 사용자 id, 커뮤니티 id를 사용해 소유권을 바꾸는 API ")
 	@PostMapping("")
 	public Response<?> occupyPixel(@RequestBody PixelOccupyRequest pixelOccupyRequest) {
-		pixelService.occupyPixel(pixelOccupyRequest);
+		pixelService.occupyPixelWithLock(pixelOccupyRequest);
 		return Response.createSuccessWithNoData();
 	}
 

--- a/src/main/java/com/m3pro/groundflip/exception/ErrorCode.java
+++ b/src/main/java/com/m3pro/groundflip/exception/ErrorCode.java
@@ -20,10 +20,13 @@ public enum ErrorCode {
 	// JWT 관련 에러
 	JWT_NOT_EXISTS(HttpStatus.UNAUTHORIZED, "요청에 JWT가 존재하지 않습니다."),
 	INVALID_JWT(HttpStatus.UNAUTHORIZED, "유효하지 않은 JWT입니다."),
-	JWT_EXPIRED(HttpStatus.UNAUTHORIZED, "JWT가 만료되었습니다.");
+	JWT_EXPIRED(HttpStatus.UNAUTHORIZED, "JWT가 만료되었습니다."),
+
+	// 분산락 관련 에러
+	LOCK_ACQUISITION_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "락을 획득하는데 실패하였습니다.");
 
 	// 랭킹 관련 에러
-	
+
 	private final HttpStatus httpStatus;
 	private final String message;
 }

--- a/src/main/java/com/m3pro/groundflip/exception/ErrorCode.java
+++ b/src/main/java/com/m3pro/groundflip/exception/ErrorCode.java
@@ -10,6 +10,7 @@ import lombok.Getter;
 public enum ErrorCode {
 	DUPLICATED_NICKNAME(HttpStatus.BAD_REQUEST, "중복된 닉네임입니다."),
 	USER_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 사용자입니다."),
+	GROUP_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 그룹입니다."),
 	PIXEL_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 픽셀입니다."),
 	IMAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 이미지입니다."),
 	INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 에러 입니다"),

--- a/src/main/java/com/m3pro/groundflip/service/CommunityService.java
+++ b/src/main/java/com/m3pro/groundflip/service/CommunityService.java
@@ -7,6 +7,8 @@ import org.springframework.stereotype.Service;
 import com.m3pro.groundflip.domain.dto.community.CommunityInfoResponse;
 import com.m3pro.groundflip.domain.dto.community.CommunitySearchResponse;
 import com.m3pro.groundflip.domain.entity.Community;
+import com.m3pro.groundflip.exception.AppException;
+import com.m3pro.groundflip.exception.ErrorCode;
 import com.m3pro.groundflip.repository.CommunityRepository;
 
 import lombok.RequiredArgsConstructor;
@@ -29,7 +31,7 @@ public class CommunityService {
 
 	public CommunityInfoResponse findCommunityById(Long id) {
 		Community community = communityRepository.findById(id)
-			.orElseThrow(() -> new IllegalArgumentException("Community not found"));
+			.orElseThrow(() -> new AppException(ErrorCode.GROUP_NOT_FOUND));
 		return CommunityInfoResponse.from(community, 0, 0);
 	}
 }

--- a/src/main/java/com/m3pro/groundflip/service/StepService.java
+++ b/src/main/java/com/m3pro/groundflip/service/StepService.java
@@ -16,6 +16,7 @@ import com.m3pro.groundflip.exception.AppException;
 import com.m3pro.groundflip.exception.ErrorCode;
 import com.m3pro.groundflip.repository.StepRecordRepository;
 import com.m3pro.groundflip.repository.UserRepository;
+import com.m3pro.groundflip.util.DateUtils;
 
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
@@ -62,27 +63,11 @@ public class StepService {
 		calendar.setTime(startDate);
 
 		while (!calendar.getTime().after(endDate)) {
-			Date currentDate = truncateTime(calendar.getTime());
+			Date currentDate = DateUtils.truncateTime(calendar.getTime());
 			int steps = stepsMap.getOrDefault(currentDate, 0);
 			result.add(steps);
 			calendar.add(Calendar.DATE, 1);
 		}
-
 		return result;
-	}
-
-	/*
-	 * 시, 분, 초를 0으로 하고 년,월,일 만 구하기
-	 * @Param input Date
-	 * @return result Date
-	 * */
-	private Date truncateTime(Date date) {
-		Calendar calendar = Calendar.getInstance();
-		calendar.setTime(date);
-		calendar.set(Calendar.HOUR_OF_DAY, 0);
-		calendar.set(Calendar.MINUTE, 0);
-		calendar.set(Calendar.SECOND, 0);
-		calendar.set(Calendar.MILLISECOND, 0);
-		return calendar.getTime();
 	}
 }

--- a/src/main/java/com/m3pro/groundflip/util/DateUtils.java
+++ b/src/main/java/com/m3pro/groundflip/util/DateUtils.java
@@ -4,6 +4,8 @@ import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.time.temporal.TemporalAdjusters;
 import java.time.temporal.WeekFields;
+import java.util.Calendar;
+import java.util.Date;
 
 public class DateUtils {
 	public static boolean isDateInCurrentWeek(LocalDate date) {
@@ -18,5 +20,20 @@ public class DateUtils {
 	public static LocalDate getThisWeekStartDate() {
 		LocalDate today = LocalDate.now();
 		return today.with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY));
+	}
+
+	/*
+	 * 시, 분, 초를 0으로 하고 년,월,일 만 구하기
+	 * @Param input Date
+	 * @return result Date
+	 * */
+	public static Date truncateTime(Date date) {
+		Calendar calendar = Calendar.getInstance();
+		calendar.setTime(date);
+		calendar.set(Calendar.HOUR_OF_DAY, 0);
+		calendar.set(Calendar.MINUTE, 0);
+		calendar.set(Calendar.SECOND, 0);
+		calendar.set(Calendar.MILLISECOND, 0);
+		return calendar.getTime();
 	}
 }

--- a/src/test/java/com/m3pro/groundflip/service/CommunityServiceTest.java
+++ b/src/test/java/com/m3pro/groundflip/service/CommunityServiceTest.java
@@ -1,0 +1,87 @@
+package com.m3pro.groundflip.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import com.m3pro.groundflip.domain.dto.community.CommunityInfoResponse;
+import com.m3pro.groundflip.domain.dto.community.CommunitySearchResponse;
+import com.m3pro.groundflip.domain.entity.Community;
+import com.m3pro.groundflip.exception.AppException;
+import com.m3pro.groundflip.exception.ErrorCode;
+import com.m3pro.groundflip.repository.CommunityRepository;
+
+class CommunityServiceTest {
+	@InjectMocks
+	private CommunityService communityService;
+
+	@Mock
+	private CommunityRepository communityRepository;
+
+	private Community community;
+
+	@BeforeEach
+	void setUp() {
+		MockitoAnnotations.openMocks(this);
+
+		// Community 객체 생성
+		community = Community.builder()
+			.id(1L)
+			.name("Test Community")
+			.build();
+	}
+
+	@Test
+	@DisplayName("[findAllCommunityByName_] searchName 과 일치하는 모든 그룹 정보 반환")
+	void findAllCommunityByName_shouldReturnMatchingCommunities() {
+		// Given
+		String searchName = "Test";
+		when(communityRepository.findAllByNameLike("%" + searchName + "%"))
+			.thenReturn(List.of(community));
+
+		// When
+		List<CommunitySearchResponse> results = communityService.findAllCommunityByName(searchName);
+
+		// Then
+		assertNotNull(results);
+		assertEquals(1, results.size());
+		assertEquals("Test Community", results.get(0).getName());
+	}
+
+	@Test
+	@DisplayName("[findCommunityById] 그룹 아이디에 해당하는 그룹 정보 반환")
+	void findCommunityById_shouldReturnCommunityInfoResponse() {
+		// Given
+		Long communityId = 1L;
+		when(communityRepository.findById(communityId)).thenReturn(Optional.of(community));
+
+		// When
+		CommunityInfoResponse result = communityService.findCommunityById(communityId);
+
+		// Then
+		assertNotNull(result);
+		assertEquals("Test Community", result.getName());
+	}
+
+	@Test
+	@DisplayName("[findCommunityById] 없는 그룹인 경우 에러")
+	void findCommunityById_shouldThrowExceptionWhenCommunityNotFound() {
+		// Given
+		Long communityId = 2L;
+		when(communityRepository.findById(communityId)).thenReturn(Optional.empty());
+
+		// When & Then
+		AppException exception = assertThrows(AppException.class,
+			() -> communityService.findCommunityById(communityId));
+		assertEquals(ErrorCode.GROUP_NOT_FOUND, exception.getErrorCode());
+	}
+}

--- a/src/test/java/com/m3pro/groundflip/service/PixelServiceTest.java
+++ b/src/test/java/com/m3pro/groundflip/service/PixelServiceTest.java
@@ -9,6 +9,8 @@ import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.Condition;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -17,6 +19,9 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.redisson.api.RFuture;
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
 import org.springframework.context.ApplicationEventPublisher;
 
 import com.m3pro.groundflip.domain.dto.pixel.IndividualPixelInfoResponse;
@@ -49,6 +54,8 @@ class PixelServiceTest {
 	private RankingService rankingService;
 	@Mock
 	private ApplicationEventPublisher applicationEventPublisher;
+	@Mock
+	private RedissonClient redissonClient;
 	@InjectMocks
 	private PixelService pixelService;
 
@@ -324,9 +331,9 @@ class PixelServiceTest {
 			.address("대한민국")
 			.build();
 		when(pixelRepository.findByXAndY(222L, 233L)).thenReturn(Optional.of(pixel));
-
+		when(redissonClient.getLock(any())).thenReturn(new RedissonLock());
 		// When
-		pixelService.occupyPixel(pixelOccupyRequest);
+		pixelService.occupyPixelWithLock(pixelOccupyRequest);
 
 		//Then
 		assertEquals(5L, pixel.getUserId());
@@ -343,9 +350,9 @@ class PixelServiceTest {
 			.address("대한민국")
 			.build();
 		when(pixelRepository.findByXAndY(222L, 233L)).thenReturn(Optional.of(pixel));
-
+		when(redissonClient.getLock(any())).thenReturn(new RedissonLock());
 		// When
-		pixelService.occupyPixel(pixelOccupyRequest);
+		pixelService.occupyPixelWithLock(pixelOccupyRequest);
 
 		// Then
 		verify(applicationEventPublisher, times(1)).publishEvent(any(PixelUserInsertEvent.class));
@@ -362,9 +369,9 @@ class PixelServiceTest {
 			.address(null)
 			.build();
 		when(pixelRepository.findByXAndY(222L, 233L)).thenReturn(Optional.of(pixel));
-
+		when(redissonClient.getLock(any())).thenReturn(new RedissonLock());
 		// When
-		pixelService.occupyPixel(pixelOccupyRequest);
+		pixelService.occupyPixelWithLock(pixelOccupyRequest);
 
 		// Then
 		verify(applicationEventPublisher, times(1)).publishEvent(any(PixelAddressUpdateEvent.class));
@@ -381,11 +388,168 @@ class PixelServiceTest {
 			.address("대한민국 ")
 			.build();
 		when(pixelRepository.findByXAndY(222L, 233L)).thenReturn(Optional.of(pixel));
-
+		when(redissonClient.getLock(any())).thenReturn(new RedissonLock());
 		// When
-		pixelService.occupyPixel(pixelOccupyRequest);
+		pixelService.occupyPixelWithLock(pixelOccupyRequest);
 
 		// Then
 		verify(applicationEventPublisher, times(0)).publishEvent(any(PixelAddressUpdateEvent.class));
+	}
+
+	static class RedissonLock implements RLock {
+		@Override
+		public String getName() {
+			return "";
+		}
+
+		@Override
+		public void lockInterruptibly(long l, TimeUnit timeUnit) throws InterruptedException {
+
+		}
+
+		@Override
+		public boolean tryLock(long l, long l1, TimeUnit timeUnit) throws InterruptedException {
+			return true;
+		}
+
+		@Override
+		public void lock(long l, TimeUnit timeUnit) {
+
+		}
+
+		@Override
+		public boolean forceUnlock() {
+			return false;
+		}
+
+		@Override
+		public boolean isLocked() {
+			return false;
+		}
+
+		@Override
+		public boolean isHeldByThread(long l) {
+			return false;
+		}
+
+		@Override
+		public boolean isHeldByCurrentThread() {
+			return false;
+		}
+
+		@Override
+		public int getHoldCount() {
+			return 0;
+		}
+
+		@Override
+		public long remainTimeToLive() {
+			return 0;
+		}
+
+		@Override
+		public void lock() {
+
+		}
+
+		@Override
+		public void lockInterruptibly() throws InterruptedException {
+
+		}
+
+		@Override
+		public boolean tryLock() {
+			return false;
+		}
+
+		@Override
+		public boolean tryLock(long time, TimeUnit unit) throws InterruptedException {
+			return false;
+		}
+
+		@Override
+		public void unlock() {
+
+		}
+
+		@Override
+		public Condition newCondition() {
+			return null;
+		}
+
+		@Override
+		public RFuture<Boolean> forceUnlockAsync() {
+			return null;
+		}
+
+		@Override
+		public RFuture<Void> unlockAsync() {
+			return null;
+		}
+
+		@Override
+		public RFuture<Void> unlockAsync(long l) {
+			return null;
+		}
+
+		@Override
+		public RFuture<Boolean> tryLockAsync() {
+			return null;
+		}
+
+		@Override
+		public RFuture<Void> lockAsync() {
+			return null;
+		}
+
+		@Override
+		public RFuture<Void> lockAsync(long l) {
+			return null;
+		}
+
+		@Override
+		public RFuture<Void> lockAsync(long l, TimeUnit timeUnit) {
+			return null;
+		}
+
+		@Override
+		public RFuture<Void> lockAsync(long l, TimeUnit timeUnit, long l1) {
+			return null;
+		}
+
+		@Override
+		public RFuture<Boolean> tryLockAsync(long l) {
+			return null;
+		}
+
+		@Override
+		public RFuture<Boolean> tryLockAsync(long l, TimeUnit timeUnit) {
+			return null;
+		}
+
+		@Override
+		public RFuture<Boolean> tryLockAsync(long l, long l1, TimeUnit timeUnit) {
+			return null;
+		}
+
+		@Override
+		public RFuture<Boolean> tryLockAsync(long l, long l1, TimeUnit timeUnit, long l2) {
+			return null;
+		}
+
+		@Override
+		public RFuture<Integer> getHoldCountAsync() {
+			return null;
+		}
+
+		@Override
+		public RFuture<Boolean> isLockedAsync() {
+			return null;
+		}
+
+		@Override
+		public RFuture<Long> remainTimeToLiveAsync() {
+			return null;
+		}
 	}
 }

--- a/src/test/java/com/m3pro/groundflip/service/StepServiceTest.java
+++ b/src/test/java/com/m3pro/groundflip/service/StepServiceTest.java
@@ -1,0 +1,104 @@
+package com.m3pro.groundflip.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import com.m3pro.groundflip.domain.dto.steprecord.UserStepInfo;
+import com.m3pro.groundflip.domain.entity.StepRecord;
+import com.m3pro.groundflip.domain.entity.User;
+import com.m3pro.groundflip.exception.AppException;
+import com.m3pro.groundflip.repository.StepRecordRepository;
+import com.m3pro.groundflip.repository.UserRepository;
+
+class StepServiceTest {
+
+	@InjectMocks
+	private StepService stepService;
+
+	@Mock
+	private UserRepository userRepository;
+
+	@Mock
+	private StepRecordRepository stepRecordRepository;
+
+	private User user;
+	private UserStepInfo userStepInfo;
+
+	@BeforeEach
+	void setUp() {
+		MockitoAnnotations.openMocks(this);
+		user = User.builder()
+			.id(1L)
+			.nickname("Test User")
+			.build();
+
+		userStepInfo = new UserStepInfo();
+		userStepInfo.setUserId(user.getId());
+		userStepInfo.setSteps(1000);
+		userStepInfo.setDate(new java.sql.Date(2024, 10, 2));
+
+		StepRecord stepRecord = StepRecord.builder()
+			.user(user)
+			.steps(1000)
+			.date(userStepInfo.getDate())
+			.build();
+
+		when(userRepository.findById(user.getId())).thenReturn(Optional.of(user));
+		when(stepRecordRepository.save(any(StepRecord.class))).thenReturn(stepRecord);
+	}
+
+	@Test
+	@DisplayName("[postUserStep] 정상적으로 걸음수 저장")
+	void postUserStep_shouldSaveStepRecord() {
+		// When
+		stepService.postUserStep(userStepInfo);
+
+		// Then
+		verify(stepRecordRepository, times(1)).save(any(StepRecord.class));
+	}
+
+	@Test
+	@DisplayName("[postUserStep] 없는 유저의 걸음수를 저장하는 경우 에러")
+	void postUserStep_shouldThrowExceptionWhenUserNotFound() {
+		// Given
+		when(userRepository.findById(user.getId())).thenReturn(Optional.empty());
+
+		// When / Then
+		assertThrows(AppException.class, () -> stepService.postUserStep(userStepInfo));
+	}
+
+	@Test
+	@DisplayName("[getUserStepWhileWeek] startDate, endDate 사이의 걸음수를 반환, 없는 경우 0으로 반환")
+	void getUserStepWhileWeek_shouldReturnListOfSteps() {
+		// Given
+		java.sql.Date startDate = new java.sql.Date(2024, 10, 2);
+		java.sql.Date endDate = new java.sql.Date(2024, 10, 8);
+
+		List<StepRecord> mockStepRecords = Arrays.asList(
+			StepRecord.builder().user(user).steps(1000).date(startDate).build(),
+			StepRecord.builder().user(user).steps(2000).date(endDate).build()
+		);
+
+		when(stepRecordRepository.findByUserIdAndDateBetween(user.getId(), startDate, endDate))
+			.thenReturn(mockStepRecords);
+
+		// When
+		List<Integer> steps = stepService.getUserStepWhileWeek(user.getId(), startDate, endDate);
+
+		// Then
+		assertEquals(7, steps.size());
+		assertEquals(1000, steps.get(0));
+		assertEquals(2000, steps.get(6));
+	}
+}

--- a/src/test/java/com/m3pro/groundflip/util/DateUtilsTest.java
+++ b/src/test/java/com/m3pro/groundflip/util/DateUtilsTest.java
@@ -5,6 +5,8 @@ import static org.junit.jupiter.api.Assertions.*;
 import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.time.temporal.WeekFields;
+import java.util.Calendar;
+import java.util.Date;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -74,5 +76,37 @@ class DateUtilsTest {
 		LocalDate date4 = LocalDate.of(2020, 2, 29);
 		int expectedWeek4 = date4.get(weekFields.weekOfWeekBasedYear());
 		assertEquals(expectedWeek4, DateUtils.getWeekOfDate(date4), "Week number of 2020-02-29 should match");
+	}
+
+	@Test
+	@DisplayName("[truncateTime]")
+	void truncateTime_shouldSetTimeToMidnight() {
+		// Given: 현재 날짜와 시간이 설정된 Date 객체
+		Calendar calendar = Calendar.getInstance();
+		calendar.set(Calendar.YEAR, 2024);
+		calendar.set(Calendar.MONTH, Calendar.AUGUST);
+		calendar.set(Calendar.DAY_OF_MONTH, 3);
+		calendar.set(Calendar.HOUR_OF_DAY, 15);
+		calendar.set(Calendar.MINUTE, 45);
+		calendar.set(Calendar.SECOND, 30);
+		calendar.set(Calendar.MILLISECOND, 123);
+		Date originalDate = calendar.getTime();
+
+		// When: 시간을 자정으로 설정
+		Date truncatedDate = DateUtils.truncateTime(originalDate);
+
+		// Then: 자정으로 시간이 설정된 날짜 확인
+		Calendar expectedCalendar = Calendar.getInstance();
+		expectedCalendar.setTime(truncatedDate);
+
+		assertEquals(2024, expectedCalendar.get(Calendar.YEAR));
+		assertEquals(Calendar.AUGUST, expectedCalendar.get(Calendar.MONTH));
+		assertEquals(3, expectedCalendar.get(Calendar.DAY_OF_MONTH));
+		assertEquals(0, expectedCalendar.get(Calendar.HOUR_OF_DAY));
+		assertEquals(0, expectedCalendar.get(Calendar.MINUTE));
+		assertEquals(0, expectedCalendar.get(Calendar.SECOND));
+		assertEquals(0, expectedCalendar.get(Calendar.MILLISECOND));
+
+		assertNotNull(truncatedDate);
 	}
 }


### PR DESCRIPTION
## 작업 내용*

- 랭킹 갱신 할 때 동시성 문제 해결
- 테스트 커버리지 70%로 올림

## 고민한 내용*
### 에러 설명

동시에 같은 유저가 같은 픽셀을 여러번 요청하면 요청한 만큼 점수가 올라가는 문제

예를 들어 

{
  "userId": 446,
  "communityId": null,
  "x": 1000,
  "y": 1000
}

이런 요청을 동시에 10번 보내면 current_pixel_count 점수에 1만 추가 되어야하는데 4가 추가되는 문제 발생

### 발생 원인

동시에 DB 에서 pixel을 읽어오는데 바뀐게 반영되지 않은채로 읽어져서 여러 스레드에서 user_id 가 null 인 값으로 읽어와서 여러 스레드에서 redis 에 플러스 1 요청을 보내 생기는 문제이다.

### 해결방법
- 스레드에서 락을 거는 것은 분산환경에서 동작하지 않으니 제외했다.
- DB에서 락을 거는 것은 DB에 부하가 전가된다고 생각되어 제외했다.
- 결국 레디스를 사용해서 분산락을 거는 방법으로 해결했다.
- Redisson 이라는 것을 사용하여 pub/sub 구조 락을 대기하는 방식으로 구현했다.

## 리뷰 요구사항

- 리뷰할 때 중점적으로 봐줬으면 하는 내용들

## 스크린샷