### PR TITLE
M3-358 지난 주차 랭킹 조회에서 순서가 뒤바뀐 버그

### DIFF
--- a/src/main/java/com/m3pro/groundflip/repository/RankingHistoryRepository.java
+++ b/src/main/java/com/m3pro/groundflip/repository/RankingHistoryRepository.java
@@ -26,4 +26,6 @@ public interface RankingHistoryRepository extends JpaRepository<RankingHistory, 
 		@Param("userId") Long userId,
 		@Param("requestYear") int year,
 		@Param("requestWeek") int week);
+
+	void deleteByUserIdAndYearAndWeek(Long userId, int year, int week);
 }

--- a/src/main/java/com/m3pro/groundflip/service/UserService.java
+++ b/src/main/java/com/m3pro/groundflip/service/UserService.java
@@ -22,10 +22,12 @@ import com.m3pro.groundflip.exception.ErrorCode;
 import com.m3pro.groundflip.jwt.JwtProvider;
 import com.m3pro.groundflip.repository.AppleRefreshTokenRepository;
 import com.m3pro.groundflip.repository.FcmTokenRepository;
+import com.m3pro.groundflip.repository.RankingHistoryRepository;
 import com.m3pro.groundflip.repository.UserCommunityRepository;
 import com.m3pro.groundflip.repository.UserRankingRedisRepository;
 import com.m3pro.groundflip.repository.UserRepository;
 import com.m3pro.groundflip.service.oauth.AppleApiClient;
+import com.m3pro.groundflip.util.DateUtils;
 import com.m3pro.groundflip.util.S3Uploader;
 
 import jakarta.transaction.Transactional;
@@ -36,6 +38,7 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 @Slf4j
 public class UserService {
+	private final RankingHistoryRepository rankingHistoryRepository;
 	private final UserRankingRedisRepository userRankingRedisRepository;
 	private final UserRepository userRepository;
 	private final AppleRefreshTokenRepository appleRefreshTokenRepository;
@@ -134,6 +137,10 @@ public class UserService {
 		jwtProvider.expireToken(userDeleteRequest.getAccessToken());
 		jwtProvider.expireToken(userDeleteRequest.getRefreshToken());
 
+		int year = LocalDate.now().getYear();
+		int week = DateUtils.getWeekOfDate(LocalDate.now());
+
+		rankingHistoryRepository.deleteByUserIdAndYearAndWeek(userId, year, week);
 		userRankingRedisRepository.deleteUserInRanking(userId);
 	}
 


### PR DESCRIPTION
## 작업 내용*

- 회원 탈퇴 시 ranking_history에서 "이번 주차의 기록"을 삭제함
- 이미 지난 주차에서 지우면 화면에 표시될 때 해당 랭킹이 없어진 것처럼 보일 수 있음

## 고민한 내용*

- 배치 서버도 기존에 상위 30명만 레디스에서 가져왔기에 전체를 가져와 영속화하게끔 수정했다.
