### PR TITLE
M3-344 그룹 정보 반환 API 구현

### DIFF
--- a/src/main/java/com/m3pro/groundflip/controller/CommunityController.java
+++ b/src/main/java/com/m3pro/groundflip/controller/CommunityController.java
@@ -20,7 +20,7 @@ import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/groups")
+@RequestMapping("/api/communities")
 @SecurityRequirement(name = "Authorization")
 public class CommunityController {
 	private final CommunityService communityService;
@@ -34,8 +34,12 @@ public class CommunityController {
 		);
 	}
 
-	@GetMapping("/{groupId}")
-	public CommunityInfoResponse findGroupById(@PathVariable Long groupId) {
-		return communityService.findCommunityById(groupId);
+	@Operation(summary = "그룹 정보 조회", description = "특정 그룹의 정보를 반환한다.")
+	@GetMapping("/{communityId}")
+	public Response<CommunityInfoResponse> getCommunityInfo(
+		@Parameter(description = "찾고자 하는 userId", required = true)
+		@PathVariable Long communityId
+	) {
+		return Response.createSuccess(new CommunityInfoResponse());
 	}
 }

--- a/src/main/java/com/m3pro/groundflip/controller/CommunityController.java
+++ b/src/main/java/com/m3pro/groundflip/controller/CommunityController.java
@@ -16,11 +16,13 @@ import com.m3pro.groundflip.service.CommunityService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/communities")
+@Tag(name = "communities", description = "그룹 API")
 @SecurityRequirement(name = "Authorization")
 public class CommunityController {
 	private final CommunityService communityService;

--- a/src/main/java/com/m3pro/groundflip/controller/CommunityController.java
+++ b/src/main/java/com/m3pro/groundflip/controller/CommunityController.java
@@ -42,6 +42,6 @@ public class CommunityController {
 		@Parameter(description = "찾고자 하는 userId", required = true)
 		@PathVariable Long communityId
 	) {
-		return Response.createSuccess(new CommunityInfoResponse());
+		return Response.createSuccess(communityService.findCommunityById(communityId));
 	}
 }

--- a/src/main/java/com/m3pro/groundflip/domain/dto/community/CommunityInfoResponse.java
+++ b/src/main/java/com/m3pro/groundflip/domain/dto/community/CommunityInfoResponse.java
@@ -46,7 +46,7 @@ public class CommunityInfoResponse {
 		Long currentPixelCount, Long accumulatePixelCount) {
 		return CommunityInfoResponse.builder()
 			.name(community.getName())
-			.communityColor(community.getPixelColor())
+			.communityColor(community.getCommunityColor())
 			.backgroundImageUrl(community.getBackgroundImageUrl())
 			.maxPixelCount(community.getMaxPixelCount())
 			.maxRanking(community.getMaxRanking())

--- a/src/main/java/com/m3pro/groundflip/domain/dto/community/CommunityInfoResponse.java
+++ b/src/main/java/com/m3pro/groundflip/domain/dto/community/CommunityInfoResponse.java
@@ -2,6 +2,7 @@ package com.m3pro.groundflip.domain.dto.community;
 
 import com.m3pro.groundflip.domain.entity.Community;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -11,21 +12,47 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @Data
 @Builder
+@Schema(title = "개인전 픽셀 정보")
 public class CommunityInfoResponse {
+
+	@Schema(description = "그룹 이름", example = "Pixel Group")
 	private String name;
-	private String pixelColor;
-	private String profileImageUrl;
+
+	@Schema(description = "그룹 색상", example = "#FF5733")
+	private String communityColor;
+
+	@Schema(description = "그룹 배경 이미지 URL", example = "https://example.com/background.jpg")
 	private String backgroundImageUrl;
-	private int groupRanking;
+
+	@Schema(description = "그룹 랭킹", example = "1")
+	private int communityRanking;
+
+	@Schema(description = "그룹 멤버 수", example = "500")
 	private int memberCount;
 
-	public static CommunityInfoResponse from(Community community, int groupRanking, int memberCount) {
+	@Schema(description = "현재 차지하고 있는 픽셀 개수", example = "5")
+	private int currentPixelCount;
+
+	@Schema(description = "누적 픽셀 개수", example = "1000")
+	private int accumulatePixelCount;
+
+	@Schema(description = "최대 픽셀 개수", example = "5000")
+	private int maxPixelCount;
+
+	@Schema(description = "최고 랭킹", example = "1")
+	private int maxRanking;
+
+	public static CommunityInfoResponse from(Community community, int communityRanking, int memberCount,
+		int currentPixelCount, int accumulatePixelCount) {
 		return CommunityInfoResponse.builder()
 			.name(community.getName())
-			.pixelColor(community.getPixelColor())
-			.profileImageUrl(community.getProfileImageUrl())
+			.communityColor(community.getPixelColor())
 			.backgroundImageUrl(community.getBackgroundImageUrl())
-			.groupRanking(groupRanking)
+			.maxPixelCount(community.getMaxPixelCount())
+			.maxRanking(community.getMaxRanking())
+			.currentPixelCount(currentPixelCount)
+			.accumulatePixelCount(accumulatePixelCount)
+			.communityRanking(communityRanking)
 			.memberCount(memberCount)
 			.build();
 	}

--- a/src/main/java/com/m3pro/groundflip/domain/dto/community/CommunityInfoResponse.java
+++ b/src/main/java/com/m3pro/groundflip/domain/dto/community/CommunityInfoResponse.java
@@ -28,13 +28,13 @@ public class CommunityInfoResponse {
 	private int communityRanking;
 
 	@Schema(description = "그룹 멤버 수", example = "500")
-	private int memberCount;
+	private Long memberCount;
 
 	@Schema(description = "현재 차지하고 있는 픽셀 개수", example = "5")
-	private int currentPixelCount;
+	private Long currentPixelCount;
 
 	@Schema(description = "누적 픽셀 개수", example = "1000")
-	private int accumulatePixelCount;
+	private Long accumulatePixelCount;
 
 	@Schema(description = "최대 픽셀 개수", example = "5000")
 	private int maxPixelCount;
@@ -42,8 +42,8 @@ public class CommunityInfoResponse {
 	@Schema(description = "최고 랭킹", example = "1")
 	private int maxRanking;
 
-	public static CommunityInfoResponse from(Community community, int communityRanking, int memberCount,
-		int currentPixelCount, int accumulatePixelCount) {
+	public static CommunityInfoResponse from(Community community, int communityRanking, Long memberCount,
+		Long currentPixelCount, Long accumulatePixelCount) {
 		return CommunityInfoResponse.builder()
 			.name(community.getName())
 			.communityColor(community.getPixelColor())

--- a/src/main/java/com/m3pro/groundflip/domain/entity/Community.java
+++ b/src/main/java/com/m3pro/groundflip/domain/entity/Community.java
@@ -30,7 +30,7 @@ public class Community extends BaseTimeEntity {
 
 	private String name;
 
-	private String pixelColor;
+	private String communityColor;
 
 	private String profileImageUrl;
 

--- a/src/main/java/com/m3pro/groundflip/domain/entity/Community.java
+++ b/src/main/java/com/m3pro/groundflip/domain/entity/Community.java
@@ -38,6 +38,10 @@ public class Community extends BaseTimeEntity {
 
 	private String description;
 
+	private int maxPixelCount;
+
+	private int maxRanking;
+
 	private LocalDateTime deletedAt;
 
 }

--- a/src/main/java/com/m3pro/groundflip/repository/UserCommunityRepository.java
+++ b/src/main/java/com/m3pro/groundflip/repository/UserCommunityRepository.java
@@ -11,4 +11,7 @@ import com.m3pro.groundflip.domain.entity.UserCommunity;
 public interface UserCommunityRepository extends JpaRepository<UserCommunity, Long> {
 	@Query("SELECT uc FROM UserCommunity uc WHERE uc.user.id = :userId AND uc.deletedAt IS NULL")
 	List<UserCommunity> findByUserId(@Param("userId") Long userId);
+
+	@Query("SELECT COUNT(uc) FROM UserCommunity uc WHERE uc.community.id = :communityId AND uc.deletedAt IS NULL")
+	Long countByCommunityId(@Param("communityId") Long communityId);
 }

--- a/src/main/java/com/m3pro/groundflip/service/CommunityService.java
+++ b/src/main/java/com/m3pro/groundflip/service/CommunityService.java
@@ -10,14 +10,15 @@ import com.m3pro.groundflip.domain.entity.Community;
 import com.m3pro.groundflip.exception.AppException;
 import com.m3pro.groundflip.exception.ErrorCode;
 import com.m3pro.groundflip.repository.CommunityRepository;
+import com.m3pro.groundflip.repository.UserCommunityRepository;
 
 import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor
 public class CommunityService {
-
 	private final CommunityRepository communityRepository;
+	private final UserCommunityRepository userCommunityRepository;
 
 	/*
 	 * 그룹명을 검색한다
@@ -29,9 +30,15 @@ public class CommunityService {
 		return community.stream().map(CommunitySearchResponse::from).toList();
 	}
 
-	public CommunityInfoResponse findCommunityById(Long id) {
-		Community community = communityRepository.findById(id)
+	public CommunityInfoResponse findCommunityById(Long communityId) {
+		Community community = communityRepository.findById(communityId)
 			.orElseThrow(() -> new AppException(ErrorCode.GROUP_NOT_FOUND));
-		return CommunityInfoResponse.from(community, 0, 0);
+		Long memberCount = getMemberCount(community);
+		// ToDo : 랭킹 하시는 분이 구현하신 것 토대로 communityRanking, currentPixelCount, accumulatePixelCount만 채워주세요.
+		return CommunityInfoResponse.from(community, 0, memberCount, 0L, 0L);
+	}
+
+	private Long getMemberCount(Community community) {
+		return userCommunityRepository.countByCommunityId(community.getId());
 	}
 }

--- a/src/test/java/com/m3pro/groundflip/service/CommunityServiceTest.java
+++ b/src/test/java/com/m3pro/groundflip/service/CommunityServiceTest.java
@@ -1,5 +1,6 @@
 package com.m3pro.groundflip.service;
 
+import static org.assertj.core.api.AssertionsForClassTypes.*;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
@@ -19,6 +20,7 @@ import com.m3pro.groundflip.domain.entity.Community;
 import com.m3pro.groundflip.exception.AppException;
 import com.m3pro.groundflip.exception.ErrorCode;
 import com.m3pro.groundflip.repository.CommunityRepository;
+import com.m3pro.groundflip.repository.UserCommunityRepository;
 
 class CommunityServiceTest {
 	@InjectMocks
@@ -26,6 +28,9 @@ class CommunityServiceTest {
 
 	@Mock
 	private CommunityRepository communityRepository;
+
+	@Mock
+	private UserCommunityRepository userCommunityRepository;
 
 	private Community community;
 
@@ -37,6 +42,10 @@ class CommunityServiceTest {
 		community = Community.builder()
 			.id(1L)
 			.name("Test Community")
+			.communityColor("0xFF0DF69E")
+			.maxRanking(3)
+			.maxPixelCount(54)
+			.backgroundImageUrl("www.test.com")
 			.build();
 	}
 
@@ -63,6 +72,7 @@ class CommunityServiceTest {
 		// Given
 		Long communityId = 1L;
 		when(communityRepository.findById(communityId)).thenReturn(Optional.of(community));
+		when(userCommunityRepository.countByCommunityId(communityId)).thenReturn(3L);
 
 		// When
 		CommunityInfoResponse result = communityService.findCommunityById(communityId);
@@ -70,6 +80,10 @@ class CommunityServiceTest {
 		// Then
 		assertNotNull(result);
 		assertEquals("Test Community", result.getName());
+		assertThat(result.getMemberCount()).isEqualTo(3);
+		assertThat(result.getAccumulatePixelCount()).isEqualTo(0);
+		assertThat(result.getCurrentPixelCount()).isEqualTo(0);
+		assertThat(result.getCommunityRanking()).isEqualTo(0);
 	}
 
 	@Test


### PR DESCRIPTION
## 작업 내용*
- 그룹 정보 반환 API 구현

## 고민한 내용*
### 네이밍
실제 기능 이름과 코드에서 적는 이름이 다르다. 실제는 그룹이지만 그룹기능을 위해 그룹 테이블을 만들지 못한다. 왜냐하면 group 이 mySQL 예약어라서 그렇다. 따라서 테이블 이름은 community 이다.

이러다 보니 api 이름은 group 인데 메서드 이름은 community 인 상황이 발생하여 혼란 스럽다. 때문에 용어를 community 로 통일 했다. 

### max_pixel_count, max_ranking
위 두 정보는 매번 집계하기 쉽지 않는 값들이다. 때문에 비정규화 하여 컬럼에 추가하였다. occupyPixel 로직에서 업데이트 할 때 위 두 컬럼도 같이 업데이트 해주어여할 것이다.

### 랭킹
그룹에 대한 랭킹이 아직 만들어지 않아 해당부분은 반환하도록 구현을 못했다. 때문에 그룹 구현하는 사람이 넣어주어야할듯하다.
```
	public CommunityInfoResponse findCommunityById(Long communityId) {
		Community community = communityRepository.findById(communityId)
			.orElseThrow(() -> new AppException(ErrorCode.GROUP_NOT_FOUND));
		Long memberCount = getMemberCount(community);
		// ToDo : 랭킹 하시는 분이 구현하신 것 토대로 communityRanking, currentPixelCount, accumulatePixelCount만 채워주세요.
		return CommunityInfoResponse.from(community, 0, memberCount, 0L, 0L);
	}
```

해당 부분에 Todo 주석 남겨두었으니 참고 바랍니다.

## 리뷰 요구사항

- 리뷰할 때 중점적으로 봐줬으면 하는 내용들

## 스크린샷