### PR TITLE
M3-347 그룹 랭킹 api 구현

### DIFF
--- a/src/main/java/com/m3pro/groundflip/controller/RankingController.java
+++ b/src/main/java/com/m3pro/groundflip/controller/RankingController.java
@@ -12,7 +12,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.m3pro.groundflip.domain.dto.Response;
 import com.m3pro.groundflip.domain.dto.ranking.UserRankingResponse;
-import com.m3pro.groundflip.service.RankingService;
+import com.m3pro.groundflip.service.UserRankingService;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -28,14 +28,14 @@ import lombok.extern.slf4j.Slf4j;
 @Tag(name = "ranking", description = "랭킹 API")
 @SecurityRequirement(name = "Authorization")
 public class RankingController {
-	private final RankingService rankingService;
+	private final UserRankingService userRankingService;
 
 	@Operation(summary = "개인전 전체 랭킹 조회", description = "현재 개인전 유저들의 차지 중인 픽셀 기준으로 상위 30명의 랭킹을 반환한다.")
 	@GetMapping("/user")
 	public Response<List<UserRankingResponse>> getAllUserRanking(
 		@RequestParam(required = false, name = "lookup-date") @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate lookUpDate) {
 		return Response.createSuccess(
-			rankingService.getCurrentPixelAllUserRankings(lookUpDate)
+			userRankingService.getCurrentPixelAllUserRankings(lookUpDate)
 		);
 	}
 
@@ -47,6 +47,6 @@ public class RankingController {
 		@RequestParam(required = false, name = "lookup-date") @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate lookUpDate
 	) {
 		return Response.createSuccess(
-			rankingService.getUserCurrentPixelRankInfo(userId, lookUpDate));
+			userRankingService.getUserCurrentPixelRankInfo(userId, lookUpDate));
 	}
 }

--- a/src/main/java/com/m3pro/groundflip/controller/RankingController.java
+++ b/src/main/java/com/m3pro/groundflip/controller/RankingController.java
@@ -11,7 +11,9 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.m3pro.groundflip.domain.dto.Response;
+import com.m3pro.groundflip.domain.dto.ranking.CommunityRankingResponse;
 import com.m3pro.groundflip.domain.dto.ranking.UserRankingResponse;
+import com.m3pro.groundflip.service.CommunityRankingService;
 import com.m3pro.groundflip.service.UserRankingService;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -29,6 +31,7 @@ import lombok.extern.slf4j.Slf4j;
 @SecurityRequirement(name = "Authorization")
 public class RankingController {
 	private final UserRankingService userRankingService;
+	private final CommunityRankingService communityRankingService;
 
 	@Operation(summary = "개인전 전체 랭킹 조회", description = "현재 개인전 유저들의 차지 중인 픽셀 기준으로 상위 30명의 랭킹을 반환한다.")
 	@GetMapping("/user")
@@ -48,5 +51,14 @@ public class RankingController {
 	) {
 		return Response.createSuccess(
 			userRankingService.getUserCurrentPixelRankInfo(userId, lookUpDate));
+	}
+
+	@Operation(summary = "그룹 전체 랭킹 조회", description = "현재 그룹들의 차지 중인 픽셀 기준으로 상위 30개의 랭킹을 반환한다.")
+	@GetMapping("/community")
+	public Response<List<CommunityRankingResponse>> getAllCommunityRanking(
+		@RequestParam(required = false, name = "lookup-date") @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate lookUpDate) {
+		return Response.createSuccess(
+			communityRankingService.getCurrentPixelAllUCommunityRankings(lookUpDate)
+		);
 	}
 }

--- a/src/main/java/com/m3pro/groundflip/controller/RankingController.java
+++ b/src/main/java/com/m3pro/groundflip/controller/RankingController.java
@@ -61,4 +61,15 @@ public class RankingController {
 			communityRankingService.getCurrentPixelAllUCommunityRankings(lookUpDate)
 		);
 	}
+
+	@Operation(summary = "그룹 별 랭킹 조회", description = "특정 그룹의 현재 순위를 반환한다.")
+	@GetMapping("/community/{communityId}")
+	public Response<CommunityRankingResponse> getCommunityRank(
+		@Parameter(description = "찾고자 하는 communityId", required = true)
+		@PathVariable Long communityId,
+		@RequestParam(required = false, name = "lookup-date") @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate lookUpDate
+	) {
+		return Response.createSuccess(
+			communityRankingService.getCommunityCurrentPixelRankInfo(communityId, lookUpDate));
+	}
 }

--- a/src/main/java/com/m3pro/groundflip/domain/dto/community/CommunityInfoResponse.java
+++ b/src/main/java/com/m3pro/groundflip/domain/dto/community/CommunityInfoResponse.java
@@ -25,7 +25,7 @@ public class CommunityInfoResponse {
 	private String backgroundImageUrl;
 
 	@Schema(description = "그룹 랭킹", example = "1")
-	private int communityRanking;
+	private Long communityRanking;
 
 	@Schema(description = "그룹 멤버 수", example = "500")
 	private Long memberCount;
@@ -42,7 +42,7 @@ public class CommunityInfoResponse {
 	@Schema(description = "최고 랭킹", example = "1")
 	private int maxRanking;
 
-	public static CommunityInfoResponse from(Community community, int communityRanking, Long memberCount,
+	public static CommunityInfoResponse from(Community community, Long communityRanking, Long memberCount,
 		Long currentPixelCount, Long accumulatePixelCount) {
 		return CommunityInfoResponse.builder()
 			.name(community.getName())

--- a/src/main/java/com/m3pro/groundflip/domain/dto/pixel/PixelOccupyRequest.java
+++ b/src/main/java/com/m3pro/groundflip/domain/dto/pixel/PixelOccupyRequest.java
@@ -16,7 +16,7 @@ public class PixelOccupyRequest {
 	private Long userId;
 
 	@Schema(description = "커뮤니티 ID", nullable = true, example = "78611")
-	private Long communityId;
+	private Long communityId = -1L;
 
 	@Schema(description = "픽셀의 세로 상대좌표", example = "222")
 	private Long x;

--- a/src/main/java/com/m3pro/groundflip/domain/dto/ranking/CommunityRankingResponse.java
+++ b/src/main/java/com/m3pro/groundflip/domain/dto/ranking/CommunityRankingResponse.java
@@ -1,0 +1,49 @@
+package com.m3pro.groundflip.domain.dto.ranking;
+
+import com.m3pro.groundflip.domain.entity.Community;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Data
+@Builder
+@Schema(title = "그룹 랭킹")
+public class CommunityRankingResponse {
+	@Schema(description = "그룹 ID", example = "1234")
+	private Long communityId;
+
+	@Schema(description = "그룹 닉네임", example = "홍익대학교")
+	private String name;
+
+	@Schema(description = "그룹 프로필 사진 주소", example = "http://www.test.com")
+	private String profileImageUrl;
+
+	@Schema(description = "현재 차지하고 있는 픽셀 개수", example = "5")
+	private Long currentPixelCount;
+
+	@Schema(description = "순위", example = "4")
+	private Long rank;
+
+	public static CommunityRankingResponse from(Community community, Long rank, Long currentPixelCount) {
+		return CommunityRankingResponse.builder()
+			.communityId(community.getId())
+			.name(community.getName())
+			.profileImageUrl(community.getBackgroundImageUrl())
+			.currentPixelCount(currentPixelCount)
+			.rank(rank)
+			.build();
+	}
+
+	public static CommunityRankingResponse from(Community community) {
+		return CommunityRankingResponse.builder()
+			.communityId(community.getId())
+			.name(community.getName())
+			.profileImageUrl(community.getBackgroundImageUrl())
+			.build();
+	}
+}

--- a/src/main/java/com/m3pro/groundflip/domain/dto/ranking/Ranking.java
+++ b/src/main/java/com/m3pro/groundflip/domain/dto/ranking/Ranking.java
@@ -12,7 +12,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @Data
 public class Ranking {
-	private Long userId;
+	private Long id;
 	private Long currentPixelCount;
 	private Long rank;
 

--- a/src/main/java/com/m3pro/groundflip/domain/entity/CommunityRankingHistory.java
+++ b/src/main/java/com/m3pro/groundflip/domain/entity/CommunityRankingHistory.java
@@ -1,0 +1,36 @@
+package com.m3pro.groundflip.domain.entity;
+
+import com.m3pro.groundflip.domain.entity.global.BaseTimeEntity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class CommunityRankingHistory extends BaseTimeEntity {
+	@Id
+	@Column(name = "community_ranking_history_id")
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	Long id;
+
+	Long communityId;
+
+	Long ranking;
+
+	Long currentPixelCount;
+
+	Integer year;
+
+	Integer week;
+}

--- a/src/main/java/com/m3pro/groundflip/domain/entity/Pixel.java
+++ b/src/main/java/com/m3pro/groundflip/domain/entity/Pixel.java
@@ -1,8 +1,8 @@
 package com.m3pro.groundflip.domain.entity;
 
-import org.locationtech.jts.geom.Point;
+import java.time.LocalDateTime;
 
-import com.m3pro.groundflip.domain.entity.global.BaseTimeEntity;
+import org.locationtech.jts.geom.Point;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -20,7 +20,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder
-public class Pixel extends BaseTimeEntity {
+public class Pixel {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	@Column(name = "pixel_id")
@@ -40,11 +40,35 @@ public class Pixel extends BaseTimeEntity {
 	@Column(name = "user_id")
 	private Long userId;
 
+	private Long communityId;
+
+	private LocalDateTime createdAt;
+
+	private LocalDateTime userOccupiedAt;
+
+	private LocalDateTime communityOccupiedAt;
+
 	public void updateAddress(String address) {
 		this.address = address;
 	}
 
 	public void updateUserId(Long userId) {
 		this.userId = userId;
+	}
+
+	public void updateUserOccupiedAtToNow() {
+		userOccupiedAt = LocalDateTime.now();
+	}
+
+	public void updateCommunityOccupiedAtToNow() {
+		communityOccupiedAt = LocalDateTime.now();
+	}
+
+	public void updateUserOccupiedAt(LocalDateTime localDateTime) {
+		userOccupiedAt = localDateTime;
+	}
+
+	public void updateCommunityOccupiedAt(LocalDateTime localDateTime) {
+		communityOccupiedAt = localDateTime;
 	}
 }

--- a/src/main/java/com/m3pro/groundflip/domain/entity/Pixel.java
+++ b/src/main/java/com/m3pro/groundflip/domain/entity/Pixel.java
@@ -71,4 +71,8 @@ public class Pixel {
 	public void updateCommunityOccupiedAt(LocalDateTime localDateTime) {
 		communityOccupiedAt = localDateTime;
 	}
+
+	public void updateCommunityId(Long communityId) {
+		this.communityId = communityId;
+	}
 }

--- a/src/main/java/com/m3pro/groundflip/exception/ErrorCode.java
+++ b/src/main/java/com/m3pro/groundflip/exception/ErrorCode.java
@@ -11,7 +11,7 @@ public enum ErrorCode {
 	DUPLICATED_NICKNAME(HttpStatus.BAD_REQUEST, "중복된 닉네임입니다."),
 	ALREADY_JOINED(HttpStatus.BAD_REQUEST, "이미 가입된 유저입니다."),
 	USER_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 사용자입니다."),
-	GROUP_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 그룹입니다."),
+	COMMUNITY_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 그룹입니다."),
 	PIXEL_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 픽셀입니다."),
 	IMAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 이미지입니다."),
 	PLACE_NOT_FOUND(HttpStatus.NOT_FOUND, "장소가 등록되어 있지 않습니다."),

--- a/src/main/java/com/m3pro/groundflip/repository/CommunityRankingHistoryRepository.java
+++ b/src/main/java/com/m3pro/groundflip/repository/CommunityRankingHistoryRepository.java
@@ -1,0 +1,29 @@
+package com.m3pro.groundflip.repository;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import com.m3pro.groundflip.domain.dto.ranking.CommunityRankingResponse;
+import com.m3pro.groundflip.domain.entity.CommunityRankingHistory;
+
+public interface CommunityRankingHistoryRepository extends JpaRepository<CommunityRankingHistory, Long> {
+	@Query("""
+			SELECT new com.m3pro.groundflip.domain.dto.ranking.CommunityRankingResponse
+			(c.id, c.name, c.backgroundImageUrl, crh.currentPixelCount, crh.ranking)
+			FROM CommunityRankingHistory crh 
+			INNER JOIN Community c on c.id = crh.communityId 
+			WHERE crh.year = :requestYear AND crh.week = :requestWeek
+			ORDER BY crh.ranking ASC 
+			LIMIT 30 
+		""")
+	List<CommunityRankingResponse> findAllByYearAndWeek(@Param("requestYear") int year, @Param("requestWeek") int week);
+
+	Optional<CommunityRankingHistory> findByCommunityIdAndYearAndWeek(
+		@Param("communityId") Long communityId,
+		@Param("requestYear") int year,
+		@Param("requestWeek") int week);
+}

--- a/src/main/java/com/m3pro/groundflip/repository/CommunityRankingRedisRepository.java
+++ b/src/main/java/com/m3pro/groundflip/repository/CommunityRankingRedisRepository.java
@@ -22,4 +22,19 @@ public class CommunityRankingRedisRepository {
 		zSetOperations = redisTemplate.opsForZSet();
 	}
 
+	public void increaseCurrentPixelCount(Long communityId) {
+		zSetOperations.incrementScore(CURRENT_PIXEL_RANKING_KEY, communityId.toString(), 1);
+	}
+
+	public void decreaseCurrentPixelCount(Long communityId) {
+		Double currentScore = zSetOperations.score(CURRENT_PIXEL_RANKING_KEY, communityId.toString());
+		if (currentScore != null && currentScore > 0) {
+			zSetOperations.incrementScore(CURRENT_PIXEL_RANKING_KEY, communityId.toString(), -1);
+		}
+	}
+
+	public void increaseAccumulatePixelCount(Long communityId) {
+		zSetOperations.incrementScore(ACCUMULATE_PIXEL_RANKING_KEY, communityId.toString(), 1);
+		System.out.println("값 증가 +++++++++++++++++++++++");
+	}
 }

--- a/src/main/java/com/m3pro/groundflip/repository/CommunityRankingRedisRepository.java
+++ b/src/main/java/com/m3pro/groundflip/repository/CommunityRankingRedisRepository.java
@@ -1,8 +1,15 @@
 package com.m3pro.groundflip.repository;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.ZSetOperations;
 import org.springframework.stereotype.Repository;
+
+import com.m3pro.groundflip.domain.dto.ranking.Ranking;
 
 import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
@@ -35,6 +42,36 @@ public class CommunityRankingRedisRepository {
 
 	public void increaseAccumulatePixelCount(Long communityId) {
 		zSetOperations.incrementScore(ACCUMULATE_PIXEL_RANKING_KEY, communityId.toString(), 1);
-		System.out.println("값 증가 +++++++++++++++++++++++");
+	}
+
+	public List<Ranking> getRankingsWithCurrentPixelCount() {
+		Set<ZSetOperations.TypedTuple<String>> typedTuples = zSetOperations.reverseRangeWithScores(
+			CURRENT_PIXEL_RANKING_KEY,
+			RANKING_START_INDEX, RANKING_END_INDEX);
+		if (typedTuples == null) {
+			return new ArrayList<>();
+		}
+
+		List<Ranking> rankings = new ArrayList<>();
+		long rank = 1;
+		for (ZSetOperations.TypedTuple<String> typedTuple : typedTuples) {
+			rankings.add(Ranking.from(typedTuple, rank++));
+		}
+		return rankings;
+	}
+
+	public Optional<Long> getCommunityCurrentPixelRank(Long communityId) {
+		Long rank = zSetOperations.reverseRank(CURRENT_PIXEL_RANKING_KEY, communityId.toString());
+		return Optional.ofNullable(rank).map(r -> r + 1);
+	}
+
+	public Optional<Long> getCommunityCurrentPixelCount(Long communityId) {
+		Double currentPixelCount = zSetOperations.score(CURRENT_PIXEL_RANKING_KEY, communityId.toString());
+		return Optional.ofNullable(currentPixelCount).map(Double::longValue);
+	}
+
+	public Optional<Long> getCommunityAccumulatePixelCount(Long communityId) {
+		Double accumulatePixelCount = zSetOperations.score(ACCUMULATE_PIXEL_RANKING_KEY, communityId.toString());
+		return Optional.ofNullable(accumulatePixelCount).map(Double::longValue);
 	}
 }

--- a/src/main/java/com/m3pro/groundflip/repository/CommunityRankingRedisRepository.java
+++ b/src/main/java/com/m3pro/groundflip/repository/CommunityRankingRedisRepository.java
@@ -1,0 +1,25 @@
+package com.m3pro.groundflip.repository;
+
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ZSetOperations;
+import org.springframework.stereotype.Repository;
+
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class CommunityRankingRedisRepository {
+	private static final String CURRENT_PIXEL_RANKING_KEY = "group_current_pixel_ranking";
+	private static final String ACCUMULATE_PIXEL_RANKING_KEY = "group_accumulate_pixel_ranking";
+	private static final int RANKING_START_INDEX = 0;
+	private static final int RANKING_END_INDEX = 29;
+	private final RedisTemplate<String, String> redisTemplate;
+	private ZSetOperations<String, String> zSetOperations;
+
+	@PostConstruct
+	void init() {
+		zSetOperations = redisTemplate.opsForZSet();
+	}
+
+}

--- a/src/main/java/com/m3pro/groundflip/repository/PixelRepository.java
+++ b/src/main/java/com/m3pro/groundflip/repository/PixelRepository.java
@@ -28,7 +28,7 @@ public interface PixelRepository extends JpaRepository<Pixel, Long> {
 		WHERE
 			ST_CONTAINS((ST_Buffer(:center, :radius)), pixel.coordinate)
 			AND pixel.user_id IS NOT NULL
-			AND pixel.modified_at >= :weekStartDate
+			AND pixel.user_occupied_at >= :weekStartDate
 		""", nativeQuery = true)
 	List<IndividualModePixelResponse> findAllIndividualModePixelsByCoordinate(
 		@Param("center") Point center,

--- a/src/main/java/com/m3pro/groundflip/repository/PixelUserRepository.java
+++ b/src/main/java/com/m3pro/groundflip/repository/PixelUserRepository.java
@@ -53,4 +53,6 @@ public interface PixelUserRepository extends JpaRepository<PixelUser, Long> {
 		@Param("community_id") Long communityId);
 
 	boolean existsByPixelIdAndUserId(Long pixelId, Long userId);
+
+	boolean existsByPixelIdAndCommunityId(Long pixelId, Long communityId);
 }

--- a/src/main/java/com/m3pro/groundflip/repository/UserRankingRedisRepository.java
+++ b/src/main/java/com/m3pro/groundflip/repository/UserRankingRedisRepository.java
@@ -16,7 +16,7 @@ import lombok.RequiredArgsConstructor;
 
 @Repository
 @RequiredArgsConstructor
-public class RankingRedisRepository {
+public class UserRankingRedisRepository {
 	private static final String CURRENT_PIXEL_RANKING_KEY = "current_pixel_ranking";
 	private static final String ACCUMULATE_PIXEL_RANKING_KEY = "accumulate_pixel_ranking";
 	private static final int RANKING_START_INDEX = 0;

--- a/src/main/java/com/m3pro/groundflip/service/CommunityRankingService.java
+++ b/src/main/java/com/m3pro/groundflip/service/CommunityRankingService.java
@@ -1,12 +1,26 @@
 package com.m3pro.groundflip.service;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
 
+import com.m3pro.groundflip.domain.dto.ranking.CommunityRankingResponse;
+import com.m3pro.groundflip.domain.dto.ranking.Ranking;
+import com.m3pro.groundflip.domain.entity.Community;
+import com.m3pro.groundflip.domain.entity.CommunityRankingHistory;
 import com.m3pro.groundflip.domain.entity.Pixel;
+import com.m3pro.groundflip.exception.AppException;
+import com.m3pro.groundflip.exception.ErrorCode;
+import com.m3pro.groundflip.repository.CommunityRankingHistoryRepository;
 import com.m3pro.groundflip.repository.CommunityRankingRedisRepository;
+import com.m3pro.groundflip.repository.CommunityRepository;
 import com.m3pro.groundflip.util.DateUtils;
 
 import lombok.RequiredArgsConstructor;
@@ -17,6 +31,8 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class CommunityRankingService {
 	private final CommunityRankingRedisRepository communityRankingRedisRepository;
+	private final CommunityRepository communityRepository;
+	private final CommunityRankingHistoryRepository communityRankingHistoryRepository;
 
 	public void updateCurrentPixelRanking(Pixel targetPixel, Long occupyingCommunityId) {
 		Long originalOwnerCommunityId = targetPixel.getCommunityId();
@@ -45,5 +61,134 @@ public class CommunityRankingService {
 
 	public void updateAccumulatedRanking(Long occupyingCommunityId) {
 		communityRankingRedisRepository.increaseAccumulatePixelCount(occupyingCommunityId);
+	}
+
+	public Long getCurrentPixelCountFromCache(Long communityId) {
+		return communityRankingRedisRepository.getCommunityCurrentPixelCount(communityId).orElse(0L);
+	}
+
+	public Long getAccumulatePixelCount(Long communityId) {
+		return communityRankingRedisRepository.getCommunityAccumulatePixelCount(communityId).orElse(0L);
+	}
+
+	public List<CommunityRankingResponse> getCurrentPixelAllUCommunityRankings(LocalDate lookUpDate) {
+		if (lookUpDate == null) {
+			lookUpDate = LocalDate.now();
+		}
+
+		if (DateUtils.isDateInCurrentWeek(lookUpDate)) {
+			return getCurrentWeekCurrentPixelRankings();
+		} else {
+			return getPastWeekCurrentPixelRankingsByDate(lookUpDate);
+		}
+	}
+
+	private List<CommunityRankingResponse> getPastWeekCurrentPixelRankingsByDate(LocalDate lookUpDate) {
+		return communityRankingHistoryRepository.findAllByYearAndWeek(
+			lookUpDate.getYear(),
+			DateUtils.getWeekOfDate(lookUpDate)
+		);
+	}
+
+	private List<CommunityRankingResponse> getCurrentWeekCurrentPixelRankings() {
+		List<Ranking> rankings = communityRankingRedisRepository.getRankingsWithCurrentPixelCount();
+		Map<Long, Community> communities = getRankedCommunities(rankings);
+
+		rankings = filterNotExistCommunities(rankings, communities);
+
+		return rankings.stream()
+			.map(ranking -> {
+				Community community = communities.get(ranking.getId());
+				return CommunityRankingResponse.from(community, ranking.getRank(), ranking.getCurrentPixelCount());
+			})
+			.collect(Collectors.toList());
+	}
+
+	private List<Ranking> filterNotExistCommunities(List<Ranking> rankings, Map<Long, Community> communities) {
+		return rankings.stream()
+			.filter(ranking -> {
+				if (communities.containsKey(ranking.getId())) {
+					return true;
+				} else {
+					log.error("[filterNotExistUsers] communityId {}은 데이터베이스에 존재하지 않음", ranking.getId());
+					return false;
+				}
+			})
+			.toList();
+	}
+
+	/**
+	 * 30위 안에 있는 그룹 entity 를 반환한다.
+	 * @param rankings 랭킹 정보 (그룹 id 와 rank, 점수만 들어있음)
+	 * @return Map 형식의 Community 엔티티
+	 */
+	private Map<Long, Community> getRankedCommunities(List<Ranking> rankings) {
+		Set<Long> communityIds = rankings.stream()
+			.map(Ranking::getId)
+			.collect(Collectors.toSet());
+
+		List<Community> communities = communityRepository.findAllById(communityIds);
+
+		return communities.stream()
+			.collect(Collectors.toMap(Community::getId, community -> community));
+	}
+
+	/**
+	 * 그룹의 순위 정보를 반환한다.
+	 * @param communityId 그룹 Id
+	 * @return 그룹의 순위 정보
+	 */
+	public CommunityRankingResponse getCommunityCurrentPixelRankInfo(Long communityId, LocalDate lookUpDate) {
+		if (lookUpDate == null) {
+			lookUpDate = LocalDate.now();
+		}
+
+		if (DateUtils.isDateInCurrentWeek(lookUpDate)) {
+			return getCurrentWeekCurrentPixelCommunityRanking(communityId);
+		} else {
+			return getPastWeekCurrentPixelCommunityRanking(communityId, lookUpDate);
+		}
+	}
+
+	private CommunityRankingResponse getPastWeekCurrentPixelCommunityRanking(Long communityId, LocalDate lookUpDate) {
+		Community community = communityRepository.findById(communityId)
+			.orElseThrow(() -> new AppException(ErrorCode.COMMUNITY_NOT_FOUND));
+
+		Optional<CommunityRankingHistory> rankingHistory = communityRankingHistoryRepository.findByCommunityIdAndYearAndWeek(
+			communityId,
+			lookUpDate.getYear(),
+			DateUtils.getWeekOfDate(lookUpDate)
+		);
+
+		if (rankingHistory.isPresent()) {
+			return CommunityRankingResponse.from(
+				community,
+				rankingHistory.get().getRanking(),
+				rankingHistory.get().getCurrentPixelCount());
+		} else {
+			return CommunityRankingResponse.from(community);
+		}
+	}
+
+	private CommunityRankingResponse getCurrentWeekCurrentPixelCommunityRanking(Long communityId) {
+		Community community = communityRepository.findById(communityId)
+			.orElseThrow(() -> new AppException(ErrorCode.COMMUNITY_NOT_FOUND));
+
+		Long rank = getCommunityCurrentPixelRankFromCache(communityId);
+		Long currentPixelCount = getCurrentPixelCountFromCache(communityId);
+		return CommunityRankingResponse.from(community, rank, currentPixelCount);
+	}
+
+	/**
+	 * 그룹의 순위를 반환한다
+	 * @param communityId 그룹 Id
+	 * @return 그룹의 순위
+	 */
+	private Long getCommunityCurrentPixelRankFromCache(Long communityId) {
+		return communityRankingRedisRepository.getCommunityCurrentPixelRank(communityId)
+			.orElseThrow(() -> {
+				log.error("Community {} not register at redis", communityId);
+				return new AppException(ErrorCode.INTERNAL_SERVER_ERROR);
+			});
 	}
 }

--- a/src/main/java/com/m3pro/groundflip/service/CommunityRankingService.java
+++ b/src/main/java/com/m3pro/groundflip/service/CommunityRankingService.java
@@ -2,8 +2,8 @@ package com.m3pro.groundflip.service;
 
 import org.springframework.stereotype.Service;
 
+import com.m3pro.groundflip.repository.CommunityRankingRedisRepository;
 import com.m3pro.groundflip.repository.RankingHistoryRepository;
-import com.m3pro.groundflip.repository.UserRankingRedisRepository;
 import com.m3pro.groundflip.repository.UserRepository;
 
 import lombok.RequiredArgsConstructor;
@@ -13,8 +13,8 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 @Slf4j
 public class CommunityRankingService {
-	private final UserRankingRedisRepository userRankingRedisRepository;
+	private final CommunityRankingRedisRepository communityRankingRedisRepository;
 	private final UserRepository userRepository;
 	private final RankingHistoryRepository rankingHistoryRepository;
-
+	
 }

--- a/src/main/java/com/m3pro/groundflip/service/CommunityRankingService.java
+++ b/src/main/java/com/m3pro/groundflip/service/CommunityRankingService.java
@@ -184,7 +184,7 @@ public class CommunityRankingService {
 	 * @param communityId 그룹 Id
 	 * @return 그룹의 순위
 	 */
-	private Long getCommunityCurrentPixelRankFromCache(Long communityId) {
+	public Long getCommunityCurrentPixelRankFromCache(Long communityId) {
 		return communityRankingRedisRepository.getCommunityCurrentPixelRank(communityId)
 			.orElseThrow(() -> {
 				log.error("Community {} not register at redis", communityId);

--- a/src/main/java/com/m3pro/groundflip/service/CommunityRankingService.java
+++ b/src/main/java/com/m3pro/groundflip/service/CommunityRankingService.java
@@ -1,0 +1,20 @@
+package com.m3pro.groundflip.service;
+
+import org.springframework.stereotype.Service;
+
+import com.m3pro.groundflip.repository.RankingHistoryRepository;
+import com.m3pro.groundflip.repository.UserRankingRedisRepository;
+import com.m3pro.groundflip.repository.UserRepository;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class CommunityRankingService {
+	private final UserRankingRedisRepository userRankingRedisRepository;
+	private final UserRepository userRepository;
+	private final RankingHistoryRepository rankingHistoryRepository;
+
+}

--- a/src/main/java/com/m3pro/groundflip/service/CommunityService.java
+++ b/src/main/java/com/m3pro/groundflip/service/CommunityService.java
@@ -37,7 +37,7 @@ public class CommunityService {
 
 	public CommunityInfoResponse findCommunityById(Long communityId) {
 		Community community = communityRepository.findById(communityId)
-			.orElseThrow(() -> new AppException(ErrorCode.GROUP_NOT_FOUND));
+			.orElseThrow(() -> new AppException(ErrorCode.COMMUNITY_NOT_FOUND));
 		Long memberCount = getMemberCount(community);
 		// ToDo : 랭킹 하시는 분이 구현하신 것 토대로 communityRanking, currentPixelCount, accumulatePixelCount만 채워주세요.
 		return CommunityInfoResponse.from(community, 0, memberCount, 0L, 0L);

--- a/src/main/java/com/m3pro/groundflip/service/CommunityService.java
+++ b/src/main/java/com/m3pro/groundflip/service/CommunityService.java
@@ -23,6 +23,7 @@ import lombok.RequiredArgsConstructor;
 public class CommunityService {
 	private final CommunityRepository communityRepository;
 	private final UserCommunityRepository userCommunityRepository;
+	private final CommunityRankingService communityRankingService;
 	private final UserRepository userRepository;
 
 	/*
@@ -40,7 +41,10 @@ public class CommunityService {
 			.orElseThrow(() -> new AppException(ErrorCode.COMMUNITY_NOT_FOUND));
 		Long memberCount = getMemberCount(community);
 		// ToDo : 랭킹 하시는 분이 구현하신 것 토대로 communityRanking, currentPixelCount, accumulatePixelCount만 채워주세요.
-		return CommunityInfoResponse.from(community, 0, memberCount, 0L, 0L);
+		Long rank = communityRankingService.getCommunityCurrentPixelRankFromCache(communityId);
+		Long currentPixel = communityRankingService.getCurrentPixelCountFromCache(communityId);
+		Long accumulatePixel = communityRankingService.getAccumulatePixelCount(communityId);
+		return CommunityInfoResponse.from(community, rank, memberCount, currentPixel, accumulatePixel);
 	}
 
 	public void joinCommunity(Long communityId, CommunityJoinRequest communityJoinRequest) {

--- a/src/main/java/com/m3pro/groundflip/service/PixelManager.java
+++ b/src/main/java/com/m3pro/groundflip/service/PixelManager.java
@@ -1,6 +1,5 @@
 package com.m3pro.groundflip.service;
 
-import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
@@ -72,9 +71,10 @@ public class PixelManager {
 			.orElseThrow(() -> new AppException(ErrorCode.PIXEL_NOT_FOUND));
 
 		userRankingService.updateCurrentPixelRanking(targetPixel, occupyingUserId);
-
 		updateAccumulatePixelCount(targetPixel, occupyingUserId);
-		updatePixelOwner(targetPixel, occupyingUserId);
+		updatePixelOwnUser(targetPixel, occupyingUserId);
+
+		pixelRepository.saveAndFlush(targetPixel);
 
 		updatePixelAddress(targetPixel);
 		eventPublisher.publishEvent(new PixelUserInsertEvent(targetPixel.getId(), occupyingUserId, communityId));
@@ -86,13 +86,9 @@ public class PixelManager {
 		}
 	}
 
-	private void updatePixelOwner(Pixel targetPixel, Long occupyingUserId) {
-		if (Objects.equals(targetPixel.getUserId(), occupyingUserId)) {
-			targetPixel.updateModifiedAtToNow();
-		} else {
-			targetPixel.updateUserId(occupyingUserId);
-		}
-		pixelRepository.saveAndFlush(targetPixel);
+	private void updatePixelOwnUser(Pixel targetPixel, Long occupyingUserId) {
+		targetPixel.updateUserId(occupyingUserId);
+		targetPixel.updateUserOccupiedAtToNow();
 	}
 
 	/**

--- a/src/main/java/com/m3pro/groundflip/service/PixelManager.java
+++ b/src/main/java/com/m3pro/groundflip/service/PixelManager.java
@@ -26,6 +26,7 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class PixelManager {
 	private static final String REDISSON_LOCK_PREFIX = "LOCK:";
+	private static final Long DEFAULT_COMMUNITY_ID = -1L;
 
 	private final PixelRepository pixelRepository;
 	private final UserRankingService userRankingService;
@@ -65,30 +66,56 @@ public class PixelManager {
 
 	private void occupyPixel(PixelOccupyRequest pixelOccupyRequest) {
 		Long occupyingUserId = pixelOccupyRequest.getUserId();
-		Long communityId = Optional.ofNullable(pixelOccupyRequest.getCommunityId()).orElse(-1L);
+		Long occupyingCommunityId = Optional.ofNullable(pixelOccupyRequest.getCommunityId()).orElse(-1L);
 
 		Pixel targetPixel = pixelRepository.findByXAndY(pixelOccupyRequest.getX(), pixelOccupyRequest.getY())
 			.orElseThrow(() -> new AppException(ErrorCode.PIXEL_NOT_FOUND));
 
 		userRankingService.updateCurrentPixelRanking(targetPixel, occupyingUserId);
-		updateAccumulatePixelCount(targetPixel, occupyingUserId);
-		updatePixelOwnUser(targetPixel, occupyingUserId);
+		updateUserAccumulatePixelCount(targetPixel, occupyingUserId);
+		updatePixelOwnerUser(targetPixel, occupyingUserId);
+
+		updateCommunityCurrentPixelCount(targetPixel, occupyingCommunityId);
+		updateCommunityAccumulatePixelCount(targetPixel, occupyingCommunityId);
+		updatePixelOwnerCommunity(targetPixel, occupyingCommunityId);
 
 		pixelRepository.saveAndFlush(targetPixel);
-
+		
 		updatePixelAddress(targetPixel);
-		eventPublisher.publishEvent(new PixelUserInsertEvent(targetPixel.getId(), occupyingUserId, communityId));
+		eventPublisher.publishEvent(
+			new PixelUserInsertEvent(targetPixel.getId(), occupyingUserId, occupyingCommunityId));
 	}
 
-	private void updateAccumulatePixelCount(Pixel targetPixel, Long userId) {
+	private void updateCommunityAccumulatePixelCount(Pixel targetPixel, Long communityId) {
+		if (!pixelUserRepository.existsByPixelIdAndCommunityId(targetPixel.getId(), communityId)) {
+			if (!communityId.equals(DEFAULT_COMMUNITY_ID)) {
+				communityRankingService.updateAccumulatedRanking(communityId);
+			}
+		}
+	}
+
+	private void updateUserAccumulatePixelCount(Pixel targetPixel, Long userId) {
 		if (!pixelUserRepository.existsByPixelIdAndUserId(targetPixel.getId(), userId)) {
 			userRankingService.updateAccumulatedRanking(userId);
 		}
 	}
 
-	private void updatePixelOwnUser(Pixel targetPixel, Long occupyingUserId) {
+	private void updateCommunityCurrentPixelCount(Pixel targetPixel, Long communityId) {
+		if (!communityId.equals(DEFAULT_COMMUNITY_ID)) {
+			communityRankingService.updateCurrentPixelRanking(targetPixel, communityId);
+		}
+	}
+
+	private void updatePixelOwnerUser(Pixel targetPixel, Long occupyingUserId) {
 		targetPixel.updateUserId(occupyingUserId);
 		targetPixel.updateUserOccupiedAtToNow();
+	}
+
+	private void updatePixelOwnerCommunity(Pixel targetPixel, Long occupyingCommunityId) {
+		if (!occupyingCommunityId.equals(DEFAULT_COMMUNITY_ID)) {
+			targetPixel.updateCommunityId(occupyingCommunityId);
+			targetPixel.updateCommunityOccupiedAtToNow();
+		}
 	}
 
 	/**

--- a/src/main/java/com/m3pro/groundflip/service/PixelManager.java
+++ b/src/main/java/com/m3pro/groundflip/service/PixelManager.java
@@ -29,7 +29,8 @@ public class PixelManager {
 	private static final String REDISSON_LOCK_PREFIX = "LOCK:";
 
 	private final PixelRepository pixelRepository;
-	private final RankingService rankingService;
+	private final UserRankingService userRankingService;
+	private final CommunityRankingService communityRankingService;
 	private final ApplicationEventPublisher eventPublisher;
 	private final RedissonClient redissonClient;
 	private final PixelUserRepository pixelUserRepository;
@@ -69,7 +70,9 @@ public class PixelManager {
 
 		Pixel targetPixel = pixelRepository.findByXAndY(pixelOccupyRequest.getX(), pixelOccupyRequest.getY())
 			.orElseThrow(() -> new AppException(ErrorCode.PIXEL_NOT_FOUND));
-		rankingService.updateCurrentPixelRanking(targetPixel, occupyingUserId);
+
+		userRankingService.updateCurrentPixelRanking(targetPixel, occupyingUserId);
+
 		updateAccumulatePixelCount(targetPixel, occupyingUserId);
 		updatePixelOwner(targetPixel, occupyingUserId);
 
@@ -79,7 +82,7 @@ public class PixelManager {
 
 	private void updateAccumulatePixelCount(Pixel targetPixel, Long userId) {
 		if (!pixelUserRepository.existsByPixelIdAndUserId(targetPixel.getId(), userId)) {
-			rankingService.updateAccumulatedRanking(userId);
+			userRankingService.updateAccumulatedRanking(userId);
 		}
 	}
 

--- a/src/main/java/com/m3pro/groundflip/service/PixelReader.java
+++ b/src/main/java/com/m3pro/groundflip/service/PixelReader.java
@@ -41,7 +41,7 @@ public class PixelReader {
 	private final PixelRepository pixelRepository;
 	private final PixelUserRepository pixelUserRepository;
 	private final UserRepository userRepository;
-	private final RankingService rankingService;
+	private final UserRankingService userRankingService;
 
 	/**
 	 * 사용자를 중심으로 일정한 반경 내에 개인전 픽셀들을 가져온다.
@@ -136,13 +136,13 @@ public class PixelReader {
 	public PixelCountResponse getPixelCount(Long userId, LocalDate lookUpDate) {
 		Long accumulatePixelCount;
 		if (lookUpDate == null) {
-			accumulatePixelCount = rankingService.getAccumulatePixelCount(userId);
+			accumulatePixelCount = userRankingService.getAccumulatePixelCount(userId);
 		} else {
 			accumulatePixelCount = pixelUserRepository.countAccumulatePixelByUserId(userId, lookUpDate.atStartOfDay());
 		}
 
 		return PixelCountResponse.builder()
-			.currentPixelCount(rankingService.getCurrentPixelCountFromCache(userId))
+			.currentPixelCount(userRankingService.getCurrentPixelCountFromCache(userId))
 			.accumulatePixelCount(accumulatePixelCount)
 			.build();
 	}
@@ -159,7 +159,7 @@ public class PixelReader {
 		} else {
 			Long accumulatePixelCount = pixelUserRepository.countAccumulatePixelByUserId(ownerUserId,
 				LocalDate.parse(DEFAULT_LOOK_UP_DATE).atStartOfDay());
-			Long currentPixelCount = rankingService.getCurrentPixelCountFromCache(ownerUserId);
+			Long currentPixelCount = userRankingService.getCurrentPixelCountFromCache(ownerUserId);
 			User ownerUser = userRepository.findById(ownerUserId)
 				.orElseThrow(() -> {
 					log.error("pixel {} 의 소유자가 {} 인데 존재하지 않음.", pixel.getId(), ownerUserId);

--- a/src/main/java/com/m3pro/groundflip/service/UserRankingService.java
+++ b/src/main/java/com/m3pro/groundflip/service/UserRankingService.java
@@ -37,15 +37,15 @@ public class UserRankingService {
 	public void updateCurrentPixelRanking(Pixel targetPixel, Long occupyingUserId) {
 		Long originalOwnerUserId = targetPixel.getUserId();
 		LocalDateTime thisWeekStart = DateUtils.getThisWeekStartDate().atTime(0, 0);
-		LocalDateTime modifiedAt = targetPixel.getModifiedAt();
+		LocalDateTime userOccupiedAt = targetPixel.getUserOccupiedAt();
 
 		if (Objects.equals(originalOwnerUserId, occupyingUserId)) {
-			if (modifiedAt.isAfter(thisWeekStart)) {
+			if (userOccupiedAt.isAfter(thisWeekStart)) {
 				return;
 			}
 			userRankingRedisRepository.increaseCurrentPixelCount(occupyingUserId);
 		} else {
-			if (originalOwnerUserId == null || modifiedAt.isBefore(thisWeekStart)) {
+			if (originalOwnerUserId == null || userOccupiedAt.isBefore(thisWeekStart)) {
 				userRankingRedisRepository.increaseCurrentPixelCount(occupyingUserId);
 			} else {
 				updateCurrentPixelRankingAfterOccupy(occupyingUserId, originalOwnerUserId);

--- a/src/main/java/com/m3pro/groundflip/service/UserRankingService.java
+++ b/src/main/java/com/m3pro/groundflip/service/UserRankingService.java
@@ -19,7 +19,7 @@ import com.m3pro.groundflip.domain.entity.User;
 import com.m3pro.groundflip.exception.AppException;
 import com.m3pro.groundflip.exception.ErrorCode;
 import com.m3pro.groundflip.repository.RankingHistoryRepository;
-import com.m3pro.groundflip.repository.RankingRedisRepository;
+import com.m3pro.groundflip.repository.UserRankingRedisRepository;
 import com.m3pro.groundflip.repository.UserRepository;
 import com.m3pro.groundflip.util.DateUtils;
 
@@ -29,8 +29,8 @@ import lombok.extern.slf4j.Slf4j;
 @Service
 @RequiredArgsConstructor
 @Slf4j
-public class RankingService {
-	private final RankingRedisRepository rankingRedisRepository;
+public class UserRankingService {
+	private final UserRankingRedisRepository userRankingRedisRepository;
 	private final UserRepository userRepository;
 	private final RankingHistoryRepository rankingHistoryRepository;
 
@@ -43,10 +43,10 @@ public class RankingService {
 			if (modifiedAt.isAfter(thisWeekStart)) {
 				return;
 			}
-			rankingRedisRepository.increaseCurrentPixelCount(occupyingUserId);
+			userRankingRedisRepository.increaseCurrentPixelCount(occupyingUserId);
 		} else {
 			if (originalOwnerUserId == null || modifiedAt.isBefore(thisWeekStart)) {
-				rankingRedisRepository.increaseCurrentPixelCount(occupyingUserId);
+				userRankingRedisRepository.increaseCurrentPixelCount(occupyingUserId);
 			} else {
 				updateCurrentPixelRankingAfterOccupy(occupyingUserId, originalOwnerUserId);
 			}
@@ -54,7 +54,7 @@ public class RankingService {
 	}
 
 	public void updateAccumulatedRanking(Long userId) {
-		rankingRedisRepository.increaseAccumulatePixelCount(userId);
+		userRankingRedisRepository.increaseAccumulatePixelCount(userId);
 	}
 
 	/**
@@ -63,8 +63,8 @@ public class RankingService {
 	 * @param deprivedUserId 픽셀을 뺴앗긴 유저
 	 */
 	public void updateCurrentPixelRankingAfterOccupy(Long occupyingUserId, Long deprivedUserId) {
-		rankingRedisRepository.increaseCurrentPixelCount(occupyingUserId);
-		rankingRedisRepository.decreaseCurrentPixelCount(deprivedUserId);
+		userRankingRedisRepository.increaseCurrentPixelCount(occupyingUserId);
+		userRankingRedisRepository.decreaseCurrentPixelCount(deprivedUserId);
 	}
 
 	/**
@@ -73,11 +73,11 @@ public class RankingService {
 	 * @return 현재 소유한 픽셀의 개수
 	 */
 	public Long getCurrentPixelCountFromCache(Long userId) {
-		return rankingRedisRepository.getUserCurrentPixelCount(userId).orElse(0L);
+		return userRankingRedisRepository.getUserCurrentPixelCount(userId).orElse(0L);
 	}
 
 	public Long getAccumulatePixelCount(Long userId) {
-		return rankingRedisRepository.getUserAccumulatePixelCount(userId).orElse(0L);
+		return userRankingRedisRepository.getUserAccumulatePixelCount(userId).orElse(0L);
 	}
 
 	/**
@@ -104,7 +104,7 @@ public class RankingService {
 	}
 
 	private List<UserRankingResponse> getCurrentWeekCurrentPixelRankings() {
-		List<Ranking> rankings = rankingRedisRepository.getRankingsWithCurrentPixelCount();
+		List<Ranking> rankings = userRankingRedisRepository.getRankingsWithCurrentPixelCount();
 		Map<Long, User> users = getRankedUsers(rankings);
 
 		rankings = filterNotExistUsers(rankings, users);
@@ -195,7 +195,7 @@ public class RankingService {
 	 * @return 사용자의 순위
 	 */
 	private Long getUserCurrentPixelRankFromCache(Long userId) {
-		return rankingRedisRepository.getUserCurrentPixelRank(userId)
+		return userRankingRedisRepository.getUserCurrentPixelRank(userId)
 			.orElseThrow(() -> {
 				log.error("User {} not register at redis", userId);
 				return new AppException(ErrorCode.INTERNAL_SERVER_ERROR);

--- a/src/main/java/com/m3pro/groundflip/service/UserRankingService.java
+++ b/src/main/java/com/m3pro/groundflip/service/UserRankingService.java
@@ -111,7 +111,7 @@ public class UserRankingService {
 
 		return rankings.stream()
 			.map(ranking -> {
-				User user = users.get(ranking.getUserId());
+				User user = users.get(ranking.getId());
 				return UserRankingResponse.from(user, ranking.getRank(), ranking.getCurrentPixelCount());
 			})
 			.collect(Collectors.toList());
@@ -120,10 +120,10 @@ public class UserRankingService {
 	private List<Ranking> filterNotExistUsers(List<Ranking> rankings, Map<Long, User> users) {
 		return rankings.stream()
 			.filter(ranking -> {
-				if (users.containsKey(ranking.getUserId())) {
+				if (users.containsKey(ranking.getId())) {
 					return true;
 				} else {
-					log.error("[filterNotExistUsers] userId {}은 데이터베이스에 존재하지 않음", ranking.getUserId());
+					log.error("[filterNotExistUsers] userId {}은 데이터베이스에 존재하지 않음", ranking.getId());
 					return false;
 				}
 			})
@@ -137,7 +137,7 @@ public class UserRankingService {
 	 */
 	private Map<Long, User> getRankedUsers(List<Ranking> rankings) {
 		Set<Long> userIds = rankings.stream()
-			.map(Ranking::getUserId)
+			.map(Ranking::getId)
 			.collect(Collectors.toSet());
 		List<User> users = userRepository.findAllById(userIds);
 		return users.stream()

--- a/src/main/java/com/m3pro/groundflip/service/UserService.java
+++ b/src/main/java/com/m3pro/groundflip/service/UserService.java
@@ -22,8 +22,8 @@ import com.m3pro.groundflip.exception.ErrorCode;
 import com.m3pro.groundflip.jwt.JwtProvider;
 import com.m3pro.groundflip.repository.AppleRefreshTokenRepository;
 import com.m3pro.groundflip.repository.FcmTokenRepository;
-import com.m3pro.groundflip.repository.RankingRedisRepository;
 import com.m3pro.groundflip.repository.UserCommunityRepository;
+import com.m3pro.groundflip.repository.UserRankingRedisRepository;
 import com.m3pro.groundflip.repository.UserRepository;
 import com.m3pro.groundflip.service.oauth.AppleApiClient;
 import com.m3pro.groundflip.util.S3Uploader;
@@ -36,7 +36,7 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 @Slf4j
 public class UserService {
-	private final RankingRedisRepository rankingRedisRepository;
+	private final UserRankingRedisRepository userRankingRedisRepository;
 	private final UserRepository userRepository;
 	private final AppleRefreshTokenRepository appleRefreshTokenRepository;
 	private final UserCommunityRepository userCommunityRepository;
@@ -99,7 +99,7 @@ public class UserService {
 		user.updateStatus(UserStatus.COMPLETE);
 		user.updateProfileImage(fileS3Url);
 		userRepository.save(user);
-		rankingRedisRepository.saveUserInRanking(user.getId());
+		userRankingRedisRepository.saveUserInRanking(user.getId());
 	}
 
 	private Date convertToDate(int year) {
@@ -134,7 +134,7 @@ public class UserService {
 		jwtProvider.expireToken(userDeleteRequest.getAccessToken());
 		jwtProvider.expireToken(userDeleteRequest.getRefreshToken());
 
-		rankingRedisRepository.deleteUserInRanking(userId);
+		userRankingRedisRepository.deleteUserInRanking(userId);
 	}
 
 	private void revokeAppleToken(Long userId) {

--- a/src/test/java/com/m3pro/groundflip/repository/PixelRepositoryTest.java
+++ b/src/test/java/com/m3pro/groundflip/repository/PixelRepositoryTest.java
@@ -2,6 +2,7 @@ package com.m3pro.groundflip.repository;
 
 import static org.assertj.core.api.Assertions.*;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -91,7 +92,8 @@ public class PixelRepositoryTest {
 
 	private Pixel savePixel(double latitude, double longitude, Long x, Long y, Long userId) {
 		Point point = createPoint(longitude, latitude);
-		return pixelRepository.save(Pixel.builder().coordinate(point).userId(userId).x(x).y(y).build());
+		return pixelRepository.save(
+			Pixel.builder().userOccupiedAt(LocalDateTime.now()).coordinate(point).userId(userId).x(x).y(y).build());
 	}
 
 	private Point createPoint(double longitude, double latitude) {

--- a/src/test/java/com/m3pro/groundflip/repository/UserRankingRedisRepositoryTest.java
+++ b/src/test/java/com/m3pro/groundflip/repository/UserRankingRedisRepositoryTest.java
@@ -19,10 +19,10 @@ import com.m3pro.groundflip.domain.dto.ranking.Ranking;
 
 @SpringBootTest
 @ActiveProfiles("test")
-class RankingRedisRepositoryTest {
+class UserRankingRedisRepositoryTest {
 	private static final String RANKING_KEY = "current_pixel_ranking";
 	@Autowired
-	RankingRedisRepository rankingRedisRepository;
+	UserRankingRedisRepository userRankingRedisRepository;
 	@Autowired
 	private RedisTemplate<String, String> redisTemplate;
 
@@ -40,10 +40,10 @@ class RankingRedisRepositoryTest {
 		//Given
 		ZSetOperations<String, String> zSetOperations = redisTemplate.opsForZSet();
 		Long userId = 1L;
-		rankingRedisRepository.saveUserInRanking(userId);
+		userRankingRedisRepository.saveUserInRanking(userId);
 
 		// When
-		rankingRedisRepository.increaseCurrentPixelCount(userId);
+		userRankingRedisRepository.increaseCurrentPixelCount(userId);
 
 		// Then
 		Double score = zSetOperations.score(RANKING_KEY, userId.toString());
@@ -58,7 +58,7 @@ class RankingRedisRepositoryTest {
 		Long userId = 1L;
 
 		// When
-		rankingRedisRepository.increaseCurrentPixelCount(userId);
+		userRankingRedisRepository.increaseCurrentPixelCount(userId);
 
 		// Then
 		Double score = zSetOperations.score(RANKING_KEY, userId.toString());
@@ -71,12 +71,12 @@ class RankingRedisRepositoryTest {
 		//Given
 		ZSetOperations<String, String> zSetOperations = redisTemplate.opsForZSet();
 		Long userId = 1L;
-		rankingRedisRepository.saveUserInRanking(userId);
-		rankingRedisRepository.increaseCurrentPixelCount(userId);
-		rankingRedisRepository.increaseCurrentPixelCount(userId);
+		userRankingRedisRepository.saveUserInRanking(userId);
+		userRankingRedisRepository.increaseCurrentPixelCount(userId);
+		userRankingRedisRepository.increaseCurrentPixelCount(userId);
 
 		// When
-		rankingRedisRepository.decreaseCurrentPixelCount(userId);
+		userRankingRedisRepository.decreaseCurrentPixelCount(userId);
 
 		// Then
 		Double score = zSetOperations.score(RANKING_KEY, userId.toString());
@@ -89,10 +89,10 @@ class RankingRedisRepositoryTest {
 		//Given
 		ZSetOperations<String, String> zSetOperations = redisTemplate.opsForZSet();
 		Long userId = 1L;
-		rankingRedisRepository.saveUserInRanking(userId);
+		userRankingRedisRepository.saveUserInRanking(userId);
 
 		// When
-		rankingRedisRepository.decreaseCurrentPixelCount(userId);
+		userRankingRedisRepository.decreaseCurrentPixelCount(userId);
 
 		// Then
 		Double score = zSetOperations.score(RANKING_KEY, userId.toString());
@@ -107,7 +107,7 @@ class RankingRedisRepositoryTest {
 		Long userId = 1L;
 
 		// When
-		rankingRedisRepository.saveUserInRanking(userId);
+		userRankingRedisRepository.saveUserInRanking(userId);
 
 		// Then
 		Double score = zSetOperations.score(RANKING_KEY, userId.toString());
@@ -122,7 +122,7 @@ class RankingRedisRepositoryTest {
 		Long userId = 1L;
 
 		// When
-		rankingRedisRepository.deleteUserInRanking(userId);
+		userRankingRedisRepository.deleteUserInRanking(userId);
 
 		// Then
 		Double score = zSetOperations.score(RANKING_KEY, userId.toString());
@@ -139,7 +139,7 @@ class RankingRedisRepositoryTest {
 		setRanking(userId1, userId2, userId3);
 
 		// When
-		List<Ranking> rankings = rankingRedisRepository.getRankingsWithCurrentPixelCount();
+		List<Ranking> rankings = userRankingRedisRepository.getRankingsWithCurrentPixelCount();
 
 		//Then
 		assertThat(rankings).hasSize(3);
@@ -161,7 +161,7 @@ class RankingRedisRepositoryTest {
 		setRanking(userId1, userId2, userId3);
 
 		// When
-		Optional<Long> score = rankingRedisRepository.getUserCurrentPixelRank(userId1);
+		Optional<Long> score = userRankingRedisRepository.getUserCurrentPixelRank(userId1);
 
 		//Then
 		assertThat(score.isPresent()).isEqualTo(true);
@@ -176,7 +176,7 @@ class RankingRedisRepositoryTest {
 		Long userId1 = 1L;
 
 		// When
-		Optional<Long> score = rankingRedisRepository.getUserCurrentPixelRank(userId1);
+		Optional<Long> score = userRankingRedisRepository.getUserCurrentPixelRank(userId1);
 
 		// Then
 		assertThat(score.isEmpty()).isEqualTo(true);
@@ -192,7 +192,7 @@ class RankingRedisRepositoryTest {
 		setRanking(userId1, userId2, userId3);
 
 		// When
-		Optional<Long> currentPixelCount = rankingRedisRepository.getUserCurrentPixelCount(userId1);
+		Optional<Long> currentPixelCount = userRankingRedisRepository.getUserCurrentPixelCount(userId1);
 
 		//Then
 		assertThat(currentPixelCount.isPresent()).isEqualTo(true);
@@ -207,22 +207,22 @@ class RankingRedisRepositoryTest {
 		Long userId1 = 1L;
 
 		// When
-		Optional<Long> currentPixelCount = rankingRedisRepository.getUserCurrentPixelCount(userId1);
+		Optional<Long> currentPixelCount = userRankingRedisRepository.getUserCurrentPixelCount(userId1);
 
 		// Then
 		assertThat(currentPixelCount.isEmpty()).isEqualTo(true);
 	}
 
 	private void setRanking(Long userId1, Long userId2, Long userId3) {
-		rankingRedisRepository.saveUserInRanking(userId1);
-		rankingRedisRepository.saveUserInRanking(userId2);
-		rankingRedisRepository.saveUserInRanking(userId3);
+		userRankingRedisRepository.saveUserInRanking(userId1);
+		userRankingRedisRepository.saveUserInRanking(userId2);
+		userRankingRedisRepository.saveUserInRanking(userId3);
 
-		rankingRedisRepository.increaseCurrentPixelCount(userId1);
-		rankingRedisRepository.increaseCurrentPixelCount(userId1);
-		rankingRedisRepository.increaseCurrentPixelCount(userId2);
-		rankingRedisRepository.increaseCurrentPixelCount(userId3);
-		rankingRedisRepository.increaseCurrentPixelCount(userId3);
-		rankingRedisRepository.increaseCurrentPixelCount(userId3);
+		userRankingRedisRepository.increaseCurrentPixelCount(userId1);
+		userRankingRedisRepository.increaseCurrentPixelCount(userId1);
+		userRankingRedisRepository.increaseCurrentPixelCount(userId2);
+		userRankingRedisRepository.increaseCurrentPixelCount(userId3);
+		userRankingRedisRepository.increaseCurrentPixelCount(userId3);
+		userRankingRedisRepository.increaseCurrentPixelCount(userId3);
 	}
 }

--- a/src/test/java/com/m3pro/groundflip/repository/UserRankingRedisRepositoryTest.java
+++ b/src/test/java/com/m3pro/groundflip/repository/UserRankingRedisRepositoryTest.java
@@ -143,9 +143,9 @@ class UserRankingRedisRepositoryTest {
 
 		//Then
 		assertThat(rankings).hasSize(3);
-		assertThat(rankings.get(0).getUserId()).isEqualTo(userId3);
-		assertThat(rankings.get(1).getUserId()).isEqualTo(userId1);
-		assertThat(rankings.get(2).getUserId()).isEqualTo(userId2);
+		assertThat(rankings.get(0).getId()).isEqualTo(userId3);
+		assertThat(rankings.get(1).getId()).isEqualTo(userId1);
+		assertThat(rankings.get(2).getId()).isEqualTo(userId2);
 		assertThat(rankings.get(0).getRank()).isEqualTo(1);
 		assertThat(rankings.get(1).getRank()).isEqualTo(2);
 		assertThat(rankings.get(2).getRank()).isEqualTo(3);

--- a/src/test/java/com/m3pro/groundflip/service/AuthServiceTest.java
+++ b/src/test/java/com/m3pro/groundflip/service/AuthServiceTest.java
@@ -26,7 +26,7 @@ import com.m3pro.groundflip.enums.UserStatus;
 import com.m3pro.groundflip.jwt.JwtProvider;
 import com.m3pro.groundflip.repository.AppleRefreshTokenRepository;
 import com.m3pro.groundflip.repository.PermissionRepository;
-import com.m3pro.groundflip.repository.RankingRedisRepository;
+import com.m3pro.groundflip.repository.UserRankingRedisRepository;
 import com.m3pro.groundflip.repository.UserRepository;
 import com.m3pro.groundflip.service.oauth.OauthService;
 
@@ -39,7 +39,7 @@ class AuthServiceTest {
 	@Mock
 	private UserRepository userRepository;
 	@Mock
-	private RankingRedisRepository rankingRedisRepository;
+	private UserRankingRedisRepository userRankingRedisRepository;
 	@Mock
 	private AppleRefreshTokenRepository appleRefreshTokenRepository;
 	@Mock
@@ -115,7 +115,7 @@ class AuthServiceTest {
 		verify(userRepository, times(1)).save(any(User.class));
 		verify(jwtProvider, times(1)).createAccessToken(newUser.getId());
 		verify(jwtProvider, times(1)).createRefreshToken(newUser.getId());
-		verifyNoMoreInteractions(oauthUserInfoService, userRepository, jwtProvider, rankingRedisRepository);
+		verifyNoMoreInteractions(oauthUserInfoService, userRepository, jwtProvider, userRankingRedisRepository);
 	}
 
 	@Test
@@ -237,7 +237,7 @@ class AuthServiceTest {
 		verify(appleRefreshTokenRepository, times(1)).save(any(AppleRefreshToken.class));
 		verify(jwtProvider, times(1)).createAccessToken(newUser.getId());
 		verify(jwtProvider, times(1)).createRefreshToken(newUser.getId());
-		verifyNoMoreInteractions(oauthUserInfoService, userRepository, jwtProvider, rankingRedisRepository);
+		verifyNoMoreInteractions(oauthUserInfoService, userRepository, jwtProvider, userRankingRedisRepository);
 	}
 
 	@Test

--- a/src/test/java/com/m3pro/groundflip/service/CommunityServiceTest.java
+++ b/src/test/java/com/m3pro/groundflip/service/CommunityServiceTest.java
@@ -119,7 +119,7 @@ class CommunityServiceTest {
 		// When & Then
 		AppException exception = assertThrows(AppException.class,
 			() -> communityService.findCommunityById(communityId));
-		assertEquals(ErrorCode.GROUP_NOT_FOUND, exception.getErrorCode());
+		assertEquals(ErrorCode.COMMUNITY_NOT_FOUND, exception.getErrorCode());
 	}
 
 	@Test

--- a/src/test/java/com/m3pro/groundflip/service/PixelManagerTest.java
+++ b/src/test/java/com/m3pro/groundflip/service/PixelManagerTest.java
@@ -37,6 +37,8 @@ class PixelManagerTest {
 	private RedissonClient redissonClient;
 	@Mock
 	private UserRankingService userRankingService;
+	@Mock
+	private CommunityRankingService communityRankingService;
 	@InjectMocks
 	private PixelManager pixelManager;
 
@@ -60,6 +62,7 @@ class PixelManagerTest {
 		//Then
 		verify(userRankingService, times(1)).updateCurrentPixelRanking(any(), any());
 		verify(userRankingService, times(1)).updateAccumulatedRanking(any());
+		verify(communityRankingService, times(1)).updateCurrentPixelRanking(any(), any());
 		assertEquals(5L, pixel.getUserId());
 	}
 
@@ -81,6 +84,7 @@ class PixelManagerTest {
 		// Then
 		verify(applicationEventPublisher, times(1)).publishEvent(any(PixelUserInsertEvent.class));
 		verify(userRankingService, times(1)).updateAccumulatedRanking(any());
+		verify(communityRankingService, times(1)).updateCurrentPixelRanking(any(), any());
 	}
 
 	@Test
@@ -101,6 +105,7 @@ class PixelManagerTest {
 		// Then
 		verify(applicationEventPublisher, times(1)).publishEvent(any(PixelAddressUpdateEvent.class));
 		verify(userRankingService, times(1)).updateAccumulatedRanking(any());
+		verify(communityRankingService, times(1)).updateCurrentPixelRanking(any(), any());
 	}
 
 	@Test
@@ -121,6 +126,7 @@ class PixelManagerTest {
 		// Then
 		verify(applicationEventPublisher, times(0)).publishEvent(any(PixelAddressUpdateEvent.class));
 		verify(userRankingService, times(1)).updateAccumulatedRanking(any());
+		verify(communityRankingService, times(1)).updateCurrentPixelRanking(any(), any());
 	}
 
 	static class RedissonLock implements RLock {

--- a/src/test/java/com/m3pro/groundflip/service/PixelManagerTest.java
+++ b/src/test/java/com/m3pro/groundflip/service/PixelManagerTest.java
@@ -36,7 +36,7 @@ class PixelManagerTest {
 	@Mock
 	private RedissonClient redissonClient;
 	@Mock
-	private RankingService rankingService;
+	private UserRankingService userRankingService;
 	@InjectMocks
 	private PixelManager pixelManager;
 
@@ -58,8 +58,8 @@ class PixelManagerTest {
 		pixelManager.occupyPixelWithLock(pixelOccupyRequest);
 
 		//Then
-		verify(rankingService, times(1)).updateCurrentPixelRanking(any(), any());
-		verify(rankingService, times(1)).updateAccumulatedRanking(any());
+		verify(userRankingService, times(1)).updateCurrentPixelRanking(any(), any());
+		verify(userRankingService, times(1)).updateAccumulatedRanking(any());
 		assertEquals(5L, pixel.getUserId());
 	}
 
@@ -80,7 +80,7 @@ class PixelManagerTest {
 
 		// Then
 		verify(applicationEventPublisher, times(1)).publishEvent(any(PixelUserInsertEvent.class));
-		verify(rankingService, times(1)).updateAccumulatedRanking(any());
+		verify(userRankingService, times(1)).updateAccumulatedRanking(any());
 	}
 
 	@Test
@@ -100,7 +100,7 @@ class PixelManagerTest {
 
 		// Then
 		verify(applicationEventPublisher, times(1)).publishEvent(any(PixelAddressUpdateEvent.class));
-		verify(rankingService, times(1)).updateAccumulatedRanking(any());
+		verify(userRankingService, times(1)).updateAccumulatedRanking(any());
 	}
 
 	@Test
@@ -120,7 +120,7 @@ class PixelManagerTest {
 
 		// Then
 		verify(applicationEventPublisher, times(0)).publishEvent(any(PixelAddressUpdateEvent.class));
-		verify(rankingService, times(1)).updateAccumulatedRanking(any());
+		verify(userRankingService, times(1)).updateAccumulatedRanking(any());
 	}
 
 	static class RedissonLock implements RLock {

--- a/src/test/java/com/m3pro/groundflip/service/PixelReaderTest.java
+++ b/src/test/java/com/m3pro/groundflip/service/PixelReaderTest.java
@@ -42,7 +42,7 @@ public class PixelReaderTest {
 	@Mock
 	private UserRepository userRepository;
 	@Mock
-	private RankingService rankingService;
+	private UserRankingService userRankingService;
 	@InjectMocks
 	private PixelReader pixelReader;
 
@@ -120,7 +120,7 @@ public class PixelReaderTest {
 		when(userRepository.findById(ownerId)).thenReturn(Optional.of(ownerUser));
 		when(pixelUserRepository.countAccumulatePixelByUserId(ownerId,
 			LocalDate.parse("2024-07-15").atStartOfDay())).thenReturn(10L);
-		when(rankingService.getCurrentPixelCountFromCache(ownerId)).thenReturn(5L);
+		when(userRankingService.getCurrentPixelCountFromCache(ownerId)).thenReturn(5L);
 
 		// When
 		IndividualPixelInfoResponse response = pixelReader.getIndividualModePixelInfo(pixelId);
@@ -294,8 +294,8 @@ public class PixelReaderTest {
 		// Given
 		Long userId = 1L;
 
-		when(rankingService.getCurrentPixelCountFromCache(userId)).thenReturn(3L);
-		when(rankingService.getAccumulatePixelCount(any())).thenReturn(5L);
+		when(userRankingService.getCurrentPixelCountFromCache(userId)).thenReturn(3L);
+		when(userRankingService.getAccumulatePixelCount(any())).thenReturn(5L);
 
 		// When
 		PixelCountResponse pixelCount = pixelReader.getPixelCount(userId, null);
@@ -311,7 +311,7 @@ public class PixelReaderTest {
 		// Given
 		Long userId = 1L;
 
-		when(rankingService.getCurrentPixelCountFromCache(userId)).thenReturn(3L);
+		when(userRankingService.getCurrentPixelCountFromCache(userId)).thenReturn(3L);
 		when(pixelUserRepository.countAccumulatePixelByUserId(userId,
 			LocalDate.parse("2024-07-15").atStartOfDay())).thenReturn(5L);
 

--- a/src/test/java/com/m3pro/groundflip/service/UserRankingServiceTest.java
+++ b/src/test/java/com/m3pro/groundflip/service/UserRankingServiceTest.java
@@ -52,7 +52,7 @@ class UserRankingServiceTest {
 	void updateRanking_NoUpdateCurrentPixel() {
 		Long occupyingUserId = 1L;
 		Pixel targetPixel = Pixel.builder().userId(occupyingUserId).build();
-		targetPixel.updateModifiedAt(DateUtils.getThisWeekStartDate().atTime(0, 0, 0).plusDays(1));
+		targetPixel.updateUserOccupiedAt(DateUtils.getThisWeekStartDate().atTime(0, 0, 0).plusDays(1));
 
 		userRankingService.updateCurrentPixelRanking(targetPixel, occupyingUserId);
 
@@ -64,7 +64,7 @@ class UserRankingServiceTest {
 	void updateRanking_UpdateCurrentPixelBeforeThisWeek() {
 		Long occupyingUserId = 1L;
 		Pixel targetPixel = Pixel.builder().userId(occupyingUserId).build();
-		targetPixel.updateModifiedAt(DateUtils.getThisWeekStartDate().atTime(0, 0, 0).minusDays(3));
+		targetPixel.updateUserOccupiedAt(DateUtils.getThisWeekStartDate().atTime(0, 0, 0).minusDays(3));
 
 		userRankingService.updateCurrentPixelRanking(targetPixel, occupyingUserId);
 
@@ -87,7 +87,7 @@ class UserRankingServiceTest {
 	void updateCurrentPixelRanking_BeforeThisWeek() {
 		Long occupyingUserId = 1L;
 		Pixel targetPixel = Pixel.builder().userId(3L).build();
-		targetPixel.updateModifiedAt(DateUtils.getThisWeekStartDate().atTime(0, 0, 0).minusDays(3));
+		targetPixel.updateUserOccupiedAt(DateUtils.getThisWeekStartDate().atTime(0, 0, 0).minusDays(3));
 
 		userRankingService.updateCurrentPixelRanking(targetPixel, occupyingUserId);
 
@@ -99,7 +99,7 @@ class UserRankingServiceTest {
 	void updateCurrentPixelRanking_OccupyPixel() {
 		Long occupyingUserId = 1L;
 		Pixel targetPixel = Pixel.builder().userId(3L).build();
-		targetPixel.updateModifiedAt(DateUtils.getThisWeekStartDate().atTime(0, 0, 0).plusDays(3));
+		targetPixel.updateUserOccupiedAt(DateUtils.getThisWeekStartDate().atTime(0, 0, 0).plusDays(3));
 
 		userRankingService.updateCurrentPixelRanking(targetPixel, occupyingUserId);
 

--- a/src/test/java/com/m3pro/groundflip/service/UserRankingServiceTest.java
+++ b/src/test/java/com/m3pro/groundflip/service/UserRankingServiceTest.java
@@ -27,24 +27,24 @@ import com.m3pro.groundflip.domain.entity.User;
 import com.m3pro.groundflip.exception.AppException;
 import com.m3pro.groundflip.exception.ErrorCode;
 import com.m3pro.groundflip.repository.RankingHistoryRepository;
-import com.m3pro.groundflip.repository.RankingRedisRepository;
+import com.m3pro.groundflip.repository.UserRankingRedisRepository;
 import com.m3pro.groundflip.repository.UserRepository;
 import com.m3pro.groundflip.util.DateUtils;
 
 @ExtendWith(MockitoExtension.class)
-class RankingServiceTest {
+class UserRankingServiceTest {
 	@Mock
-	private RankingRedisRepository rankingRedisRepository;
+	private UserRankingRedisRepository userRankingRedisRepository;
 	@Mock
 	private RankingHistoryRepository rankingHistoryRepository;
 	@Mock
 	private UserRepository userRepository;
 	@InjectMocks
-	private RankingService rankingService;
+	private UserRankingService userRankingService;
 
 	@BeforeEach
 	void init() {
-		reset(rankingRedisRepository);
+		reset(userRankingRedisRepository);
 	}
 
 	@Test
@@ -54,9 +54,9 @@ class RankingServiceTest {
 		Pixel targetPixel = Pixel.builder().userId(occupyingUserId).build();
 		targetPixel.updateModifiedAt(DateUtils.getThisWeekStartDate().atTime(0, 0, 0).plusDays(1));
 
-		rankingService.updateCurrentPixelRanking(targetPixel, occupyingUserId);
+		userRankingService.updateCurrentPixelRanking(targetPixel, occupyingUserId);
 
-		verify(rankingRedisRepository, never()).increaseCurrentPixelCount(occupyingUserId);
+		verify(userRankingRedisRepository, never()).increaseCurrentPixelCount(occupyingUserId);
 	}
 
 	@Test
@@ -66,9 +66,9 @@ class RankingServiceTest {
 		Pixel targetPixel = Pixel.builder().userId(occupyingUserId).build();
 		targetPixel.updateModifiedAt(DateUtils.getThisWeekStartDate().atTime(0, 0, 0).minusDays(3));
 
-		rankingService.updateCurrentPixelRanking(targetPixel, occupyingUserId);
+		userRankingService.updateCurrentPixelRanking(targetPixel, occupyingUserId);
 
-		verify(rankingRedisRepository, times(1)).increaseCurrentPixelCount(occupyingUserId);
+		verify(userRankingRedisRepository, times(1)).increaseCurrentPixelCount(occupyingUserId);
 	}
 
 	@Test
@@ -77,9 +77,9 @@ class RankingServiceTest {
 		Long occupyingUserId = 1L;
 		Pixel targetPixel = Pixel.builder().userId(null).build();
 
-		rankingService.updateCurrentPixelRanking(targetPixel, occupyingUserId);
+		userRankingService.updateCurrentPixelRanking(targetPixel, occupyingUserId);
 
-		verify(rankingRedisRepository, times(1)).increaseCurrentPixelCount(occupyingUserId);
+		verify(userRankingRedisRepository, times(1)).increaseCurrentPixelCount(occupyingUserId);
 	}
 
 	@Test
@@ -89,9 +89,9 @@ class RankingServiceTest {
 		Pixel targetPixel = Pixel.builder().userId(3L).build();
 		targetPixel.updateModifiedAt(DateUtils.getThisWeekStartDate().atTime(0, 0, 0).minusDays(3));
 
-		rankingService.updateCurrentPixelRanking(targetPixel, occupyingUserId);
+		userRankingService.updateCurrentPixelRanking(targetPixel, occupyingUserId);
 
-		verify(rankingRedisRepository, times(1)).increaseCurrentPixelCount(occupyingUserId);
+		verify(userRankingRedisRepository, times(1)).increaseCurrentPixelCount(occupyingUserId);
 	}
 
 	@Test
@@ -101,10 +101,10 @@ class RankingServiceTest {
 		Pixel targetPixel = Pixel.builder().userId(3L).build();
 		targetPixel.updateModifiedAt(DateUtils.getThisWeekStartDate().atTime(0, 0, 0).plusDays(3));
 
-		rankingService.updateCurrentPixelRanking(targetPixel, occupyingUserId);
+		userRankingService.updateCurrentPixelRanking(targetPixel, occupyingUserId);
 
-		verify(rankingRedisRepository, times(1)).increaseCurrentPixelCount(occupyingUserId);
-		verify(rankingRedisRepository, times(1)).decreaseCurrentPixelCount(3L);
+		verify(userRankingRedisRepository, times(1)).increaseCurrentPixelCount(occupyingUserId);
+		verify(userRankingRedisRepository, times(1)).decreaseCurrentPixelCount(3L);
 	}
 
 	@Test
@@ -113,19 +113,19 @@ class RankingServiceTest {
 		Long occupyingUserId = 1L;
 		Long deprivedUserId = 2L;
 
-		rankingService.updateCurrentPixelRankingAfterOccupy(occupyingUserId, deprivedUserId);
+		userRankingService.updateCurrentPixelRankingAfterOccupy(occupyingUserId, deprivedUserId);
 
-		verify(rankingRedisRepository, times(1)).decreaseCurrentPixelCount(deprivedUserId);
-		verify(rankingRedisRepository, times(1)).increaseCurrentPixelCount(occupyingUserId);
+		verify(userRankingRedisRepository, times(1)).decreaseCurrentPixelCount(deprivedUserId);
+		verify(userRankingRedisRepository, times(1)).increaseCurrentPixelCount(occupyingUserId);
 	}
 
 	@Test
 	@DisplayName("[getCurrentPixelCount] userId 가 소유한 픽셀의 개수를 반환한다.")
 	void getCurrentPixelCountFromCacheTest() {
 		Long userId = 1L;
-		when(rankingRedisRepository.getUserCurrentPixelCount(any())).thenReturn(Optional.of(15L));
+		when(userRankingRedisRepository.getUserCurrentPixelCount(any())).thenReturn(Optional.of(15L));
 
-		Long count = rankingService.getCurrentPixelCountFromCache(userId);
+		Long count = userRankingService.getCurrentPixelCountFromCache(userId);
 
 		assertThat(count).isEqualTo(15L);
 	}
@@ -134,9 +134,9 @@ class RankingServiceTest {
 	@DisplayName("[getCurrentPixelCount] userId가 sortedSet에 없다면 0 반환")
 	void getCurrentPixelCountFromCacheTestNull() {
 		Long userId = 1L;
-		when(rankingRedisRepository.getUserCurrentPixelCount(any())).thenReturn(Optional.empty());
+		when(userRankingRedisRepository.getUserCurrentPixelCount(any())).thenReturn(Optional.empty());
 
-		Long count = rankingService.getCurrentPixelCountFromCache(userId);
+		Long count = userRankingService.getCurrentPixelCountFromCache(userId);
 
 		assertThat(count).isEqualTo(0L);
 	}
@@ -148,7 +148,7 @@ class RankingServiceTest {
 		when(userRepository.findById(userId)).thenReturn(Optional.empty());
 
 		AppException exception = assertThrows(AppException.class,
-			() -> rankingService.getUserCurrentPixelRankInfo(userId, LocalDate.now()));
+			() -> userRankingService.getUserCurrentPixelRankInfo(userId, LocalDate.now()));
 
 		assertEquals(ErrorCode.USER_NOT_FOUND, exception.getErrorCode());
 	}
@@ -163,10 +163,11 @@ class RankingServiceTest {
 			.profileImage("test")
 			.build();
 		when(userRepository.findById(userId)).thenReturn(Optional.of(user));
-		when(rankingRedisRepository.getUserCurrentPixelCount(any())).thenReturn(Optional.of(15L));
-		when(rankingRedisRepository.getUserCurrentPixelRank(any())).thenReturn(Optional.of(1L));
+		when(userRankingRedisRepository.getUserCurrentPixelCount(any())).thenReturn(Optional.of(15L));
+		when(userRankingRedisRepository.getUserCurrentPixelRank(any())).thenReturn(Optional.of(1L));
 
-		UserRankingResponse userRankingResponse = rankingService.getUserCurrentPixelRankInfo(userId, LocalDate.now());
+		UserRankingResponse userRankingResponse = userRankingService.getUserCurrentPixelRankInfo(userId,
+			LocalDate.now());
 
 		assertThat(userRankingResponse.getUserId()).isEqualTo(userId);
 		assertThat(userRankingResponse.getCurrentPixelCount()).isEqualTo(15L);
@@ -183,10 +184,10 @@ class RankingServiceTest {
 			.id(1L)
 			.build()));
 
-		when(rankingRedisRepository.getUserCurrentPixelRank(userId)).thenReturn(Optional.empty());
+		when(userRankingRedisRepository.getUserCurrentPixelRank(userId)).thenReturn(Optional.empty());
 
 		AppException exception = assertThrows(AppException.class,
-			() -> rankingService.getUserCurrentPixelRankInfo(userId, LocalDate.now()));
+			() -> userRankingService.getUserCurrentPixelRankInfo(userId, LocalDate.now()));
 
 		assertEquals(ErrorCode.INTERNAL_SERVER_ERROR, exception.getErrorCode());
 	}
@@ -206,10 +207,10 @@ class RankingServiceTest {
 			User.builder().id(3L).nickname("User3").profileImage("url3").build()
 		);
 
-		when(rankingRedisRepository.getRankingsWithCurrentPixelCount()).thenReturn(rankings);
+		when(userRankingRedisRepository.getRankingsWithCurrentPixelCount()).thenReturn(rankings);
 		when(userRepository.findAllById(anySet())).thenReturn(users);
 
-		List<UserRankingResponse> responses = rankingService.getCurrentPixelAllUserRankings(LocalDate.now());
+		List<UserRankingResponse> responses = userRankingService.getCurrentPixelAllUserRankings(LocalDate.now());
 
 		assertEquals(3, responses.size());
 		assertEquals(1L, responses.get(0).getUserId());
@@ -231,11 +232,11 @@ class RankingServiceTest {
 			User.builder().id(2L).nickname("User2").profileImage("url2").build(),
 			User.builder().id(3L).nickname("User3").profileImage("url3").build()
 		);
-		when(rankingRedisRepository.getRankingsWithCurrentPixelCount()).thenReturn(rankings);
+		when(userRankingRedisRepository.getRankingsWithCurrentPixelCount()).thenReturn(rankings);
 		when(userRepository.findAllById(anySet())).thenReturn(
 			users.stream().filter(user -> user.getId() != 2L).collect(Collectors.toList()));
 
-		List<UserRankingResponse> responses = rankingService.getCurrentPixelAllUserRankings(LocalDate.now());
+		List<UserRankingResponse> responses = userRankingService.getCurrentPixelAllUserRankings(LocalDate.now());
 		assertEquals(2, responses.size());
 		assertEquals(1L, responses.get(0).getUserId());
 		assertEquals(3L, responses.get(1).getUserId());
@@ -248,7 +249,7 @@ class RankingServiceTest {
 		when(userRepository.findById(userId)).thenReturn(Optional.empty());
 
 		AppException exception = assertThrows(AppException.class,
-			() -> rankingService.getUserCurrentPixelRankInfo(userId, LocalDate.of(2024, 07, 17)));
+			() -> userRankingService.getUserCurrentPixelRankInfo(userId, LocalDate.of(2024, 07, 17)));
 
 		assertEquals(ErrorCode.USER_NOT_FOUND, exception.getErrorCode());
 	}
@@ -272,7 +273,8 @@ class RankingServiceTest {
 		when(rankingHistoryRepository.findByUserIdAndYearAndWeek(userId, 2024, 29))
 			.thenReturn(Optional.ofNullable(rankingHistory));
 
-		UserRankingResponse response = rankingService.getUserCurrentPixelRankInfo(userId, LocalDate.of(2024, 7, 17));
+		UserRankingResponse response = userRankingService.getUserCurrentPixelRankInfo(userId,
+			LocalDate.of(2024, 7, 17));
 
 		Assertions.assertThat(response.getUserId()).isEqualTo(userId);
 		Assertions.assertThat(response.getRank()).isEqualTo(1L);
@@ -290,7 +292,8 @@ class RankingServiceTest {
 		when(rankingHistoryRepository.findByUserIdAndYearAndWeek(userId, 2024, 29))
 			.thenReturn(Optional.empty());
 
-		UserRankingResponse response = rankingService.getUserCurrentPixelRankInfo(userId, LocalDate.of(2024, 7, 17));
+		UserRankingResponse response = userRankingService.getUserCurrentPixelRankInfo(userId,
+			LocalDate.of(2024, 7, 17));
 
 		Assertions.assertThat(response.getUserId()).isEqualTo(userId);
 		Assertions.assertThat(response.getRank()).isEqualTo(null);
@@ -302,18 +305,18 @@ class RankingServiceTest {
 	void updateAccumulatedRankingTest() {
 		Long userId = 1L;
 
-		rankingService.updateAccumulatedRanking(userId);
+		userRankingService.updateAccumulatedRanking(userId);
 
-		verify(rankingRedisRepository, times(1)).increaseAccumulatePixelCount(userId);
+		verify(userRankingRedisRepository, times(1)).increaseAccumulatePixelCount(userId);
 	}
 
 	@Test
 	@DisplayName("[getAccumulatePixelCount]")
 	void getAccumulatePixelCountTest() {
 		Long userId = 1L;
-		when(rankingRedisRepository.getUserAccumulatePixelCount(any())).thenReturn(Optional.of(15L));
+		when(userRankingRedisRepository.getUserAccumulatePixelCount(any())).thenReturn(Optional.of(15L));
 
-		Long count = rankingService.getAccumulatePixelCount(userId);
+		Long count = userRankingService.getAccumulatePixelCount(userId);
 
 		assertThat(count).isEqualTo(15L);
 	}

--- a/src/test/java/com/m3pro/groundflip/service/UserServiceTest.java
+++ b/src/test/java/com/m3pro/groundflip/service/UserServiceTest.java
@@ -37,8 +37,8 @@ import com.m3pro.groundflip.exception.ErrorCode;
 import com.m3pro.groundflip.jwt.JwtProvider;
 import com.m3pro.groundflip.repository.AppleRefreshTokenRepository;
 import com.m3pro.groundflip.repository.FcmTokenRepository;
-import com.m3pro.groundflip.repository.RankingRedisRepository;
 import com.m3pro.groundflip.repository.UserCommunityRepository;
+import com.m3pro.groundflip.repository.UserRankingRedisRepository;
 import com.m3pro.groundflip.repository.UserRepository;
 import com.m3pro.groundflip.service.oauth.AppleApiClient;
 import com.m3pro.groundflip.util.S3Uploader;
@@ -49,7 +49,7 @@ class UserServiceTest {
 	private UserRepository userRepository;
 
 	@Mock
-	private RankingRedisRepository rankingRedisRepository;
+	private UserRankingRedisRepository userRankingRedisRepository;
 
 	@Mock
 	private FcmTokenRepository fcmTokenRepository;


### PR DESCRIPTION
## 작업 내용*

- occupyPixel()이 그룹전에서 작동하도록 수정
- 그룹 별 랭킹 정보 반환 API 구현
- 그룹 간 랭킹 목록 반환 API 구현

## 고민한 내용*

- 기존 랭킹 관련 코드는 유저 랭킹 기능에 맞춰져 있었음

- 따라서 거의 비슷한 로직을 따르는 CommunityRankingService 등을 새로 생성.
- 후에 인터페이스 등을 활용해 중복 코드를 제거 해야할 것 같다.

- 또한 락 내에서 실행되는 로직의 추가로 응답속도 또한 고려해야 할 것으로 보임

- 프로덕션 배포 시  바뀌거나 추가된 데이터베이스 컬럼 반영을 위해 점검 시간 필요
