### PR TITLE
M3-349 그룹전 픽셀 상세 정보 반환 api 구현

### DIFF
--- a/src/main/java/com/m3pro/groundflip/controller/PixelController.java
+++ b/src/main/java/com/m3pro/groundflip/controller/PixelController.java
@@ -13,6 +13,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.m3pro.groundflip.domain.dto.Response;
+import com.m3pro.groundflip.domain.dto.pixel.CommunityPixelInfoResponse;
 import com.m3pro.groundflip.domain.dto.pixel.IndividualHistoryPixelResponse;
 import com.m3pro.groundflip.domain.dto.pixel.IndividualModePixelResponse;
 import com.m3pro.groundflip.domain.dto.pixel.IndividualPixelInfoResponse;
@@ -102,6 +103,16 @@ public class PixelController {
 	) {
 		return Response.createSuccess(
 			pixelReader.getIndividualHistoryPixelInfo(pixelId, userId, lookUpDate)
+		);
+	}
+
+	@Operation(summary = "그룹전 픽셀 정보 조회", description = "특정 그룹전 픽셀의 정보를 조회 API")
+	@GetMapping("/community-mode/{pixelId}")
+	public Response<CommunityPixelInfoResponse> getCommunityPixelInfo(
+		@Parameter(description = "찾고자 하는 pixelId", required = true)
+		@PathVariable Long pixelId) {
+		return Response.createSuccess(
+			pixelReader.getCommunityModePixelInfo(pixelId)
 		);
 	}
 

--- a/src/main/java/com/m3pro/groundflip/domain/dto/pixel/CommunityPixelInfoResponse.java
+++ b/src/main/java/com/m3pro/groundflip/domain/dto/pixel/CommunityPixelInfoResponse.java
@@ -1,0 +1,48 @@
+package com.m3pro.groundflip.domain.dto.pixel;
+
+import java.util.List;
+
+import com.m3pro.groundflip.domain.entity.Pixel;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Data
+@Builder
+@Schema(title = "그룹전 픽셀 정보")
+public class CommunityPixelInfoResponse {
+	private String address;
+	private Integer addressNumber;
+	private Integer visitCount;
+	private PixelOwnerCommunityResponse pixelOwnerCommunity;
+	private List<VisitedCommunityInfo> visitList;
+
+	public static CommunityPixelInfoResponse from(Pixel pixel, PixelOwnerCommunityResponse pixelOwnerCommunityResponse,
+		List<VisitedCommunityInfo> visitedCommunityList) {
+		String realAddress;
+
+		if (pixel.getAddress() != null) {
+			String[] addressArr = pixel.getAddress().split(" ");
+			if (addressArr[0].equals("대한민국")) {
+				realAddress = addressArr[0];
+			} else {
+				realAddress = addressArr[1] + ' ' + addressArr[2];
+			}
+		} else {
+			realAddress = null;
+		}
+
+		return CommunityPixelInfoResponse.builder()
+			.address(realAddress)
+			.addressNumber(pixel.getAddressNumber())
+			.visitCount(visitedCommunityList.size())
+			.pixelOwnerCommunity(pixelOwnerCommunityResponse)
+			.visitList(visitedCommunityList)
+			.build();
+	}
+}

--- a/src/main/java/com/m3pro/groundflip/domain/dto/pixel/PixelOwnerCommunityResponse.java
+++ b/src/main/java/com/m3pro/groundflip/domain/dto/pixel/PixelOwnerCommunityResponse.java
@@ -1,0 +1,35 @@
+package com.m3pro.groundflip.domain.dto.pixel;
+
+import com.m3pro.groundflip.domain.entity.Community;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Data
+@Builder
+public class PixelOwnerCommunityResponse {
+	private Long communityId;
+	private String name;
+	private String profileImageUrl;
+	private Long currentPixelCount;
+	private Long accumulatePixelCount;
+
+	public static PixelOwnerCommunityResponse from(Community pixelOwnerCommunity, Long currentPixelCount,
+		Long accumulatePixelCount) {
+		if (pixelOwnerCommunity == null) {
+			return null;
+		} else {
+			return PixelOwnerCommunityResponse.builder()
+				.communityId(pixelOwnerCommunity.getId())
+				.name(pixelOwnerCommunity.getName())
+				.profileImageUrl(pixelOwnerCommunity.getBackgroundImageUrl())
+				.accumulatePixelCount(accumulatePixelCount)
+				.currentPixelCount(currentPixelCount)
+				.build();
+		}
+	}
+}

--- a/src/main/java/com/m3pro/groundflip/domain/dto/pixel/VisitedCommunityInfo.java
+++ b/src/main/java/com/m3pro/groundflip/domain/dto/pixel/VisitedCommunityInfo.java
@@ -1,0 +1,24 @@
+package com.m3pro.groundflip.domain.dto.pixel;
+
+import com.m3pro.groundflip.domain.dto.pixelUser.VisitedCommunity;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Data
+@Builder
+public class VisitedCommunityInfo {
+	private String name;
+	private String profileImageUrl;
+
+	public static VisitedCommunityInfo from(VisitedCommunity visitedCommunity) {
+		return VisitedCommunityInfo.builder()
+			.name(visitedCommunity.getName())
+			.profileImageUrl(visitedCommunity.getProfileImage())
+			.build();
+	}
+}

--- a/src/main/java/com/m3pro/groundflip/domain/dto/pixelUser/VisitedCommunity.java
+++ b/src/main/java/com/m3pro/groundflip/domain/dto/pixelUser/VisitedCommunity.java
@@ -1,0 +1,11 @@
+package com.m3pro.groundflip.domain.dto.pixelUser;
+
+public interface VisitedCommunity {
+	Long getPixelId();
+
+	Long getCommunityId();
+
+	String getName();
+
+	String getProfileImage();
+}

--- a/src/main/java/com/m3pro/groundflip/repository/CommunityRankingRedisRepository.java
+++ b/src/main/java/com/m3pro/groundflip/repository/CommunityRankingRedisRepository.java
@@ -1,77 +1,11 @@
 package com.m3pro.groundflip.repository;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Optional;
-import java.util.Set;
-
 import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.data.redis.core.ZSetOperations;
 import org.springframework.stereotype.Repository;
 
-import com.m3pro.groundflip.domain.dto.ranking.Ranking;
-
-import jakarta.annotation.PostConstruct;
-import lombok.RequiredArgsConstructor;
-
 @Repository
-@RequiredArgsConstructor
-public class CommunityRankingRedisRepository {
-	private static final String CURRENT_PIXEL_RANKING_KEY = "group_current_pixel_ranking";
-	private static final String ACCUMULATE_PIXEL_RANKING_KEY = "group_accumulate_pixel_ranking";
-	private static final int RANKING_START_INDEX = 0;
-	private static final int RANKING_END_INDEX = 29;
-	private final RedisTemplate<String, String> redisTemplate;
-	private ZSetOperations<String, String> zSetOperations;
-
-	@PostConstruct
-	void init() {
-		zSetOperations = redisTemplate.opsForZSet();
-	}
-
-	public void increaseCurrentPixelCount(Long communityId) {
-		zSetOperations.incrementScore(CURRENT_PIXEL_RANKING_KEY, communityId.toString(), 1);
-	}
-
-	public void decreaseCurrentPixelCount(Long communityId) {
-		Double currentScore = zSetOperations.score(CURRENT_PIXEL_RANKING_KEY, communityId.toString());
-		if (currentScore != null && currentScore > 0) {
-			zSetOperations.incrementScore(CURRENT_PIXEL_RANKING_KEY, communityId.toString(), -1);
-		}
-	}
-
-	public void increaseAccumulatePixelCount(Long communityId) {
-		zSetOperations.incrementScore(ACCUMULATE_PIXEL_RANKING_KEY, communityId.toString(), 1);
-	}
-
-	public List<Ranking> getRankingsWithCurrentPixelCount() {
-		Set<ZSetOperations.TypedTuple<String>> typedTuples = zSetOperations.reverseRangeWithScores(
-			CURRENT_PIXEL_RANKING_KEY,
-			RANKING_START_INDEX, RANKING_END_INDEX);
-		if (typedTuples == null) {
-			return new ArrayList<>();
-		}
-
-		List<Ranking> rankings = new ArrayList<>();
-		long rank = 1;
-		for (ZSetOperations.TypedTuple<String> typedTuple : typedTuples) {
-			rankings.add(Ranking.from(typedTuple, rank++));
-		}
-		return rankings;
-	}
-
-	public Optional<Long> getCommunityCurrentPixelRank(Long communityId) {
-		Long rank = zSetOperations.reverseRank(CURRENT_PIXEL_RANKING_KEY, communityId.toString());
-		return Optional.ofNullable(rank).map(r -> r + 1);
-	}
-
-	public Optional<Long> getCommunityCurrentPixelCount(Long communityId) {
-		Double currentPixelCount = zSetOperations.score(CURRENT_PIXEL_RANKING_KEY, communityId.toString());
-		return Optional.ofNullable(currentPixelCount).map(Double::longValue);
-	}
-
-	public Optional<Long> getCommunityAccumulatePixelCount(Long communityId) {
-		Double accumulatePixelCount = zSetOperations.score(ACCUMULATE_PIXEL_RANKING_KEY, communityId.toString());
-		return Optional.ofNullable(accumulatePixelCount).map(Double::longValue);
+public class CommunityRankingRedisRepository extends RankingRedisRepository {
+	public CommunityRankingRedisRepository(RedisTemplate<String, String> redisTemplate) {
+		super(redisTemplate, "group_current_pixel_ranking", "group_accumulate_pixel_ranking");
 	}
 }

--- a/src/main/java/com/m3pro/groundflip/repository/PixelUserRepository.java
+++ b/src/main/java/com/m3pro/groundflip/repository/PixelUserRepository.java
@@ -8,6 +8,7 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import com.m3pro.groundflip.domain.dto.pixelUser.VisitedCommunity;
 import com.m3pro.groundflip.domain.dto.pixelUser.VisitedUser;
 import com.m3pro.groundflip.domain.entity.Pixel;
 import com.m3pro.groundflip.domain.entity.PixelUser;
@@ -25,6 +26,19 @@ public interface PixelUserRepository extends JpaRepository<PixelUser, Long> {
 			GROUP BY pu.user_id;
 		""", nativeQuery = true)
 	List<VisitedUser> findAllVisitedUserByPixelId(
+		@Param("pixel_id") Long pixelId);
+
+	@Query(value = """
+			SELECT pu.pixel_id AS pixelId,
+				pu.community_id AS communityId,
+				c.name AS name,
+				c.background_image_url AS profileImage
+			FROM pixel_user pu
+			JOIN community c ON pu.community_id = c.community_id
+			WHERE pu.pixel_id = :pixel_id AND pu.created_at >= current_date()
+			GROUP BY pu.community_id;
+		""", nativeQuery = true)
+	List<VisitedCommunity> findAllVisitedCommunityByPixelId(
 		@Param("pixel_id") Long pixelId);
 
 	@Query(value = """

--- a/src/main/java/com/m3pro/groundflip/repository/RankingRedisRepository.java
+++ b/src/main/java/com/m3pro/groundflip/repository/RankingRedisRepository.java
@@ -1,0 +1,97 @@
+package com.m3pro.groundflip.repository;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ZSetOperations;
+
+import com.m3pro.groundflip.domain.dto.ranking.Ranking;
+
+public class RankingRedisRepository {
+	private static final int RANKING_START_INDEX = 0;
+	private static final int RANKING_END_INDEX = 29;
+	private final String currentPixelRankingKey;
+	private final String accumulatePixelRankingKey;
+	private final ZSetOperations<String, String> zSetOperations;
+
+	public RankingRedisRepository(RedisTemplate<String, String> redisTemplate, String currentPixelRankingKey,
+		String accumulatePixelRankingKey) {
+		// this.redisTemplate = redisTemplate;
+		this.currentPixelRankingKey = currentPixelRankingKey;
+		this.accumulatePixelRankingKey = accumulatePixelRankingKey;
+		zSetOperations = redisTemplate.opsForZSet();
+	}
+
+	public void increaseCurrentPixelCount(Long userId) {
+		zSetOperations.incrementScore(currentPixelRankingKey, userId.toString(), 1);
+	}
+
+	public void increaseAccumulatePixelCount(Long userId) {
+		zSetOperations.incrementScore(accumulatePixelRankingKey, userId.toString(), 1);
+	}
+
+	public void decreaseCurrentPixelCount(Long userId) {
+		Double currentScore = zSetOperations.score(currentPixelRankingKey, userId.toString());
+		if (currentScore != null && currentScore > 0) {
+			zSetOperations.incrementScore(currentPixelRankingKey, userId.toString(), -1);
+		}
+	}
+
+	public void saveUserInRanking(Long userId) {
+		Double currentPixelScore = zSetOperations.score(currentPixelRankingKey, userId.toString());
+		Double accumulatePixelScore = zSetOperations.score(accumulatePixelRankingKey, userId.toString());
+
+		if (currentPixelScore == null) {
+			zSetOperations.add(currentPixelRankingKey, userId.toString(), 0);
+		}
+		if (accumulatePixelScore == null) {
+			zSetOperations.add(accumulatePixelRankingKey, userId.toString(), 0);
+		}
+	}
+
+	public void deleteUserInRanking(Long userId) {
+		Double currentPixelScore = zSetOperations.score(currentPixelRankingKey, userId.toString());
+		Double accumulatePixelScore = zSetOperations.score(accumulatePixelRankingKey, userId.toString());
+
+		if (currentPixelScore != null) {
+			zSetOperations.remove(currentPixelRankingKey, userId.toString());
+		}
+		if (accumulatePixelScore == null) {
+			zSetOperations.remove(accumulatePixelRankingKey, userId.toString());
+		}
+	}
+
+	public List<Ranking> getRankingsWithCurrentPixelCount() {
+		Set<ZSetOperations.TypedTuple<String>> typedTuples = zSetOperations.reverseRangeWithScores(
+			currentPixelRankingKey,
+			RANKING_START_INDEX, RANKING_END_INDEX);
+		if (typedTuples == null) {
+			return new ArrayList<>();
+		}
+
+		List<Ranking> rankings = new ArrayList<>();
+		long rank = 1;
+		for (ZSetOperations.TypedTuple<String> typedTuple : typedTuples) {
+			rankings.add(Ranking.from(typedTuple, rank++));
+		}
+		return rankings;
+	}
+
+	public Optional<Long> getCurrentPixelRank(Long userId) {
+		Long rank = zSetOperations.reverseRank(currentPixelRankingKey, userId.toString());
+		return Optional.ofNullable(rank).map(r -> r + 1);
+	}
+
+	public Optional<Long> getCurrentPixelCount(Long userId) {
+		Double currentPixelCount = zSetOperations.score(currentPixelRankingKey, userId.toString());
+		return Optional.ofNullable(currentPixelCount).map(Double::longValue);
+	}
+
+	public Optional<Long> getAccumulatePixelCount(Long userId) {
+		Double accumulatePixelCount = zSetOperations.score(accumulatePixelRankingKey, userId.toString());
+		return Optional.ofNullable(accumulatePixelCount).map(Double::longValue);
+	}
+}

--- a/src/main/java/com/m3pro/groundflip/repository/RankingRedisRepository.java
+++ b/src/main/java/com/m3pro/groundflip/repository/RankingRedisRepository.java
@@ -19,7 +19,6 @@ public class RankingRedisRepository {
 
 	public RankingRedisRepository(RedisTemplate<String, String> redisTemplate, String currentPixelRankingKey,
 		String accumulatePixelRankingKey) {
-		// this.redisTemplate = redisTemplate;
 		this.currentPixelRankingKey = currentPixelRankingKey;
 		this.accumulatePixelRankingKey = accumulatePixelRankingKey;
 		zSetOperations = redisTemplate.opsForZSet();

--- a/src/main/java/com/m3pro/groundflip/repository/UserRankingRedisRepository.java
+++ b/src/main/java/com/m3pro/groundflip/repository/UserRankingRedisRepository.java
@@ -1,101 +1,11 @@
 package com.m3pro.groundflip.repository;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Optional;
-import java.util.Set;
-
 import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.data.redis.core.ZSetOperations;
 import org.springframework.stereotype.Repository;
 
-import com.m3pro.groundflip.domain.dto.ranking.Ranking;
-
-import jakarta.annotation.PostConstruct;
-import lombok.RequiredArgsConstructor;
-
 @Repository
-@RequiredArgsConstructor
-public class UserRankingRedisRepository {
-	private static final String CURRENT_PIXEL_RANKING_KEY = "current_pixel_ranking";
-	private static final String ACCUMULATE_PIXEL_RANKING_KEY = "accumulate_pixel_ranking";
-	private static final int RANKING_START_INDEX = 0;
-	private static final int RANKING_END_INDEX = 29;
-	private final RedisTemplate<String, String> redisTemplate;
-	private ZSetOperations<String, String> zSetOperations;
-
-	@PostConstruct
-	void init() {
-		zSetOperations = redisTemplate.opsForZSet();
-	}
-
-	public void increaseCurrentPixelCount(Long userId) {
-		zSetOperations.incrementScore(CURRENT_PIXEL_RANKING_KEY, userId.toString(), 1);
-	}
-
-	public void increaseAccumulatePixelCount(Long userId) {
-		zSetOperations.incrementScore(ACCUMULATE_PIXEL_RANKING_KEY, userId.toString(), 1);
-	}
-
-	public void decreaseCurrentPixelCount(Long userId) {
-		Double currentScore = zSetOperations.score(CURRENT_PIXEL_RANKING_KEY, userId.toString());
-		if (currentScore != null && currentScore > 0) {
-			zSetOperations.incrementScore(CURRENT_PIXEL_RANKING_KEY, userId.toString(), -1);
-		}
-	}
-
-	public void saveUserInRanking(Long userId) {
-		Double currentPixelScore = zSetOperations.score(CURRENT_PIXEL_RANKING_KEY, userId.toString());
-		Double accumulatePixelScore = zSetOperations.score(ACCUMULATE_PIXEL_RANKING_KEY, userId.toString());
-
-		if (currentPixelScore == null) {
-			zSetOperations.add(CURRENT_PIXEL_RANKING_KEY, userId.toString(), 0);
-		}
-		if (accumulatePixelScore == null) {
-			zSetOperations.add(ACCUMULATE_PIXEL_RANKING_KEY, userId.toString(), 0);
-		}
-	}
-
-	public void deleteUserInRanking(Long userId) {
-		Double currentPixelScore = zSetOperations.score(CURRENT_PIXEL_RANKING_KEY, userId.toString());
-		Double accumulatePixelScore = zSetOperations.score(ACCUMULATE_PIXEL_RANKING_KEY, userId.toString());
-
-		if (currentPixelScore != null) {
-			zSetOperations.remove(CURRENT_PIXEL_RANKING_KEY, userId.toString());
-		}
-		if (accumulatePixelScore == null) {
-			zSetOperations.remove(ACCUMULATE_PIXEL_RANKING_KEY, userId.toString());
-		}
-	}
-
-	public List<Ranking> getRankingsWithCurrentPixelCount() {
-		Set<ZSetOperations.TypedTuple<String>> typedTuples = zSetOperations.reverseRangeWithScores(
-			CURRENT_PIXEL_RANKING_KEY,
-			RANKING_START_INDEX, RANKING_END_INDEX);
-		if (typedTuples == null) {
-			return new ArrayList<>();
-		}
-
-		List<Ranking> rankings = new ArrayList<>();
-		long rank = 1;
-		for (ZSetOperations.TypedTuple<String> typedTuple : typedTuples) {
-			rankings.add(Ranking.from(typedTuple, rank++));
-		}
-		return rankings;
-	}
-
-	public Optional<Long> getUserCurrentPixelRank(Long userId) {
-		Long rank = zSetOperations.reverseRank(CURRENT_PIXEL_RANKING_KEY, userId.toString());
-		return Optional.ofNullable(rank).map(r -> r + 1);
-	}
-
-	public Optional<Long> getUserCurrentPixelCount(Long userId) {
-		Double currentPixelCount = zSetOperations.score(CURRENT_PIXEL_RANKING_KEY, userId.toString());
-		return Optional.ofNullable(currentPixelCount).map(Double::longValue);
-	}
-
-	public Optional<Long> getUserAccumulatePixelCount(Long userId) {
-		Double accumulatePixelCount = zSetOperations.score(ACCUMULATE_PIXEL_RANKING_KEY, userId.toString());
-		return Optional.ofNullable(accumulatePixelCount).map(Double::longValue);
+public class UserRankingRedisRepository extends RankingRedisRepository {
+	public UserRankingRedisRepository(RedisTemplate<String, String> redisTemplate) {
+		super(redisTemplate, "current_pixel_ranking", "accumulate_pixel_ranking");
 	}
 }

--- a/src/main/java/com/m3pro/groundflip/service/CommunityRankingService.java
+++ b/src/main/java/com/m3pro/groundflip/service/CommunityRankingService.java
@@ -54,7 +54,7 @@ public class CommunityRankingService {
 		}
 	}
 
-	private void updateCurrentPixelRankingAfterOccupy(Long occupyingCommunityId, Long deprivedCommunityId) {
+	public void updateCurrentPixelRankingAfterOccupy(Long occupyingCommunityId, Long deprivedCommunityId) {
 		communityRankingRedisRepository.increaseCurrentPixelCount(occupyingCommunityId);
 		communityRankingRedisRepository.decreaseCurrentPixelCount(deprivedCommunityId);
 	}

--- a/src/main/java/com/m3pro/groundflip/service/CommunityRankingService.java
+++ b/src/main/java/com/m3pro/groundflip/service/CommunityRankingService.java
@@ -64,11 +64,11 @@ public class CommunityRankingService {
 	}
 
 	public Long getCurrentPixelCountFromCache(Long communityId) {
-		return communityRankingRedisRepository.getCommunityCurrentPixelCount(communityId).orElse(0L);
+		return communityRankingRedisRepository.getCurrentPixelCount(communityId).orElse(0L);
 	}
 
 	public Long getAccumulatePixelCount(Long communityId) {
-		return communityRankingRedisRepository.getCommunityAccumulatePixelCount(communityId).orElse(0L);
+		return communityRankingRedisRepository.getAccumulatePixelCount(communityId).orElse(0L);
 	}
 
 	public List<CommunityRankingResponse> getCurrentPixelAllUCommunityRankings(LocalDate lookUpDate) {
@@ -185,7 +185,7 @@ public class CommunityRankingService {
 	 * @return 그룹의 순위
 	 */
 	public Long getCommunityCurrentPixelRankFromCache(Long communityId) {
-		return communityRankingRedisRepository.getCommunityCurrentPixelRank(communityId)
+		return communityRankingRedisRepository.getCurrentPixelRank(communityId)
 			.orElseThrow(() -> {
 				log.error("Community {} not register at redis", communityId);
 				return new AppException(ErrorCode.INTERNAL_SERVER_ERROR);

--- a/src/main/java/com/m3pro/groundflip/service/PixelReader.java
+++ b/src/main/java/com/m3pro/groundflip/service/PixelReader.java
@@ -192,7 +192,7 @@ public class PixelReader {
 	}
 
 	private PixelOwnerCommunityResponse getPixelOwnerCommunityInfo(Pixel pixel) {
-		Long ownerCommunityId = pixel.getId();
+		Long ownerCommunityId = pixel.getCommunityId();
 		if (ownerCommunityId == null) {
 			return null;
 		} else {

--- a/src/main/java/com/m3pro/groundflip/service/UserRankingService.java
+++ b/src/main/java/com/m3pro/groundflip/service/UserRankingService.java
@@ -73,11 +73,11 @@ public class UserRankingService {
 	 * @return 현재 소유한 픽셀의 개수
 	 */
 	public Long getCurrentPixelCountFromCache(Long userId) {
-		return userRankingRedisRepository.getUserCurrentPixelCount(userId).orElse(0L);
+		return userRankingRedisRepository.getCurrentPixelCount(userId).orElse(0L);
 	}
 
 	public Long getAccumulatePixelCount(Long userId) {
-		return userRankingRedisRepository.getUserAccumulatePixelCount(userId).orElse(0L);
+		return userRankingRedisRepository.getAccumulatePixelCount(userId).orElse(0L);
 	}
 
 	/**
@@ -195,7 +195,7 @@ public class UserRankingService {
 	 * @return 사용자의 순위
 	 */
 	private Long getUserCurrentPixelRankFromCache(Long userId) {
-		return userRankingRedisRepository.getUserCurrentPixelRank(userId)
+		return userRankingRedisRepository.getCurrentPixelRank(userId)
 			.orElseThrow(() -> {
 				log.error("User {} not register at redis", userId);
 				return new AppException(ErrorCode.INTERNAL_SERVER_ERROR);

--- a/src/test/java/com/m3pro/groundflip/service/CommunityRankingServiceTest.java
+++ b/src/test/java/com/m3pro/groundflip/service/CommunityRankingServiceTest.java
@@ -1,0 +1,424 @@
+package com.m3pro.groundflip.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.time.LocalDate;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.m3pro.groundflip.domain.dto.ranking.CommunityRankingResponse;
+import com.m3pro.groundflip.domain.dto.ranking.Ranking;
+import com.m3pro.groundflip.domain.entity.Community;
+import com.m3pro.groundflip.domain.entity.CommunityRankingHistory;
+import com.m3pro.groundflip.domain.entity.Pixel;
+import com.m3pro.groundflip.exception.AppException;
+import com.m3pro.groundflip.exception.ErrorCode;
+import com.m3pro.groundflip.repository.CommunityRankingHistoryRepository;
+import com.m3pro.groundflip.repository.CommunityRankingRedisRepository;
+import com.m3pro.groundflip.repository.CommunityRepository;
+import com.m3pro.groundflip.util.DateUtils;
+
+@ExtendWith(MockitoExtension.class)
+public class CommunityRankingServiceTest {
+	@Mock
+	private CommunityRankingRedisRepository communityRankingRedisRepository;
+	@Mock
+	private CommunityRepository communityRepository;
+	@Mock
+	private CommunityRankingHistoryRepository communityRankingHistoryRepository;
+	@InjectMocks
+	private CommunityRankingService communityRankingService;
+
+	@BeforeEach
+	void init() {
+		reset(communityRankingRedisRepository);
+	}
+
+	@Test
+	@DisplayName("[updateRanking] Same community already owns pixel and it's from this week, no ranking update")
+	void updateRanking_NoUpdateCurrentPixel() {
+		Long occupyingCommunityId = 1L;
+		Pixel targetPixel = Pixel.builder().communityId(occupyingCommunityId).build();
+		targetPixel.updateCommunityOccupiedAt(DateUtils.getThisWeekStartDate().atTime(0, 0, 0).plusDays(1));
+
+		communityRankingService.updateCurrentPixelRanking(targetPixel, occupyingCommunityId);
+
+		verify(communityRankingRedisRepository, never()).increaseCurrentPixelCount(occupyingCommunityId);
+	}
+
+	@Test
+	@DisplayName("[updateRanking] Community owned the pixel last week, ranking updated")
+	void updateRanking_UpdateCurrentPixelBeforeThisWeek() {
+		Long occupyingCommunityId = 1L;
+		Pixel targetPixel = Pixel.builder().communityId(occupyingCommunityId).build();
+		targetPixel.updateCommunityOccupiedAt(DateUtils.getThisWeekStartDate().atTime(0, 0, 0).minusDays(3));
+
+		communityRankingService.updateCurrentPixelRanking(targetPixel, occupyingCommunityId);
+
+		verify(communityRankingRedisRepository, times(1)).increaseCurrentPixelCount(occupyingCommunityId);
+	}
+
+	@Test
+	@DisplayName("[updateRanking] Pixel never owned, adds to occupying community's score")
+	void updateCurrentPixelRanking_NeverOccupied() {
+		Long occupyingCommunityId = 1L;
+		Pixel targetPixel = Pixel.builder().communityId(null).build();
+
+		communityRankingService.updateCurrentPixelRanking(targetPixel, occupyingCommunityId);
+
+		verify(communityRankingRedisRepository, times(1)).increaseCurrentPixelCount(occupyingCommunityId);
+	}
+
+	@Test
+	@DisplayName("[updateRankingAfterOccupy] Increases score for occupying community, decreases for deprived")
+	void updateCurrentPixelRankingAfterOccupyTest() {
+		Long occupyingCommunityId = 1L;
+		Long deprivedCommunityId = 2L;
+
+		communityRankingService.updateCurrentPixelRankingAfterOccupy(occupyingCommunityId, deprivedCommunityId);
+
+		verify(communityRankingRedisRepository, times(1)).decreaseCurrentPixelCount(deprivedCommunityId);
+		verify(communityRankingRedisRepository, times(1)).increaseCurrentPixelCount(occupyingCommunityId);
+	}
+
+	@Test
+	@DisplayName("[getCurrentPixelCount] Returns community's pixel count")
+	void getCurrentPixelCountFromCacheTest() {
+		Long communityId = 1L;
+		when(communityRankingRedisRepository.getCurrentPixelCount(any())).thenReturn(Optional.of(15L));
+
+		Long count = communityRankingService.getCurrentPixelCountFromCache(communityId);
+
+		assertThat(count).isEqualTo(15L);
+	}
+
+	@Test
+	@DisplayName("[getCurrentPixelCount] Returns 0 if community not in Redis")
+	void getCurrentPixelCountFromCacheTestEmpty() {
+		Long communityId = 1L;
+		when(communityRankingRedisRepository.getCurrentPixelCount(any())).thenReturn(Optional.empty());
+
+		Long count = communityRankingService.getCurrentPixelCountFromCache(communityId);
+
+		assertThat(count).isEqualTo(0L);
+	}
+
+	@Test
+	@DisplayName("[getCommunityRankInfo] Community not found, throws exception")
+	void getCommunityRankInfo_NotFound() {
+		Long communityId = 1L;
+		when(communityRepository.findById(communityId)).thenReturn(Optional.empty());
+
+		AppException exception = assertThrows(AppException.class,
+			() -> communityRankingService.getCommunityCurrentPixelRankInfo(communityId, LocalDate.now()));
+
+		assertEquals(ErrorCode.COMMUNITY_NOT_FOUND, exception.getErrorCode());
+	}
+
+	@Test
+	@DisplayName("[getCommunityRankInfo] Returns current community ranking")
+	void getCommunityCurrentPixelRankFromCacheInfoTest() {
+		Long communityId = 1L;
+		Community community = Community.builder()
+			.id(communityId)
+			.name("Community1")
+			.build();
+		when(communityRepository.findById(communityId)).thenReturn(Optional.of(community));
+		when(communityRankingRedisRepository.getCurrentPixelCount(any())).thenReturn(Optional.of(15L));
+		when(communityRankingRedisRepository.getCurrentPixelRank(any())).thenReturn(Optional.of(1L));
+
+		CommunityRankingResponse response = communityRankingService.getCommunityCurrentPixelRankInfo(communityId,
+			LocalDate.now());
+
+		assertThat(response.getCommunityId()).isEqualTo(communityId);
+		assertThat(response.getCurrentPixelCount()).isEqualTo(15L);
+		assertThat(response.getRank()).isEqualTo(1L);
+	}
+
+	@Test
+	@DisplayName("[getCommunityRankInfo] Lookup date is null, defaults to current date and uses current week logic")
+	void getCommunityCurrentPixelRankInfo_LookUpDateIsNull() {
+		Long communityId = 1L;
+		Community community = Community.builder()
+			.id(communityId)
+			.name("Community1")
+			.build();
+
+		when(communityRepository.findById(communityId)).thenReturn(Optional.of(community));
+		when(communityRankingRedisRepository.getCurrentPixelCount(any())).thenReturn(Optional.of(15L));
+		when(communityRankingRedisRepository.getCurrentPixelRank(any())).thenReturn(Optional.of(1L));
+
+		CommunityRankingResponse response = communityRankingService.getCommunityCurrentPixelRankInfo(communityId, null);
+
+		assertThat(response.getCommunityId()).isEqualTo(communityId);
+		assertThat(response.getCurrentPixelCount()).isEqualTo(15L);
+		assertThat(response.getRank()).isEqualTo(1L);
+	}
+
+	@Test
+	@DisplayName("[getCommunityRankInfo] Lookup date is in the current week, returns current ranking")
+	void getCommunityCurrentPixelRankInfo_CurrentWeek() {
+		Long communityId = 1L;
+		Community community = Community.builder()
+			.id(communityId)
+			.name("Community1")
+			.build();
+
+		when(communityRepository.findById(communityId)).thenReturn(Optional.of(community));
+		when(communityRankingRedisRepository.getCurrentPixelCount(any())).thenReturn(Optional.of(20L));
+		when(communityRankingRedisRepository.getCurrentPixelRank(any())).thenReturn(Optional.of(5L));
+
+		LocalDate currentWeekDate = DateUtils.getThisWeekStartDate().plusDays(1);
+		CommunityRankingResponse response = communityRankingService.getCommunityCurrentPixelRankInfo(communityId,
+			currentWeekDate);
+
+		assertThat(response.getCommunityId()).isEqualTo(communityId);
+		assertThat(response.getCurrentPixelCount()).isEqualTo(20L);
+		assertThat(response.getRank()).isEqualTo(5L);
+	}
+
+	@Test
+	@DisplayName("[getCommunityRankInfo] Lookup date is in a past week, returns past ranking from history")
+	void getCommunityCurrentPixelRankInfo_PastWeek() {
+		Long communityId = 1L;
+		Community community = Community.builder()
+			.id(communityId)
+			.name("Community1")
+			.build();
+
+		when(communityRepository.findById(communityId)).thenReturn(Optional.of(community));
+
+		CommunityRankingHistory rankingHistory = CommunityRankingHistory.builder()
+			.communityId(communityId)
+			.currentPixelCount(50L)
+			.ranking(2L)
+			.year(2023)
+			.week(10)
+			.build();
+
+		when(communityRankingHistoryRepository.findByCommunityIdAndYearAndWeek(anyLong(), anyInt(), anyInt()))
+			.thenReturn(Optional.of(rankingHistory));
+
+		LocalDate pastDate = LocalDate.of(2023, 3, 7); // Assuming this is in week 10 of 2023
+		CommunityRankingResponse response = communityRankingService.getCommunityCurrentPixelRankInfo(communityId,
+			pastDate);
+
+		assertThat(response.getCommunityId()).isEqualTo(communityId);
+		assertThat(response.getCurrentPixelCount()).isEqualTo(50L);
+		assertThat(response.getRank()).isEqualTo(2L);
+	}
+
+	@Test
+	@DisplayName("[getCommunityRankInfo] Lookup date is in a past week, no history found, returns community without ranking")
+	void getCommunityCurrentPixelRankInfo_PastWeekNoHistory() {
+		Long communityId = 1L;
+		Community community = Community.builder()
+			.id(communityId)
+			.name("Community1")
+			.build();
+
+		when(communityRepository.findById(communityId)).thenReturn(Optional.of(community));
+		when(communityRankingHistoryRepository.findByCommunityIdAndYearAndWeek(anyLong(), anyInt(), anyInt()))
+			.thenReturn(Optional.empty());
+
+		LocalDate pastDate = LocalDate.of(2023, 5, 10); // Assuming this is a past date
+		CommunityRankingResponse response = communityRankingService.getCommunityCurrentPixelRankInfo(communityId,
+			pastDate);
+
+		assertThat(response.getCommunityId()).isEqualTo(communityId);
+		assertNull(response.getRank());
+		assertNull(response.getCurrentPixelCount());
+	}
+
+	@Test
+	@DisplayName("[getCommunityRankInfo] Current week community not found in Redis, throws exception")
+	void getCommunityCurrentPixelRankInfo_CurrentWeekCommunityNotFoundInRedis() {
+		Long communityId = 1L;
+		when(communityRepository.findById(communityId)).thenReturn(Optional.of(Community.builder()
+			.id(communityId)
+			.name("Community1")
+			.build()));
+
+		when(communityRankingRedisRepository.getCurrentPixelRank(communityId)).thenReturn(Optional.empty());
+
+		AppException exception = assertThrows(AppException.class,
+			() -> communityRankingService.getCommunityCurrentPixelRankInfo(communityId, LocalDate.now()));
+
+		assertEquals(ErrorCode.INTERNAL_SERVER_ERROR, exception.getErrorCode());
+	}
+
+	@Test
+	@DisplayName("[getAllCommunityRanking] Fetches top 30 community rankings")
+	void getAllCurrentWeekRankingTest() {
+		List<Ranking> rankings = Arrays.asList(
+			new Ranking(1L, 10L, 3L),
+			new Ranking(2L, 20L, 1L),
+			new Ranking(3L, 15L, 2L)
+		);
+
+		List<Community> communities = Arrays.asList(
+			Community.builder().id(1L).name("Community1").build(),
+			Community.builder().id(2L).name("Community2").build(),
+			Community.builder().id(3L).name("Community3").build()
+		);
+
+		when(communityRankingRedisRepository.getRankingsWithCurrentPixelCount()).thenReturn(rankings);
+		when(communityRepository.findAllById(anySet())).thenReturn(communities);
+
+		List<CommunityRankingResponse> responses = communityRankingService.getCurrentPixelAllUCommunityRankings(
+			LocalDate.now());
+
+		assertEquals(3, responses.size());
+		assertEquals(1L, responses.get(0).getCommunityId());
+		assertEquals(2L, responses.get(1).getCommunityId());
+		assertEquals(3L, responses.get(2).getCommunityId());
+	}
+
+	@Test
+	@DisplayName("[getCurrentPixelAllUCommunityRankings] Lookup date is null, defaults to current date and fetches current week rankings")
+	void getCurrentPixelAllUCommunityRankings_LookUpDateIsNull() {
+		List<Ranking> rankings = Arrays.asList(
+			new Ranking(1L, 10L, 3L),
+			new Ranking(2L, 20L, 1L)
+		);
+
+		List<Community> communities = Arrays.asList(
+			Community.builder().id(1L).name("Community1").build(),
+			Community.builder().id(2L).name("Community2").build()
+		);
+
+		when(communityRankingRedisRepository.getRankingsWithCurrentPixelCount()).thenReturn(rankings);
+		when(communityRepository.findAllById(anySet())).thenReturn(communities);
+
+		List<CommunityRankingResponse> responses = communityRankingService.getCurrentPixelAllUCommunityRankings(null);
+
+		assertEquals(2, responses.size());
+		assertEquals(1L, responses.get(0).getCommunityId());
+		assertEquals(2L, responses.get(1).getCommunityId());
+	}
+
+	@Test
+	@DisplayName("[getCurrentPixelAllUCommunityRankings] Lookup date is in the current week, returns current week rankings")
+	void getCurrentPixelAllUCommunityRankings_CurrentWeek() {
+		List<Ranking> rankings = Arrays.asList(
+			new Ranking(1L, 10L, 3L),
+			new Ranking(2L, 20L, 1L)
+		);
+
+		List<Community> communities = Arrays.asList(
+			Community.builder().id(1L).name("Community1").build(),
+			Community.builder().id(2L).name("Community2").build()
+		);
+
+		when(communityRankingRedisRepository.getRankingsWithCurrentPixelCount()).thenReturn(rankings);
+		when(communityRepository.findAllById(anySet())).thenReturn(communities);
+
+		LocalDate currentWeekDate = DateUtils.getThisWeekStartDate().plusDays(1);
+		List<CommunityRankingResponse> responses = communityRankingService.getCurrentPixelAllUCommunityRankings(
+			currentWeekDate);
+
+		assertEquals(2, responses.size());
+		assertEquals(1L, responses.get(0).getCommunityId());
+		assertEquals(2L, responses.get(1).getCommunityId());
+	}
+
+	@Test
+	@DisplayName("[getCurrentPixelAllUCommunityRankings] Lookup date is in a past week, returns past week rankings")
+	void getCurrentPixelAllUCommunityRankings_PastWeek() {
+		when(communityRankingHistoryRepository.findAllByYearAndWeek(anyInt(), anyInt()))
+			.thenReturn(Arrays.asList(
+				CommunityRankingResponse.from(Community.builder().id(1L).name("Community1").build(), 2L, 50L),
+				CommunityRankingResponse.from(Community.builder().id(2L).name("Community2").build(), 1L, 30L)
+			));
+
+		LocalDate pastDate = LocalDate.of(2023, 3, 7); // Assuming this is in week 10 of 2023
+		List<CommunityRankingResponse> responses = communityRankingService.getCurrentPixelAllUCommunityRankings(
+			pastDate);
+
+		assertEquals(2, responses.size());
+		assertEquals(1L, responses.get(0).getCommunityId());
+		assertEquals(2L, responses.get(1).getCommunityId());
+	}
+
+	@Test
+	@DisplayName("[getCurrentPixelAllUCommunityRankings] Lookup date is in a past week, no ranking history found")
+	void getCurrentPixelAllUCommunityRankings_PastWeekNoHistory() {
+		when(communityRankingHistoryRepository.findAllByYearAndWeek(anyInt(), anyInt()))
+			.thenReturn(List.of());
+
+		LocalDate pastDate = LocalDate.of(2023, 5, 10); // Assuming this is a past date
+		List<CommunityRankingResponse> responses = communityRankingService.getCurrentPixelAllUCommunityRankings(
+			pastDate);
+
+		assertEquals(0, responses.size());
+	}
+
+	@Test
+	@DisplayName("[getCurrentPixelAllUCommunityRankings] No rankings available in Redis for the current week")
+	void getCurrentPixelAllUCommunityRankings_NoRankingsInRedis() {
+		when(communityRankingRedisRepository.getRankingsWithCurrentPixelCount()).thenReturn(List.of());
+
+		List<CommunityRankingResponse> responses = communityRankingService.getCurrentPixelAllUCommunityRankings(
+			LocalDate.now());
+
+		assertEquals(0, responses.size());
+	}
+
+	@Test
+	@DisplayName("[getCurrentPixelAllUCommunityRankings] Filters out communities not found in database")
+	void getCurrentPixelAllUCommunityRankings_FilterMissingCommunities() {
+		List<Ranking> rankings = Arrays.asList(
+			new Ranking(1L, 10L, 3L),
+			new Ranking(2L, 20L, 1L),
+			new Ranking(3L, 15L, 2L) // This community will not be found in the repository
+		);
+
+		List<Community> communities = Arrays.asList(
+			Community.builder().id(1L).name("Community1").build(),
+			Community.builder().id(2L).name("Community2").build()
+		);
+
+		when(communityRankingRedisRepository.getRankingsWithCurrentPixelCount()).thenReturn(rankings);
+		when(communityRepository.findAllById(anySet())).thenReturn(communities);
+
+		List<CommunityRankingResponse> responses = communityRankingService.getCurrentPixelAllUCommunityRankings(
+			LocalDate.now());
+
+		// We expect only the two existing communities to be returned
+		assertEquals(2, responses.size());
+		assertEquals(1L, responses.get(0).getCommunityId());
+		assertEquals(2L, responses.get(1).getCommunityId());
+	}
+
+	@Test
+	@DisplayName("[updateAccumulatedRanking]")
+	void updateAccumulatedRankingTest() {
+		Long communityId = 1L;
+
+		communityRankingService.updateAccumulatedRanking(communityId);
+
+		verify(communityRankingRedisRepository, times(1)).increaseAccumulatePixelCount(communityId);
+	}
+
+	@Test
+	@DisplayName("[getAccumulatePixelCount]")
+	void getAccumulatePixelCountTest() {
+		Long communityId = 1L;
+		when(communityRankingRedisRepository.getAccumulatePixelCount(any())).thenReturn(Optional.of(15L));
+
+		Long count = communityRankingService.getAccumulatePixelCount(communityId);
+
+		assertThat(count).isEqualTo(15L);
+	}
+}

--- a/src/test/java/com/m3pro/groundflip/service/UserRankingServiceTest.java
+++ b/src/test/java/com/m3pro/groundflip/service/UserRankingServiceTest.java
@@ -123,7 +123,7 @@ class UserRankingServiceTest {
 	@DisplayName("[getCurrentPixelCount] userId 가 소유한 픽셀의 개수를 반환한다.")
 	void getCurrentPixelCountFromCacheTest() {
 		Long userId = 1L;
-		when(userRankingRedisRepository.getUserCurrentPixelCount(any())).thenReturn(Optional.of(15L));
+		when(userRankingRedisRepository.getCurrentPixelCount(any())).thenReturn(Optional.of(15L));
 
 		Long count = userRankingService.getCurrentPixelCountFromCache(userId);
 
@@ -134,7 +134,7 @@ class UserRankingServiceTest {
 	@DisplayName("[getCurrentPixelCount] userId가 sortedSet에 없다면 0 반환")
 	void getCurrentPixelCountFromCacheTestNull() {
 		Long userId = 1L;
-		when(userRankingRedisRepository.getUserCurrentPixelCount(any())).thenReturn(Optional.empty());
+		when(userRankingRedisRepository.getCurrentPixelCount(any())).thenReturn(Optional.empty());
 
 		Long count = userRankingService.getCurrentPixelCountFromCache(userId);
 
@@ -163,8 +163,8 @@ class UserRankingServiceTest {
 			.profileImage("test")
 			.build();
 		when(userRepository.findById(userId)).thenReturn(Optional.of(user));
-		when(userRankingRedisRepository.getUserCurrentPixelCount(any())).thenReturn(Optional.of(15L));
-		when(userRankingRedisRepository.getUserCurrentPixelRank(any())).thenReturn(Optional.of(1L));
+		when(userRankingRedisRepository.getCurrentPixelCount(any())).thenReturn(Optional.of(15L));
+		when(userRankingRedisRepository.getCurrentPixelRank(any())).thenReturn(Optional.of(1L));
 
 		UserRankingResponse userRankingResponse = userRankingService.getUserCurrentPixelRankInfo(userId,
 			LocalDate.now());
@@ -184,7 +184,7 @@ class UserRankingServiceTest {
 			.id(1L)
 			.build()));
 
-		when(userRankingRedisRepository.getUserCurrentPixelRank(userId)).thenReturn(Optional.empty());
+		when(userRankingRedisRepository.getCurrentPixelRank(userId)).thenReturn(Optional.empty());
 
 		AppException exception = assertThrows(AppException.class,
 			() -> userRankingService.getUserCurrentPixelRankInfo(userId, LocalDate.now()));
@@ -314,7 +314,7 @@ class UserRankingServiceTest {
 	@DisplayName("[getAccumulatePixelCount]")
 	void getAccumulatePixelCountTest() {
 		Long userId = 1L;
-		when(userRankingRedisRepository.getUserAccumulatePixelCount(any())).thenReturn(Optional.of(15L));
+		when(userRankingRedisRepository.getAccumulatePixelCount(any())).thenReturn(Optional.of(15L));
 
 		Long count = userRankingService.getAccumulatePixelCount(userId);
 


### PR DESCRIPTION
## 작업 내용*
- 픽셀의 상세 정보를 반환하는 api 구현

## 고민한 내용*
### 리팩토링
RankingRedisRepository 를 리팩토링 했다. 기존에는 `UserRankingRedisRepository` 와 `CommunityRankingRedisRepository` 가 sorted set 의 키값만 다르고 완전히 동일한 코드를 사용하고 있어 코드가 너무 많이 중복되었다.
때문에 중복된 로직을 RankingRedisRepository 로 묶고 sorted set 의 키값을 생성자로 받아 각각의 도메인에 대해 다른 키값을 가지는 Repository 객체를 생성할 수 있게 리팩토링 했다.

```
public class RankingRedisRepository {
	private static final int RANKING_START_INDEX = 0;
	private static final int RANKING_END_INDEX = 29;
	private final String currentPixelRankingKey;
	private final String accumulatePixelRankingKey;
	private final RedisTemplate<String, String> redisTemplate;
	private ZSetOperations<String, String> zSetOperations;

	public RankingRedisRepository(RedisTemplate<String, String> redisTemplate, String currentPixelRankingKey,
		String accumulatePixelRankingKey) {
		this.redisTemplate = redisTemplate;
		this.currentPixelRankingKey = currentPixelRankingKey;
		this.accumulatePixelRankingKey = accumulatePixelRankingKey;
	}
}
```

## 리뷰 요구사항

- 리뷰할 때 중점적으로 봐줬으면 하는 내용들

## 스크린샷