### PR TITLE
M3-343 - 그룹 가입 api, test 작성

### DIFF
--- a/src/main/java/com/m3pro/groundflip/controller/CommunityController.java
+++ b/src/main/java/com/m3pro/groundflip/controller/CommunityController.java
@@ -4,12 +4,15 @@ import java.util.List;
 
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.m3pro.groundflip.domain.dto.Response;
 import com.m3pro.groundflip.domain.dto.community.CommunityInfoResponse;
+import com.m3pro.groundflip.domain.dto.community.CommunityJoinRequest;
 import com.m3pro.groundflip.domain.dto.community.CommunitySearchResponse;
 import com.m3pro.groundflip.service.CommunityService;
 
@@ -44,5 +47,16 @@ public class CommunityController {
 		@PathVariable Long communityId
 	) {
 		return Response.createSuccess(communityService.findCommunityById(communityId));
+	}
+
+	@Operation(summary = "그룹 가입 api", description = "유저를 특정 그룹에 가입시킨다")
+	@PostMapping("/{communityId}")
+	public Response<?> joinCommunity(
+		@Parameter(description = "가입하고자 하는 groupId", required = true)
+		@PathVariable("communityId") Long communityId,
+		@RequestBody CommunityJoinRequest communityJoinRequest
+	) {
+		communityService.joinCommunity(communityId, communityJoinRequest);
+		return Response.createSuccessWithNoData();
 	}
 }

--- a/src/main/java/com/m3pro/groundflip/domain/dto/community/CommunityJoinRequest.java
+++ b/src/main/java/com/m3pro/groundflip/domain/dto/community/CommunityJoinRequest.java
@@ -1,0 +1,18 @@
+package com.m3pro.groundflip.domain.dto.community;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Data
+@Builder
+@Schema(title = "그룹 가입 정보")
+public class CommunityJoinRequest {
+
+	@Schema(description = "가입 유저 id", example = "1")
+	private Long userId;
+}

--- a/src/main/java/com/m3pro/groundflip/exception/ErrorCode.java
+++ b/src/main/java/com/m3pro/groundflip/exception/ErrorCode.java
@@ -9,6 +9,7 @@ import lombok.Getter;
 @Getter
 public enum ErrorCode {
 	DUPLICATED_NICKNAME(HttpStatus.BAD_REQUEST, "중복된 닉네임입니다."),
+	ALREADY_JOINED(HttpStatus.BAD_REQUEST, "이미 가입된 유저입니다."),
 	USER_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 사용자입니다."),
 	GROUP_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 그룹입니다."),
 	PIXEL_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 픽셀입니다."),
@@ -16,6 +17,7 @@ public enum ErrorCode {
 	PLACE_NOT_FOUND(HttpStatus.NOT_FOUND, "장소가 등록되어 있지 않습니다."),
 	INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 에러 입니다"),
 	VERSION_NOT_FOUND(HttpStatus.NOT_FOUND, "버전이 존재하지 않습니다."),
+	COMMUNITY_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 그룹입니다."),
 
 	// 권한 관련 에러
 	UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "권한이 없습니다"),

--- a/src/main/java/com/m3pro/groundflip/repository/UserCommunityRepository.java
+++ b/src/main/java/com/m3pro/groundflip/repository/UserCommunityRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import com.m3pro.groundflip.domain.entity.User;
 import com.m3pro.groundflip.domain.entity.UserCommunity;
 
 public interface UserCommunityRepository extends JpaRepository<UserCommunity, Long> {
@@ -14,4 +15,6 @@ public interface UserCommunityRepository extends JpaRepository<UserCommunity, Lo
 
 	@Query("SELECT COUNT(uc) FROM UserCommunity uc WHERE uc.community.id = :communityId AND uc.deletedAt IS NULL")
 	Long countByCommunityId(@Param("communityId") Long communityId);
+
+	UserCommunity findByUser(User user);
 }

--- a/src/main/java/com/m3pro/groundflip/service/CommunityService.java
+++ b/src/main/java/com/m3pro/groundflip/service/CommunityService.java
@@ -5,12 +5,16 @@ import java.util.List;
 import org.springframework.stereotype.Service;
 
 import com.m3pro.groundflip.domain.dto.community.CommunityInfoResponse;
+import com.m3pro.groundflip.domain.dto.community.CommunityJoinRequest;
 import com.m3pro.groundflip.domain.dto.community.CommunitySearchResponse;
 import com.m3pro.groundflip.domain.entity.Community;
+import com.m3pro.groundflip.domain.entity.User;
+import com.m3pro.groundflip.domain.entity.UserCommunity;
 import com.m3pro.groundflip.exception.AppException;
 import com.m3pro.groundflip.exception.ErrorCode;
 import com.m3pro.groundflip.repository.CommunityRepository;
 import com.m3pro.groundflip.repository.UserCommunityRepository;
+import com.m3pro.groundflip.repository.UserRepository;
 
 import lombok.RequiredArgsConstructor;
 
@@ -19,6 +23,7 @@ import lombok.RequiredArgsConstructor;
 public class CommunityService {
 	private final CommunityRepository communityRepository;
 	private final UserCommunityRepository userCommunityRepository;
+	private final UserRepository userRepository;
 
 	/*
 	 * 그룹명을 검색한다
@@ -36,6 +41,27 @@ public class CommunityService {
 		Long memberCount = getMemberCount(community);
 		// ToDo : 랭킹 하시는 분이 구현하신 것 토대로 communityRanking, currentPixelCount, accumulatePixelCount만 채워주세요.
 		return CommunityInfoResponse.from(community, 0, memberCount, 0L, 0L);
+	}
+
+	public void joinCommunity(Long communityId, CommunityJoinRequest communityJoinRequest) {
+		User user = userRepository.findById(communityJoinRequest.getUserId())
+			.orElseThrow(() -> new AppException(ErrorCode.USER_NOT_FOUND));
+
+		Community community = communityRepository.findById(communityId)
+			.orElseThrow(() -> new AppException(ErrorCode.COMMUNITY_NOT_FOUND));
+
+		UserCommunity checkJoin = userCommunityRepository.findByUser(user);
+
+		if (checkJoin != null) {
+			throw new AppException(ErrorCode.ALREADY_JOINED);
+		}
+
+		UserCommunity userCommunity = UserCommunity.builder()
+			.user(user)
+			.community(community)
+			.build();
+
+		userCommunityRepository.save(userCommunity);
 	}
 
 	private Long getMemberCount(Community community) {

--- a/src/test/java/com/m3pro/groundflip/service/CommunityServiceTest.java
+++ b/src/test/java/com/m3pro/groundflip/service/CommunityServiceTest.java
@@ -15,12 +15,16 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
 import com.m3pro.groundflip.domain.dto.community.CommunityInfoResponse;
+import com.m3pro.groundflip.domain.dto.community.CommunityJoinRequest;
 import com.m3pro.groundflip.domain.dto.community.CommunitySearchResponse;
 import com.m3pro.groundflip.domain.entity.Community;
+import com.m3pro.groundflip.domain.entity.User;
+import com.m3pro.groundflip.domain.entity.UserCommunity;
 import com.m3pro.groundflip.exception.AppException;
 import com.m3pro.groundflip.exception.ErrorCode;
 import com.m3pro.groundflip.repository.CommunityRepository;
 import com.m3pro.groundflip.repository.UserCommunityRepository;
+import com.m3pro.groundflip.repository.UserRepository;
 
 class CommunityServiceTest {
 	@InjectMocks
@@ -32,7 +36,16 @@ class CommunityServiceTest {
 	@Mock
 	private UserCommunityRepository userCommunityRepository;
 
+	@Mock
+	private UserRepository userRepository;
+
 	private Community community;
+
+	private User user;
+
+	private UserCommunity userCommunity;
+
+	private CommunityJoinRequest communityJoinRequest;
 
 	@BeforeEach
 	void setUp() {
@@ -46,6 +59,16 @@ class CommunityServiceTest {
 			.maxRanking(3)
 			.maxPixelCount(54)
 			.backgroundImageUrl("www.test.com")
+			.build();
+
+		user = User.builder()
+			.id(1L)
+			.nickname("Test User")
+			.build();
+
+		userCommunity = UserCommunity.builder()
+			.community(community)
+			.user(user)
 			.build();
 	}
 
@@ -98,4 +121,84 @@ class CommunityServiceTest {
 			() -> communityService.findCommunityById(communityId));
 		assertEquals(ErrorCode.GROUP_NOT_FOUND, exception.getErrorCode());
 	}
+
+	@Test
+	@DisplayName("[joinCommunity] 그룹 가입 테스트")
+	void testJoinCommunity() {
+		//Given
+		Long communityId = 1L;
+		Long userId = 1L;
+
+		when(communityRepository.findById(communityId)).thenReturn(Optional.of(community));
+		when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+
+		communityJoinRequest = CommunityJoinRequest.builder()
+			.userId(userId)
+			.build();
+
+		//When
+		communityService.joinCommunity(communityId, communityJoinRequest);
+
+		//Then
+		verify(userCommunityRepository).save(any(UserCommunity.class));
+	}
+
+	@Test
+	@DisplayName("[joinCommunity] 유저가 없을때 에러 테스트")
+	void testJoinCommunity_userNotFound() {
+		// Given
+		CommunityJoinRequest communityJoinRequest2 = CommunityJoinRequest.builder()
+			.userId(2L)
+			.build();
+
+		// when
+		AppException thrown = assertThrows(AppException.class, () -> {
+			communityService.joinCommunity(2L, communityJoinRequest2);
+		});
+
+		// Then
+		assertEquals(ErrorCode.USER_NOT_FOUND, thrown.getErrorCode());
+	}
+
+	@Test
+	@DisplayName("[joinCommunity] 그룹이 없을때 에러 테스트")
+	void testJoinCommunity_communityNotFound() {
+		// Given
+		when(communityRepository.findById(2L)).thenReturn(Optional.empty());
+		when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+
+		communityJoinRequest = CommunityJoinRequest.builder()
+			.userId(1L)
+			.build();
+
+		// when
+		AppException thrown = assertThrows(AppException.class, () -> {
+			communityService.joinCommunity(2L, communityJoinRequest);
+		});
+
+		// Then
+		assertEquals(ErrorCode.COMMUNITY_NOT_FOUND, thrown.getErrorCode());
+	}
+
+	@Test
+	@DisplayName("[joinCommunity] 가입된 그룹이 이미 있을때 테스트")
+	void testJoinCommunity_alreadyJoined() {
+		// Given
+		when(communityRepository.findById(1L)).thenReturn(Optional.of(community));
+		when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+		when(userCommunityRepository.findByUser(user)).thenReturn(userCommunity);
+
+		communityJoinRequest = CommunityJoinRequest.builder()
+			.userId(1L)
+			.build();
+
+		// when
+		AppException thrown = assertThrows(AppException.class, () -> {
+			communityService.joinCommunity(1L, communityJoinRequest);
+		});
+
+		// Then
+		assertEquals(ErrorCode.ALREADY_JOINED, thrown.getErrorCode());
+	}
+
 }


### PR DESCRIPTION
## 작업 내용*

- 그룹 가입 api를 작성한다
- 유저 id, 그룹 id를 이용해 유저, 그룹을 검색해서 user_community테이블에 save한다
- 해당 user, group이 없으면 exception 반환
- 유저가 이미 가입된 그룹이 있으면 exception 반환

## 고민한 내용*
- pathvariable에 communityId
- requestbody에 userId

## 리뷰 요구사항

- 변수, 함수, 로직

## 스크린샷