### PR TITLE
M3-281 옛날에 차지 했던 픽셀이 주가 지나고 다시 파지하면 내 것으로 인식되지 않는 문제

### DIFF
--- a/src/main/java/com/m3pro/groundflip/domain/entity/global/BaseTimeEntity.java
+++ b/src/main/java/com/m3pro/groundflip/domain/entity/global/BaseTimeEntity.java
@@ -22,4 +22,7 @@ public class BaseTimeEntity {
 	@LastModifiedDate
 	private LocalDateTime modifiedAt;
 
+	public void updateModifiedAt() {
+		modifiedAt = LocalDateTime.now();
+	}
 }

--- a/src/main/java/com/m3pro/groundflip/service/PixelService.java
+++ b/src/main/java/com/m3pro/groundflip/service/PixelService.java
@@ -151,11 +151,19 @@ public class PixelService {
 		Pixel targetPixel = pixelRepository.findByXAndY(pixelOccupyRequest.getX(), pixelOccupyRequest.getY())
 			.orElseThrow(() -> new AppException(ErrorCode.PIXEL_NOT_FOUND));
 		updateRankingOnCache(targetPixel, occupyingUserId);
-		targetPixel.updateUserId(occupyingUserId);
-		pixelRepository.saveAndFlush(targetPixel);
+		updatePixelOwner(targetPixel, occupyingUserId);
 
 		updatePixelAddress(targetPixel);
 		eventPublisher.publishEvent(new PixelUserInsertEvent(targetPixel.getId(), occupyingUserId, communityId));
+	}
+
+	private void updatePixelOwner(Pixel targetPixel, Long occupyingUserId) {
+		if (Objects.equals(targetPixel.getUserId(), occupyingUserId)) {
+			targetPixel.updateModifiedAt();
+		} else {
+			targetPixel.updateUserId(occupyingUserId);
+		}
+		pixelRepository.saveAndFlush(targetPixel);
 	}
 
 	/**


### PR DESCRIPTION
## 작업 내용*
- 픽셀의 소유주를 변경 할 때 동일한 소유주이면 수정날짜를 변경하도록 수정


## 고민한 내용*
### 에러 설명
옛날에 방문했던 픽셀을 이번주에 다시 방문하면 개인전 모드에서 내 땅으로 표시가 안되는 문제
### 발생 원인
최초 방문시에만 pixel 테이블의 user_id가 바뀌어 modified at 이 수정된다. 따라서 이미 user_id가 나인 상태에서 재방문하면 user_id 가 변경되지 않으므로 modified at이 변경되지 않는다.
따라서 이번주 차지 중인 픽셀을 검색할떄 modified at 이 옛날 날짜로 되어있어서 필터링이 안되서 생기는 문제이다.
### 해결 방법
이미 내가 차지한 픽셀이면 modified_at 을 현재 날짜로 변경한다.
