### PR TITLE
M3-286 FCM 토큰 관리기능 서버 구현

### DIFF
--- a/src/main/java/com/m3pro/groundflip/controller/UserController.java
+++ b/src/main/java/com/m3pro/groundflip/controller/UserController.java
@@ -5,6 +5,7 @@ import java.io.IOException;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -17,6 +18,7 @@ import com.m3pro.groundflip.domain.dto.user.FcmTokenRequest;
 import com.m3pro.groundflip.domain.dto.user.UserDeleteRequest;
 import com.m3pro.groundflip.domain.dto.user.UserInfoRequest;
 import com.m3pro.groundflip.domain.dto.user.UserInfoResponse;
+import com.m3pro.groundflip.service.FcmService;
 import com.m3pro.groundflip.service.UserService;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -32,6 +34,7 @@ import lombok.RequiredArgsConstructor;
 @SecurityRequirement(name = "Authorization")
 public class UserController {
 	private final UserService userService;
+	private final FcmService fcmService;
 
 	@Operation(summary = "사용자 기본 정보 조회", description = "닉네임, id, 출생년도, 성별, 프로필 사진, 그룹이름, 그룹 id 를 조회 한다.")
 	@GetMapping("/{userId}")
@@ -65,10 +68,11 @@ public class UserController {
 	}
 
 	@Operation(summary = "FCM 등록 토큰 등록", description = "푸시 알림을 위한 FCM 등록 토큰을 저장한다.")
-	@PutMapping("/fcm-token")
+	@PostMapping("/fcm-token")
 	public Response<?> postFcmToken(
 		@RequestBody FcmTokenRequest fcmTokenRequest
 	) {
+		fcmService.registerFcmToken(fcmTokenRequest);
 		return Response.createSuccessWithNoData();
 	}
 }

--- a/src/main/java/com/m3pro/groundflip/controller/UserController.java
+++ b/src/main/java/com/m3pro/groundflip/controller/UserController.java
@@ -13,6 +13,7 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
 import com.m3pro.groundflip.domain.dto.Response;
+import com.m3pro.groundflip.domain.dto.user.FcmTokenRequest;
 import com.m3pro.groundflip.domain.dto.user.UserDeleteRequest;
 import com.m3pro.groundflip.domain.dto.user.UserInfoRequest;
 import com.m3pro.groundflip.domain.dto.user.UserInfoResponse;
@@ -60,6 +61,14 @@ public class UserController {
 		@RequestBody UserDeleteRequest userDeleteRequest
 	) {
 		userService.deleteUser(userId, userDeleteRequest);
+		return Response.createSuccessWithNoData();
+	}
+
+	@Operation(summary = "FCM 등록 토큰 등록", description = "푸시 알림을 위한 FCM 등록 토큰을 저장한다.")
+	@PutMapping("/fcm-token")
+	public Response<?> postFcmToken(
+		@RequestBody FcmTokenRequest fcmTokenRequest
+	) {
 		return Response.createSuccessWithNoData();
 	}
 }

--- a/src/main/java/com/m3pro/groundflip/domain/dto/user/FcmTokenRequest.java
+++ b/src/main/java/com/m3pro/groundflip/domain/dto/user/FcmTokenRequest.java
@@ -1,0 +1,20 @@
+package com.m3pro.groundflip.domain.dto.user;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Schema(title = "FCM 등록 토큰 저장")
+public class FcmTokenRequest {
+	@Schema(description = "사용자 Id", example = "125")
+	private Long userId;
+
+	@Schema(description = "사용자 fcm token", example = "sdfghweredasdvasdfq/weqwefs;dvsdghrthwdffevdrer")
+	private String fcmToken;
+}

--- a/src/main/java/com/m3pro/groundflip/domain/entity/FcmToken.java
+++ b/src/main/java/com/m3pro/groundflip/domain/entity/FcmToken.java
@@ -1,0 +1,37 @@
+package com.m3pro.groundflip.domain.entity;
+
+import com.m3pro.groundflip.domain.entity.global.BaseTimeEntity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "fcm_token")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class FcmToken extends BaseTimeEntity {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "fcm_token_id")
+	private Long id;
+
+	private String token;
+
+	@OneToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "user_id")
+	private User user;
+}

--- a/src/main/java/com/m3pro/groundflip/domain/entity/global/BaseTimeEntity.java
+++ b/src/main/java/com/m3pro/groundflip/domain/entity/global/BaseTimeEntity.java
@@ -22,7 +22,11 @@ public class BaseTimeEntity {
 	@LastModifiedDate
 	private LocalDateTime modifiedAt;
 
-	public void updateModifiedAt() {
+	public void updateModifiedAtToNow() {
 		modifiedAt = LocalDateTime.now();
+	}
+
+	public void updateModifiedAt(LocalDateTime localDateTime) {
+		modifiedAt = localDateTime;
 	}
 }

--- a/src/main/java/com/m3pro/groundflip/repository/FcmTokenRepository.java
+++ b/src/main/java/com/m3pro/groundflip/repository/FcmTokenRepository.java
@@ -1,0 +1,12 @@
+package com.m3pro.groundflip.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.m3pro.groundflip.domain.entity.FcmToken;
+import com.m3pro.groundflip.domain.entity.User;
+
+public interface FcmTokenRepository extends JpaRepository<FcmToken, Long> {
+	Optional<FcmToken> findByUser(User user);
+}

--- a/src/main/java/com/m3pro/groundflip/repository/FcmTokenRepository.java
+++ b/src/main/java/com/m3pro/groundflip/repository/FcmTokenRepository.java
@@ -9,4 +9,6 @@ import com.m3pro.groundflip.domain.entity.User;
 
 public interface FcmTokenRepository extends JpaRepository<FcmToken, Long> {
 	Optional<FcmToken> findByUser(User user);
+
+	void deleteByUser(User user);
 }

--- a/src/main/java/com/m3pro/groundflip/service/FcmService.java
+++ b/src/main/java/com/m3pro/groundflip/service/FcmService.java
@@ -30,7 +30,7 @@ public class FcmService {
 		Optional<FcmToken> fcmToken = fcmTokenRepository.findByUser(user);
 
 		if (fcmToken.isPresent()) {
-			fcmToken.get().updateModifiedAt();
+			fcmToken.get().updateModifiedAtToNow();
 		} else {
 			fcmTokenRepository.save(
 				FcmToken.builder()

--- a/src/main/java/com/m3pro/groundflip/service/FcmService.java
+++ b/src/main/java/com/m3pro/groundflip/service/FcmService.java
@@ -1,0 +1,43 @@
+package com.m3pro.groundflip.service;
+
+import java.util.Optional;
+
+import org.springframework.stereotype.Service;
+
+import com.m3pro.groundflip.domain.dto.user.FcmTokenRequest;
+import com.m3pro.groundflip.domain.entity.FcmToken;
+import com.m3pro.groundflip.domain.entity.User;
+import com.m3pro.groundflip.exception.AppException;
+import com.m3pro.groundflip.exception.ErrorCode;
+import com.m3pro.groundflip.repository.FcmTokenRepository;
+import com.m3pro.groundflip.repository.UserRepository;
+
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class FcmService {
+	private final UserRepository userRepository;
+	private final FcmTokenRepository fcmTokenRepository;
+
+	@Transactional
+	public void registerFcmToken(FcmTokenRequest fcmTokenRequest) {
+		Long userId = fcmTokenRequest.getUserId();
+		User user = userRepository.findById(userId).orElseThrow(() -> new AppException(ErrorCode.USER_NOT_FOUND));
+		Optional<FcmToken> fcmToken = fcmTokenRepository.findByUser(user);
+
+		if (fcmToken.isPresent()) {
+			fcmToken.get().updateModifiedAt();
+		} else {
+			fcmTokenRepository.save(
+				FcmToken.builder()
+					.user(user)
+					.token(fcmTokenRequest.getFcmToken())
+					.build()
+			);
+		}
+	}
+}

--- a/src/main/java/com/m3pro/groundflip/service/PixelService.java
+++ b/src/main/java/com/m3pro/groundflip/service/PixelService.java
@@ -159,7 +159,7 @@ public class PixelService {
 
 	private void updatePixelOwner(Pixel targetPixel, Long occupyingUserId) {
 		if (Objects.equals(targetPixel.getUserId(), occupyingUserId)) {
-			targetPixel.updateModifiedAt();
+			targetPixel.updateModifiedAtToNow();
 		} else {
 			targetPixel.updateUserId(occupyingUserId);
 		}

--- a/src/main/java/com/m3pro/groundflip/service/RankingService.java
+++ b/src/main/java/com/m3pro/groundflip/service/RankingService.java
@@ -43,30 +43,14 @@ public class RankingService {
 			if (modifiedAt.isAfter(thisWeekStart)) {
 				return;
 			}
-			increaseCurrentPixelCount(occupyingUserId);
+			rankingRedisRepository.increaseCurrentPixelCount(occupyingUserId);
 		} else {
 			if (originalOwnerUserId == null || modifiedAt.isBefore(thisWeekStart)) {
-				increaseCurrentPixelCount(occupyingUserId);
+				rankingRedisRepository.increaseCurrentPixelCount(occupyingUserId);
 			} else {
 				updateRankingAfterOccupy(occupyingUserId, originalOwnerUserId);
 			}
 		}
-	}
-
-	/**
-	 * 현재 픽셀의 수를 1 증가 시킨다.
-	 * @param userId 사용자 id
-	 */
-	public void increaseCurrentPixelCount(Long userId) {
-		rankingRedisRepository.increaseCurrentPixelCount(userId);
-	}
-
-	/**
-	 * 현재 픽셀의 수를 1 감소 시킨다.
-	 * @param userId 사용자 id
-	 */
-	public void decreaseCurrentPixelCount(Long userId) {
-		rankingRedisRepository.decreaseCurrentPixelCount(userId);
 	}
 
 	/**
@@ -75,8 +59,8 @@ public class RankingService {
 	 * @param deprivedUserId 픽셀을 뺴앗긴 유저
 	 */
 	public void updateRankingAfterOccupy(Long occupyingUserId, Long deprivedUserId) {
-		increaseCurrentPixelCount(occupyingUserId);
-		decreaseCurrentPixelCount(deprivedUserId);
+		rankingRedisRepository.increaseCurrentPixelCount(occupyingUserId);
+		rankingRedisRepository.decreaseCurrentPixelCount(deprivedUserId);
 	}
 
 	/**

--- a/src/main/java/com/m3pro/groundflip/service/UserService.java
+++ b/src/main/java/com/m3pro/groundflip/service/UserService.java
@@ -21,6 +21,7 @@ import com.m3pro.groundflip.exception.AppException;
 import com.m3pro.groundflip.exception.ErrorCode;
 import com.m3pro.groundflip.jwt.JwtProvider;
 import com.m3pro.groundflip.repository.AppleRefreshTokenRepository;
+import com.m3pro.groundflip.repository.FcmTokenRepository;
 import com.m3pro.groundflip.repository.RankingRedisRepository;
 import com.m3pro.groundflip.repository.UserCommunityRepository;
 import com.m3pro.groundflip.repository.UserRepository;
@@ -39,6 +40,7 @@ public class UserService {
 	private final UserRepository userRepository;
 	private final AppleRefreshTokenRepository appleRefreshTokenRepository;
 	private final UserCommunityRepository userCommunityRepository;
+	private final FcmTokenRepository fcmTokenRepository;
 	private final S3Uploader s3Uploader;
 	private final JwtProvider jwtProvider;
 	private final AppleApiClient appleApiClient;
@@ -122,6 +124,8 @@ public class UserService {
 		if (deletedUser.getProvider() == Provider.APPLE) {
 			revokeAppleToken(deletedUser.getId());
 		}
+		fcmTokenRepository.deleteByUser(deletedUser);
+
 		deletedUser.updateBirthYear(convertToDate(1900));
 		deletedUser.updateNickName(null);
 		deletedUser.updateProfileImage(null);

--- a/src/test/java/com/m3pro/groundflip/service/FcmServiceTest.java
+++ b/src/test/java/com/m3pro/groundflip/service/FcmServiceTest.java
@@ -1,0 +1,75 @@
+package com.m3pro.groundflip.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.m3pro.groundflip.domain.dto.user.FcmTokenRequest;
+import com.m3pro.groundflip.domain.entity.FcmToken;
+import com.m3pro.groundflip.domain.entity.User;
+import com.m3pro.groundflip.exception.AppException;
+import com.m3pro.groundflip.exception.ErrorCode;
+import com.m3pro.groundflip.repository.FcmTokenRepository;
+import com.m3pro.groundflip.repository.UserRepository;
+
+@ExtendWith(MockitoExtension.class)
+class FcmServiceTest {
+	private static final Long testUserId = 1L;
+	private static final String testFcmToken = "test token";
+	private static FcmTokenRequest fcmTokenRequest;
+	@Mock
+	private UserRepository userRepository;
+	@Mock
+	private FcmTokenRepository fcmTokenRepository;
+	@InjectMocks
+	private FcmService fcmService;
+
+	@BeforeAll
+	static void beforeAll() {
+		fcmTokenRequest = new FcmTokenRequest(testUserId, testFcmToken);
+	}
+
+	@Test
+	@DisplayName("[registerFcmToken] user 가 없는 경우 에러 발생")
+	void registerFcmToken_UserNotFound() {
+		when(userRepository.findById(testUserId)).thenReturn(Optional.empty());
+
+		AppException exception = assertThrows(AppException.class, () -> fcmService.registerFcmToken(fcmTokenRequest));
+		assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.USER_NOT_FOUND);
+	}
+
+	@Test
+	@DisplayName("[registerFcmToken] fcm 토큰 새로 등록")
+	void registerFcmToken_RegisterNewToken() {
+		User user = User.builder().id(1L).email("test@test.com").build();
+		when(userRepository.findById(testUserId)).thenReturn(Optional.of(user));
+		when(fcmTokenRepository.findByUser(user)).thenReturn(Optional.empty());
+
+		fcmService.registerFcmToken(fcmTokenRequest);
+
+		verify(fcmTokenRepository, times(1)).save(any());
+	}
+
+	@Test
+	@DisplayName("[registerFcmToken] fcm 토큰이 이미 등록된 경우 수정 날짜만 변경")
+	void registerFcmToken_UpdateModifiedDate() {
+		User user = User.builder().id(1L).email("test@test.com").build();
+		FcmToken fcmToken = FcmToken.builder().id(1L).token(testFcmToken).user(user).build();
+		when(userRepository.findById(testUserId)).thenReturn(Optional.of(user));
+		when(fcmTokenRepository.findByUser(user)).thenReturn(Optional.of(fcmToken));
+
+		fcmService.registerFcmToken(fcmTokenRequest);
+
+		assertThat(fcmToken.getModifiedAt()).isNotNull();
+	}
+}

--- a/src/test/java/com/m3pro/groundflip/service/UserServiceTest.java
+++ b/src/test/java/com/m3pro/groundflip/service/UserServiceTest.java
@@ -36,6 +36,7 @@ import com.m3pro.groundflip.exception.AppException;
 import com.m3pro.groundflip.exception.ErrorCode;
 import com.m3pro.groundflip.jwt.JwtProvider;
 import com.m3pro.groundflip.repository.AppleRefreshTokenRepository;
+import com.m3pro.groundflip.repository.FcmTokenRepository;
 import com.m3pro.groundflip.repository.RankingRedisRepository;
 import com.m3pro.groundflip.repository.UserCommunityRepository;
 import com.m3pro.groundflip.repository.UserRepository;
@@ -49,6 +50,9 @@ class UserServiceTest {
 
 	@Mock
 	private RankingRedisRepository rankingRedisRepository;
+
+	@Mock
+	private FcmTokenRepository fcmTokenRepository;
 
 	@Mock
 	private S3Uploader s3Uploader;
@@ -207,6 +211,7 @@ class UserServiceTest {
 		Calendar calendar = Calendar.getInstance();
 		calendar.setTime(deleteUser.getBirthYear());
 
+		verify(fcmTokenRepository, times(1)).deleteByUser(any());
 		assertThat(deleteUser.getNickname()).isEqualTo(null);
 		assertThat(deleteUser.getProfileImage()).isEqualTo(null);
 		assertThat(calendar.get(Calendar.YEAR)).isEqualTo(1900);
@@ -236,6 +241,7 @@ class UserServiceTest {
 
 		Calendar calendar = Calendar.getInstance();
 		calendar.setTime(deleteUser.getBirthYear());
+		verify(fcmTokenRepository, times(1)).deleteByUser(any());
 		verify(appleApiClient, times(1)).revokeToken(any());
 		verify(appleRefreshTokenRepository, times(1)).delete(any());
 		assertThat(deleteUser.getNickname()).isEqualTo(null);


### PR DESCRIPTION
## 작업 내용*
- fcm token 등록 api 구현
- 회원 탈퇴시 기존 등록 된 토큰도 삭제 하도록 구현


## 고민한 내용*
### 토큰 관리
- fcm 공식 문서를 보면 권장사항 나와있다. 
#### 주요 권장사항
- 서버에 등록 토큰을 저장합니다.
- 서버에 토큰 타임스탬프를 구현하고 토큰이 변경될때 타임스탬프를 정기적으로 업데이트
- 업데이트 된지 2달된 토큰은 비활성화된 유저일 확률이 크기에 삭제
- 정기적으로 토큰 업데이트
- 푸시 알림후 응답이 잘못되면 토큰 삭제

등이 권장사항으로 적혀있다. 
- 그래서 나는 FcmToken 테이블을 만들어서 user_id, token, modified_at 을 저장하게 했다.
- modified_at 이 타임스탬프이며 업데이트 가능하다.
- 앱이 켜질 때 마다토큰을 서버에 전송하게 했기에 정기적 토큰 업데이트도 만족한다.
#### 아직 미구현 부분
- 업데이트 된지 2달된 토큰은 배치 서버에서 지우는 것이 적합하여 보여 작업하지 않았다.
- 푸시 알림 후 응답이 잘못된 경우는 아직 푸시 알림을 전송하는 코드가 없어서 구현하지 않았다.

## 리뷰 요구사항

- 리뷰할 때 중점적으로 봐줬으면 하는 내용들

## 스크린샷