### PR TITLE
M3-329 누적 픽셀 count 쿼리 최적화

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,19 +54,3 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           update-comment: true
           min-coverage-overall: 70
-
-  qodana:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      pull-requests: write
-      checks: write
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}  # to check out the actual pull request commit, not the merge commit
-          fetch-depth: 0  # a full history is required for pull request analysis
-      - name: 'Qodana Scan'
-        uses: JetBrains/qodana-action@v2024.1
-        env:
-          QODANA_TOKEN: ${{ secrets.QODANA_TOKEN }}

--- a/src/main/java/com/m3pro/groundflip/controller/RankingController.java
+++ b/src/main/java/com/m3pro/groundflip/controller/RankingController.java
@@ -35,7 +35,7 @@ public class RankingController {
 	public Response<List<UserRankingResponse>> getAllUserRanking(
 		@RequestParam(required = false, name = "lookup-date") @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate lookUpDate) {
 		return Response.createSuccess(
-			rankingService.getAllUserRankings(lookUpDate)
+			rankingService.getCurrentPixelAllUserRankings(lookUpDate)
 		);
 	}
 
@@ -47,6 +47,6 @@ public class RankingController {
 		@RequestParam(required = false, name = "lookup-date") @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate lookUpDate
 	) {
 		return Response.createSuccess(
-			rankingService.getUserRankInfo(userId, lookUpDate));
+			rankingService.getUserCurrentPixelRankInfo(userId, lookUpDate));
 	}
 }

--- a/src/main/java/com/m3pro/groundflip/repository/PixelUserRepository.java
+++ b/src/main/java/com/m3pro/groundflip/repository/PixelUserRepository.java
@@ -51,4 +51,6 @@ public interface PixelUserRepository extends JpaRepository<PixelUser, Long> {
 		""", nativeQuery = true)
 	void save(@Param("pixel_id") Long pixelId, @Param("user_id") Long userId,
 		@Param("community_id") Long communityId);
+
+	boolean existsByPixelIdAndUserId(Long pixelId, Long userId);
 }

--- a/src/main/java/com/m3pro/groundflip/repository/RankingRedisRepository.java
+++ b/src/main/java/com/m3pro/groundflip/repository/RankingRedisRepository.java
@@ -84,7 +84,7 @@ public class RankingRedisRepository {
 		return rankings;
 	}
 
-	public Optional<Long> getUserRank(Long userId) {
+	public Optional<Long> getUserCurrentPixelRank(Long userId) {
 		Long rank = zSetOperations.reverseRank(CURRENT_PIXEL_RANKING_KEY, userId.toString());
 		return Optional.ofNullable(rank).map(r -> r + 1);
 	}

--- a/src/main/java/com/m3pro/groundflip/repository/RankingRedisRepository.java
+++ b/src/main/java/com/m3pro/groundflip/repository/RankingRedisRepository.java
@@ -17,7 +17,8 @@ import lombok.RequiredArgsConstructor;
 @Repository
 @RequiredArgsConstructor
 public class RankingRedisRepository {
-	private static final String RANKING_KEY = "current_pixel_ranking";
+	private static final String CURRENT_PIXEL_RANKING_KEY = "current_pixel_ranking";
+	private static final String ACCUMULATE_PIXEL_RANKING_KEY = "accumulate_pixel_ranking";
 	private static final int RANKING_START_INDEX = 0;
 	private static final int RANKING_END_INDEX = 29;
 	private final RedisTemplate<String, String> redisTemplate;
@@ -29,34 +30,47 @@ public class RankingRedisRepository {
 	}
 
 	public void increaseCurrentPixelCount(Long userId) {
-		zSetOperations.incrementScore(RANKING_KEY, userId.toString(), 1);
+		zSetOperations.incrementScore(CURRENT_PIXEL_RANKING_KEY, userId.toString(), 1);
+	}
+
+	public void increaseAccumulatePixelCount(Long userId) {
+		zSetOperations.incrementScore(ACCUMULATE_PIXEL_RANKING_KEY, userId.toString(), 1);
 	}
 
 	public void decreaseCurrentPixelCount(Long userId) {
-		Double currentScore = zSetOperations.score(RANKING_KEY, userId.toString());
+		Double currentScore = zSetOperations.score(CURRENT_PIXEL_RANKING_KEY, userId.toString());
 		if (currentScore != null && currentScore > 0) {
-			zSetOperations.incrementScore(RANKING_KEY, userId.toString(), -1);
+			zSetOperations.incrementScore(CURRENT_PIXEL_RANKING_KEY, userId.toString(), -1);
 		}
 	}
 
 	public void saveUserInRanking(Long userId) {
-		Double score = zSetOperations.score(RANKING_KEY, userId.toString());
+		Double currentPixelScore = zSetOperations.score(CURRENT_PIXEL_RANKING_KEY, userId.toString());
+		Double accumulatePixelScore = zSetOperations.score(ACCUMULATE_PIXEL_RANKING_KEY, userId.toString());
 
-		if (score == null) {
-			zSetOperations.add(RANKING_KEY, userId.toString(), 0);
+		if (currentPixelScore == null) {
+			zSetOperations.add(CURRENT_PIXEL_RANKING_KEY, userId.toString(), 0);
+		}
+		if (accumulatePixelScore == null) {
+			zSetOperations.add(ACCUMULATE_PIXEL_RANKING_KEY, userId.toString(), 0);
 		}
 	}
 
 	public void deleteUserInRanking(Long userId) {
-		Double score = zSetOperations.score(RANKING_KEY, userId.toString());
+		Double currentPixelScore = zSetOperations.score(CURRENT_PIXEL_RANKING_KEY, userId.toString());
+		Double accumulatePixelScore = zSetOperations.score(ACCUMULATE_PIXEL_RANKING_KEY, userId.toString());
 
-		if (score != null) {
-			zSetOperations.remove(RANKING_KEY, userId.toString());
+		if (currentPixelScore != null) {
+			zSetOperations.remove(CURRENT_PIXEL_RANKING_KEY, userId.toString());
+		}
+		if (accumulatePixelScore == null) {
+			zSetOperations.remove(ACCUMULATE_PIXEL_RANKING_KEY, userId.toString());
 		}
 	}
 
 	public List<Ranking> getRankingsWithCurrentPixelCount() {
-		Set<ZSetOperations.TypedTuple<String>> typedTuples = zSetOperations.reverseRangeWithScores(RANKING_KEY,
+		Set<ZSetOperations.TypedTuple<String>> typedTuples = zSetOperations.reverseRangeWithScores(
+			CURRENT_PIXEL_RANKING_KEY,
 			RANKING_START_INDEX, RANKING_END_INDEX);
 		if (typedTuples == null) {
 			return new ArrayList<>();
@@ -71,12 +85,17 @@ public class RankingRedisRepository {
 	}
 
 	public Optional<Long> getUserRank(Long userId) {
-		Long rank = zSetOperations.reverseRank(RANKING_KEY, userId.toString());
+		Long rank = zSetOperations.reverseRank(CURRENT_PIXEL_RANKING_KEY, userId.toString());
 		return Optional.ofNullable(rank).map(r -> r + 1);
 	}
 
 	public Optional<Long> getUserCurrentPixelCount(Long userId) {
-		Double currentPixelCount = zSetOperations.score(RANKING_KEY, userId.toString());
+		Double currentPixelCount = zSetOperations.score(CURRENT_PIXEL_RANKING_KEY, userId.toString());
 		return Optional.ofNullable(currentPixelCount).map(Double::longValue);
+	}
+
+	public Optional<Long> getUserAccumulatePixelCount(Long userId) {
+		Double accumulatePixelCount = zSetOperations.score(ACCUMULATE_PIXEL_RANKING_KEY, userId.toString());
+		return Optional.ofNullable(accumulatePixelCount).map(Double::longValue);
 	}
 }

--- a/src/main/java/com/m3pro/groundflip/service/PixelManager.java
+++ b/src/main/java/com/m3pro/groundflip/service/PixelManager.java
@@ -69,7 +69,7 @@ public class PixelManager {
 
 		Pixel targetPixel = pixelRepository.findByXAndY(pixelOccupyRequest.getX(), pixelOccupyRequest.getY())
 			.orElseThrow(() -> new AppException(ErrorCode.PIXEL_NOT_FOUND));
-		rankingService.updateRanking(targetPixel, occupyingUserId);
+		rankingService.updateCurrentPixelRanking(targetPixel, occupyingUserId);
 		updateAccumulatePixelCount(targetPixel, occupyingUserId);
 		updatePixelOwner(targetPixel, occupyingUserId);
 

--- a/src/main/java/com/m3pro/groundflip/service/PixelManager.java
+++ b/src/main/java/com/m3pro/groundflip/service/PixelManager.java
@@ -17,6 +17,7 @@ import com.m3pro.groundflip.domain.entity.Pixel;
 import com.m3pro.groundflip.exception.AppException;
 import com.m3pro.groundflip.exception.ErrorCode;
 import com.m3pro.groundflip.repository.PixelRepository;
+import com.m3pro.groundflip.repository.PixelUserRepository;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -31,6 +32,7 @@ public class PixelManager {
 	private final RankingService rankingService;
 	private final ApplicationEventPublisher eventPublisher;
 	private final RedissonClient redissonClient;
+	private final PixelUserRepository pixelUserRepository;
 
 	/**
 	 * 픽셀을 차지한다.
@@ -68,10 +70,17 @@ public class PixelManager {
 		Pixel targetPixel = pixelRepository.findByXAndY(pixelOccupyRequest.getX(), pixelOccupyRequest.getY())
 			.orElseThrow(() -> new AppException(ErrorCode.PIXEL_NOT_FOUND));
 		rankingService.updateRanking(targetPixel, occupyingUserId);
+		updateAccumulatePixelCount(targetPixel, occupyingUserId);
 		updatePixelOwner(targetPixel, occupyingUserId);
 
 		updatePixelAddress(targetPixel);
 		eventPublisher.publishEvent(new PixelUserInsertEvent(targetPixel.getId(), occupyingUserId, communityId));
+	}
+
+	private void updateAccumulatePixelCount(Pixel targetPixel, Long userId) {
+		if (!pixelUserRepository.existsByPixelIdAndUserId(targetPixel.getId(), userId)) {
+			rankingService.updateAccumulatedRanking(userId);
+		}
 	}
 
 	private void updatePixelOwner(Pixel targetPixel, Long occupyingUserId) {

--- a/src/main/java/com/m3pro/groundflip/service/PixelReader.java
+++ b/src/main/java/com/m3pro/groundflip/service/PixelReader.java
@@ -134,13 +134,16 @@ public class PixelReader {
 	 * @author 김민욱
 	 */
 	public PixelCountResponse getPixelCount(Long userId, LocalDate lookUpDate) {
+		Long accumulatePixelCount;
 		if (lookUpDate == null) {
-			lookUpDate = LocalDate.parse(DEFAULT_LOOK_UP_DATE);
+			accumulatePixelCount = rankingService.getAccumulatePixelCount(userId);
+		} else {
+			accumulatePixelCount = pixelUserRepository.countAccumulatePixelByUserId(userId, lookUpDate.atStartOfDay());
 		}
 
 		return PixelCountResponse.builder()
 			.currentPixelCount(rankingService.getCurrentPixelCountFromCache(userId))
-			.accumulatePixelCount(pixelUserRepository.countAccumulatePixelByUserId(userId, lookUpDate.atStartOfDay()))
+			.accumulatePixelCount(accumulatePixelCount)
 			.build();
 	}
 

--- a/src/main/java/com/m3pro/groundflip/service/RankingService.java
+++ b/src/main/java/com/m3pro/groundflip/service/RankingService.java
@@ -195,7 +195,7 @@ public class RankingService {
 	 * @return 사용자의 순위
 	 */
 	private Long getUserCurrentPixelRankFromCache(Long userId) {
-		return rankingRedisRepository.getUserRank(userId)
+		return rankingRedisRepository.getUserCurrentPixelRank(userId)
 			.orElseThrow(() -> {
 				log.error("User {} not register at redis", userId);
 				return new AppException(ErrorCode.INTERNAL_SERVER_ERROR);

--- a/src/main/java/com/m3pro/groundflip/service/RankingService.java
+++ b/src/main/java/com/m3pro/groundflip/service/RankingService.java
@@ -53,6 +53,10 @@ public class RankingService {
 		}
 	}
 
+	public void updateAccumulatedRanking(Long userId) {
+		rankingRedisRepository.increaseAccumulatePixelCount(userId);
+	}
+
 	/**
 	 * 픽셀을 새로 차지하는 유저의 점수는 1증가, 빼앗긴 유저의 점수는 1감소
 	 * @param occupyingUserId 픽셀을 새로 차지하는 유저
@@ -70,6 +74,10 @@ public class RankingService {
 	 */
 	public Long getCurrentPixelCountFromCache(Long userId) {
 		return rankingRedisRepository.getUserCurrentPixelCount(userId).orElse(0L);
+	}
+
+	public Long getAccumulatePixelCount(Long userId) {
+		return rankingRedisRepository.getUserAccumulatePixelCount(userId).orElse(0L);
 	}
 
 	/**

--- a/src/test/java/com/m3pro/groundflip/repository/RankingRedisRepositoryTest.java
+++ b/src/test/java/com/m3pro/groundflip/repository/RankingRedisRepositoryTest.java
@@ -153,7 +153,7 @@ class RankingRedisRepositoryTest {
 
 	@Test
 	@DisplayName("[getUserRank] userId 에 해당하는 점수를 반환한다.")
-	void getUserRank() {
+	void getUserCurrentPixelRank() {
 		//Given
 		Long userId1 = 1L;
 		Long userId2 = 2L;
@@ -161,7 +161,7 @@ class RankingRedisRepositoryTest {
 		setRanking(userId1, userId2, userId3);
 
 		// When
-		Optional<Long> score = rankingRedisRepository.getUserRank(userId1);
+		Optional<Long> score = rankingRedisRepository.getUserCurrentPixelRank(userId1);
 
 		//Then
 		assertThat(score.isPresent()).isEqualTo(true);
@@ -171,12 +171,12 @@ class RankingRedisRepositoryTest {
 
 	@Test
 	@DisplayName("[getUserRank] 없는 userId를 넣으면 Optional에 값이 없다.")
-	void getUserRankTestNullPointException() {
+	void getUserCurrentPixelRankTestNullPointException() {
 		//Given
 		Long userId1 = 1L;
 
 		// When
-		Optional<Long> score = rankingRedisRepository.getUserRank(userId1);
+		Optional<Long> score = rankingRedisRepository.getUserCurrentPixelRank(userId1);
 
 		// Then
 		assertThat(score.isEmpty()).isEqualTo(true);

--- a/src/test/java/com/m3pro/groundflip/service/PixelReaderTest.java
+++ b/src/test/java/com/m3pro/groundflip/service/PixelReaderTest.java
@@ -295,11 +295,28 @@ public class PixelReaderTest {
 		Long userId = 1L;
 
 		when(rankingService.getCurrentPixelCountFromCache(userId)).thenReturn(3L);
+		when(rankingService.getAccumulatePixelCount(any())).thenReturn(5L);
+
+		// When
+		PixelCountResponse pixelCount = pixelReader.getPixelCount(userId, null);
+
+		// Then
+		assertEquals(pixelCount.getCurrentPixelCount(), 3L);
+		assertEquals(pixelCount.getAccumulatePixelCount(), 5L);
+	}
+
+	@Test
+	@DisplayName("[getPixelCount] lookup-date 가 있을 떄 픽셀 갯수가 정상적으로 불러와지는지 확인")
+	void getPixelCountLookupDate() {
+		// Given
+		Long userId = 1L;
+
+		when(rankingService.getCurrentPixelCountFromCache(userId)).thenReturn(3L);
 		when(pixelUserRepository.countAccumulatePixelByUserId(userId,
 			LocalDate.parse("2024-07-15").atStartOfDay())).thenReturn(5L);
 
 		// When
-		PixelCountResponse pixelCount = pixelReader.getPixelCount(userId, null);
+		PixelCountResponse pixelCount = pixelReader.getPixelCount(userId, LocalDate.parse("2024-07-15"));
 
 		// Then
 		assertEquals(pixelCount.getCurrentPixelCount(), 3L);

--- a/src/test/java/com/m3pro/groundflip/service/RankingServiceTest.java
+++ b/src/test/java/com/m3pro/groundflip/service/RankingServiceTest.java
@@ -164,7 +164,7 @@ class RankingServiceTest {
 			.build();
 		when(userRepository.findById(userId)).thenReturn(Optional.of(user));
 		when(rankingRedisRepository.getUserCurrentPixelCount(any())).thenReturn(Optional.of(15L));
-		when(rankingRedisRepository.getUserRank(any())).thenReturn(Optional.of(1L));
+		when(rankingRedisRepository.getUserCurrentPixelRank(any())).thenReturn(Optional.of(1L));
 
 		UserRankingResponse userRankingResponse = rankingService.getUserCurrentPixelRankInfo(userId, LocalDate.now());
 
@@ -183,7 +183,7 @@ class RankingServiceTest {
 			.id(1L)
 			.build()));
 
-		when(rankingRedisRepository.getUserRank(userId)).thenReturn(Optional.empty());
+		when(rankingRedisRepository.getUserCurrentPixelRank(userId)).thenReturn(Optional.empty());
 
 		AppException exception = assertThrows(AppException.class,
 			() -> rankingService.getUserCurrentPixelRankInfo(userId, LocalDate.now()));

--- a/src/test/java/com/m3pro/groundflip/service/RankingServiceTest.java
+++ b/src/test/java/com/m3pro/groundflip/service/RankingServiceTest.java
@@ -49,59 +49,59 @@ class RankingServiceTest {
 
 	@Test
 	@DisplayName("[updateRanking] 이번주에 이미 차지한 땅이라면 랭킹 업데이트 하지 않는다.")
-	void updateRanking_NoUpdate() {
+	void updateRanking_NoUpdateCurrentPixel() {
 		Long occupyingUserId = 1L;
 		Pixel targetPixel = Pixel.builder().userId(occupyingUserId).build();
 		targetPixel.updateModifiedAt(DateUtils.getThisWeekStartDate().atTime(0, 0, 0).plusDays(1));
 
-		rankingService.updateRanking(targetPixel, occupyingUserId);
+		rankingService.updateCurrentPixelRanking(targetPixel, occupyingUserId);
 
 		verify(rankingRedisRepository, never()).increaseCurrentPixelCount(occupyingUserId);
 	}
 
 	@Test
 	@DisplayName("[updateRanking] 저번주에 차지한 땅이고 차지한 사람과 차지하려는 사람이 같다면 랭킹을 업데이트한다.")
-	void updateRanking_UpdateBeforeThisWeek() {
+	void updateRanking_UpdateCurrentPixelBeforeThisWeek() {
 		Long occupyingUserId = 1L;
 		Pixel targetPixel = Pixel.builder().userId(occupyingUserId).build();
 		targetPixel.updateModifiedAt(DateUtils.getThisWeekStartDate().atTime(0, 0, 0).minusDays(3));
 
-		rankingService.updateRanking(targetPixel, occupyingUserId);
+		rankingService.updateCurrentPixelRanking(targetPixel, occupyingUserId);
 
 		verify(rankingRedisRepository, times(1)).increaseCurrentPixelCount(occupyingUserId);
 	}
 
 	@Test
 	@DisplayName("[updateRanking] 아무도 차지 한 적이 없는 땅이라면 차지하려는 사람의 점수를 추가한다.")
-	void updateRanking_NeverOccupied() {
+	void updateCurrentPixelRanking_NeverOccupied() {
 		Long occupyingUserId = 1L;
 		Pixel targetPixel = Pixel.builder().userId(null).build();
 
-		rankingService.updateRanking(targetPixel, occupyingUserId);
+		rankingService.updateCurrentPixelRanking(targetPixel, occupyingUserId);
 
 		verify(rankingRedisRepository, times(1)).increaseCurrentPixelCount(occupyingUserId);
 	}
 
 	@Test
 	@DisplayName("[updateRanking] 가장 최근에 차지한 시간이 저번주라면 지금 차지하려는 사람의 점수를 추가한다.")
-	void updateRanking_BeforeThisWeek() {
+	void updateCurrentPixelRanking_BeforeThisWeek() {
 		Long occupyingUserId = 1L;
 		Pixel targetPixel = Pixel.builder().userId(3L).build();
 		targetPixel.updateModifiedAt(DateUtils.getThisWeekStartDate().atTime(0, 0, 0).minusDays(3));
 
-		rankingService.updateRanking(targetPixel, occupyingUserId);
+		rankingService.updateCurrentPixelRanking(targetPixel, occupyingUserId);
 
 		verify(rankingRedisRepository, times(1)).increaseCurrentPixelCount(occupyingUserId);
 	}
 
 	@Test
 	@DisplayName("[updateRanking] 가장 최근에 차지한 시간이 이번주이고 차지하려는 사람과 차지한 사람이 다르면 지금 차지하려는 사람의 점수를 추가하고 차지한 사람의 점수는 감소시킨다.")
-	void updateRanking_OccupyPixel() {
+	void updateCurrentPixelRanking_OccupyPixel() {
 		Long occupyingUserId = 1L;
 		Pixel targetPixel = Pixel.builder().userId(3L).build();
 		targetPixel.updateModifiedAt(DateUtils.getThisWeekStartDate().atTime(0, 0, 0).plusDays(3));
 
-		rankingService.updateRanking(targetPixel, occupyingUserId);
+		rankingService.updateCurrentPixelRanking(targetPixel, occupyingUserId);
 
 		verify(rankingRedisRepository, times(1)).increaseCurrentPixelCount(occupyingUserId);
 		verify(rankingRedisRepository, times(1)).decreaseCurrentPixelCount(3L);
@@ -109,11 +109,11 @@ class RankingServiceTest {
 
 	@Test
 	@DisplayName("[updateRankingAfterOccupy] occupyingUserId 에 해당하는 현재 소유 픽셀의 개수를 1 증가시키고 deprivedUserId 에 해당하는 현재 소유 픽셀의 개수를 1 감소시킨다.")
-	void updateRankingAfterOccupyTest() {
+	void updateCurrentPixelRankingAfterOccupyTest() {
 		Long occupyingUserId = 1L;
 		Long deprivedUserId = 2L;
 
-		rankingService.updateRankingAfterOccupy(occupyingUserId, deprivedUserId);
+		rankingService.updateCurrentPixelRankingAfterOccupy(occupyingUserId, deprivedUserId);
 
 		verify(rankingRedisRepository, times(1)).decreaseCurrentPixelCount(deprivedUserId);
 		verify(rankingRedisRepository, times(1)).increaseCurrentPixelCount(occupyingUserId);
@@ -143,19 +143,19 @@ class RankingServiceTest {
 
 	@Test
 	@DisplayName("[getUserRankInfo] 이번주에 대해 user가 없다면 user not found")
-	void getUserRankInfoTestUserNotFoundExceptionFromCache() {
+	void getUserRankInfoTestUserCurrentPixelNotFoundExceptionFromCache() {
 		Long userId = 1L;
 		when(userRepository.findById(userId)).thenReturn(Optional.empty());
 
 		AppException exception = assertThrows(AppException.class,
-			() -> rankingService.getUserRankInfo(userId, LocalDate.now()));
+			() -> rankingService.getUserCurrentPixelRankInfo(userId, LocalDate.now()));
 
 		assertEquals(ErrorCode.USER_NOT_FOUND, exception.getErrorCode());
 	}
 
 	@Test
 	@DisplayName("[getUserRankInfo] userId에 해당하는 순위 정보 반환")
-	void getUserRankFromCacheInfoTest() {
+	void getUserCurrentPixelRankFromCacheInfoTest() {
 		Long userId = 1L;
 		User user = User.builder()
 			.id(userId)
@@ -166,7 +166,7 @@ class RankingServiceTest {
 		when(rankingRedisRepository.getUserCurrentPixelCount(any())).thenReturn(Optional.of(15L));
 		when(rankingRedisRepository.getUserRank(any())).thenReturn(Optional.of(1L));
 
-		UserRankingResponse userRankingResponse = rankingService.getUserRankInfo(userId, LocalDate.now());
+		UserRankingResponse userRankingResponse = rankingService.getUserCurrentPixelRankInfo(userId, LocalDate.now());
 
 		assertThat(userRankingResponse.getUserId()).isEqualTo(userId);
 		assertThat(userRankingResponse.getCurrentPixelCount()).isEqualTo(15L);
@@ -177,7 +177,7 @@ class RankingServiceTest {
 
 	@Test
 	@DisplayName("[getUserRankFromCache] 사용자가 Redis에 존재하지 않는다면 500 에러를 발생시킨다.")
-	void getUserRankFromCacheUserNotFoundInRedis() {
+	void getUserRankFromCacheUserCurrentPixelNotFoundInRedis() {
 		Long userId = 1L;
 		when(userRepository.findById(userId)).thenReturn(Optional.of(User.builder()
 			.id(1L)
@@ -186,7 +186,7 @@ class RankingServiceTest {
 		when(rankingRedisRepository.getUserRank(userId)).thenReturn(Optional.empty());
 
 		AppException exception = assertThrows(AppException.class,
-			() -> rankingService.getUserRankInfo(userId, LocalDate.now()));
+			() -> rankingService.getUserCurrentPixelRankInfo(userId, LocalDate.now()));
 
 		assertEquals(ErrorCode.INTERNAL_SERVER_ERROR, exception.getErrorCode());
 	}
@@ -209,7 +209,7 @@ class RankingServiceTest {
 		when(rankingRedisRepository.getRankingsWithCurrentPixelCount()).thenReturn(rankings);
 		when(userRepository.findAllById(anySet())).thenReturn(users);
 
-		List<UserRankingResponse> responses = rankingService.getAllUserRankings(LocalDate.now());
+		List<UserRankingResponse> responses = rankingService.getCurrentPixelAllUserRankings(LocalDate.now());
 
 		assertEquals(3, responses.size());
 		assertEquals(1L, responses.get(0).getUserId());
@@ -235,7 +235,7 @@ class RankingServiceTest {
 		when(userRepository.findAllById(anySet())).thenReturn(
 			users.stream().filter(user -> user.getId() != 2L).collect(Collectors.toList()));
 
-		List<UserRankingResponse> responses = rankingService.getAllUserRankings(LocalDate.now());
+		List<UserRankingResponse> responses = rankingService.getCurrentPixelAllUserRankings(LocalDate.now());
 		assertEquals(2, responses.size());
 		assertEquals(1L, responses.get(0).getUserId());
 		assertEquals(3L, responses.get(1).getUserId());
@@ -243,19 +243,19 @@ class RankingServiceTest {
 
 	@Test
 	@DisplayName("[getPastWeekUserRanking] 사용자를 찾을 수 없다면 예외가 발생한다.")
-	void getPastWeekUserRankingUserNotFound() {
+	void getPastWeekUserRankingCurrentPixelUserNotFound() {
 		Long userId = 1L;
 		when(userRepository.findById(userId)).thenReturn(Optional.empty());
 
 		AppException exception = assertThrows(AppException.class,
-			() -> rankingService.getUserRankInfo(userId, LocalDate.of(2024, 07, 17)));
+			() -> rankingService.getUserCurrentPixelRankInfo(userId, LocalDate.of(2024, 07, 17)));
 
 		assertEquals(ErrorCode.USER_NOT_FOUND, exception.getErrorCode());
 	}
 
 	@Test
 	@DisplayName("[getPastWeekUserRanking] 사용자의 과거 랭킹을 조회할 수 있다.")
-	void getPastWeekUserRankingTest() {
+	void getPastWeekCurrentPixelUserRankingTest() {
 		Long userId = 1L;
 		RankingHistory rankingHistory = RankingHistory.builder()
 			.userId(userId)
@@ -272,7 +272,7 @@ class RankingServiceTest {
 		when(rankingHistoryRepository.findByUserIdAndYearAndWeek(userId, 2024, 29))
 			.thenReturn(Optional.ofNullable(rankingHistory));
 
-		UserRankingResponse response = rankingService.getUserRankInfo(userId, LocalDate.of(2024, 7, 17));
+		UserRankingResponse response = rankingService.getUserCurrentPixelRankInfo(userId, LocalDate.of(2024, 7, 17));
 
 		Assertions.assertThat(response.getUserId()).isEqualTo(userId);
 		Assertions.assertThat(response.getRank()).isEqualTo(1L);
@@ -281,7 +281,7 @@ class RankingServiceTest {
 
 	@Test
 	@DisplayName("[getPastWeekUserRanking] 사용자의 과거 랭킹 기록이 없을 때, Null을 반환한다.")
-	void getPastWeekUserRankingHistoryNotExists() {
+	void getPastWeekCurrentPixelUserRankingHistoryNotExists() {
 		Long userId = 1L;
 		when(userRepository.findById(userId)).thenReturn(Optional.of(User.builder()
 			.id(userId)
@@ -290,10 +290,31 @@ class RankingServiceTest {
 		when(rankingHistoryRepository.findByUserIdAndYearAndWeek(userId, 2024, 29))
 			.thenReturn(Optional.empty());
 
-		UserRankingResponse response = rankingService.getUserRankInfo(userId, LocalDate.of(2024, 7, 17));
+		UserRankingResponse response = rankingService.getUserCurrentPixelRankInfo(userId, LocalDate.of(2024, 7, 17));
 
 		Assertions.assertThat(response.getUserId()).isEqualTo(userId);
 		Assertions.assertThat(response.getRank()).isEqualTo(null);
 		Assertions.assertThat(response.getCurrentPixelCount()).isEqualTo(null);
+	}
+
+	@Test
+	@DisplayName("[updateAccumulatedRanking]")
+	void updateAccumulatedRankingTest() {
+		Long userId = 1L;
+
+		rankingService.updateAccumulatedRanking(userId);
+
+		verify(rankingRedisRepository, times(1)).increaseAccumulatePixelCount(userId);
+	}
+
+	@Test
+	@DisplayName("[getAccumulatePixelCount]")
+	void getAccumulatePixelCountTest() {
+		Long userId = 1L;
+		when(rankingRedisRepository.getUserAccumulatePixelCount(any())).thenReturn(Optional.of(15L));
+
+		Long count = rankingService.getAccumulatePixelCount(userId);
+
+		assertThat(count).isEqualTo(15L);
 	}
 }


### PR DESCRIPTION
## 작업 내용*

- redis 를 사용한 집계방식으로 변경

## 고민한 내용
- DB 에 실시간으로 개수를 집계하는 것은 부하가 너무 많이 든다고 판단.
- Redis 에 미리 적용해두는 것으로 개선. 이미 방문했는지 찾는 작업은 큰 부하는 걸리지 않는다. 
- Redis Sorted set 에 저장 했기 떄문에 랭킹도 집계 가능하다.

## 리뷰 요구사항

- 리뷰할 때 중점적으로 봐줬으면 하는 내용들

## 스크린샷