### PR TITLE
M3-378 pixel 테이블 최적화

### DIFF
--- a/src/main/java/com/m3pro/groundflip/domain/entity/Pixel.java
+++ b/src/main/java/com/m3pro/groundflip/domain/entity/Pixel.java
@@ -6,8 +6,6 @@ import org.locationtech.jts.geom.Point;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -22,7 +20,6 @@ import lombok.NoArgsConstructor;
 @Builder
 public class Pixel {
 	@Id
-	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	@Column(name = "pixel_id")
 	private Long id;
 

--- a/src/main/java/com/m3pro/groundflip/service/PixelManager.java
+++ b/src/main/java/com/m3pro/groundflip/service/PixelManager.java
@@ -82,8 +82,9 @@ public class PixelManager {
 			throw new AppException(ErrorCode.PIXEL_NOT_FOUND);
 		}
 
-		Pixel targetPixel = pixelRepository.findByXAndY(pixelOccupyRequest.getX(), pixelOccupyRequest.getY())
-			.orElse(createPixel(pixelOccupyRequest.getX(), pixelOccupyRequest.getY()));
+		Pixel targetPixel = pixelRepository.findByXAndY(pixelOccupyRequest.getX(),
+				pixelOccupyRequest.getY())
+			.orElseGet(() -> createPixel(pixelOccupyRequest.getX(), pixelOccupyRequest.getY()));
 
 		userRankingService.updateCurrentPixelRanking(targetPixel, occupyingUserId);
 		updateUserAccumulatePixelCount(targetPixel, occupyingUserId);

--- a/src/test/java/com/m3pro/groundflip/repository/PixelRepositoryTest.java
+++ b/src/test/java/com/m3pro/groundflip/repository/PixelRepositoryTest.java
@@ -74,7 +74,7 @@ public class PixelRepositoryTest {
 
 		Long pixelCount = pixelRepository.countCurrentPixelByUserId(1L);
 
-		assertThat(pixelCount).isEqualTo(1);
+		assertThat(pixelCount).isEqualTo(0L);
 	}
 
 	@Test
@@ -93,7 +93,14 @@ public class PixelRepositoryTest {
 	private Pixel savePixel(double latitude, double longitude, Long x, Long y, Long userId) {
 		Point point = createPoint(longitude, latitude);
 		return pixelRepository.save(
-			Pixel.builder().userOccupiedAt(LocalDateTime.now()).coordinate(point).userId(userId).x(x).y(y).build());
+			Pixel.builder()
+				.userOccupiedAt(LocalDateTime.now())
+				.coordinate(point)
+				.userId(userId)
+				.x(x)
+				.y(y)
+				.id(x * 4156 + y + 1)
+				.build());
 	}
 
 	private Point createPoint(double longitude, double latitude) {

--- a/src/test/java/com/m3pro/groundflip/repository/PixelUserRepositoryTest.java
+++ b/src/test/java/com/m3pro/groundflip/repository/PixelUserRepositoryTest.java
@@ -26,17 +26,16 @@ import jakarta.transaction.Transactional;
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 public class PixelUserRepositoryTest {
 	private static final int WGS84_SRID = 4326;
-
+	@Autowired
+	CommunityRepository communityRepository;
+	@Autowired
+	GeometryFactory geometryFactory;
 	@Autowired
 	private PixelUserRepository pixelUserRepository;
 	@Autowired
 	private PixelRepository pixelRepository;
 	@Autowired
 	private UserRepository userRepository;
-	@Autowired
-	CommunityRepository communityRepository;
-	@Autowired
-	GeometryFactory geometryFactory;
 
 	@BeforeEach
 	void setUp() {
@@ -55,6 +54,7 @@ public class PixelUserRepositoryTest {
 		);
 
 		Pixel savedPixel = pixelRepository.save(Pixel.builder()
+			.id(1L)
 			.coordinate(createPoint(37.0, 127.0))
 			.build());
 

--- a/src/test/java/com/m3pro/groundflip/service/PixelManagerTest.java
+++ b/src/test/java/com/m3pro/groundflip/service/PixelManagerTest.java
@@ -10,6 +10,7 @@ import java.util.concurrent.locks.Condition;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.locationtech.jts.geom.GeometryFactory;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -39,6 +40,8 @@ class PixelManagerTest {
 	private UserRankingService userRankingService;
 	@Mock
 	private CommunityRankingService communityRankingService;
+	@Mock
+	private GeometryFactory geometryFactory;
 	@InjectMocks
 	private PixelManager pixelManager;
 


### PR DESCRIPTION
## 작업 내용*
- pixel 테이블 새로 삽입
- 새로 발견했을시 삽입하는 로직 구현

## 고민한 내용*
### 최적화된 pixel 테이블 생성 방법
```sql
CREATE TABLE pixel_non_null_user LIKE pixel;

INSERT INTO pixel_non_null_user
SELECT *
FROM pixel
WHERE user_id IS NOT NULL;
```
### pixel 테이블에 새로 삽입하는 로직
- pixel 테이블에 픽셀이 들어있는지 확인 후 없으면 만든다.
### pixel_id 계산

```java
Long pixel_id = x * 4156 + y + 1
```

### 위경도 계산

```java
double currentLongitude = upper_left_lon + (y * lon_per_pixel);
double currentLatitude = upper_left_lat - (x * lat_per_pixel);

double currentLongitude = 125.905952 + (3514 * 0.000909);
double currentLatitude = 38.240675 - (3489 * 0.000724);
```
## 리뷰 요구사항

- 리뷰할 때 중점적으로 봐줬으면 하는 내용들

## 스크린샷