### PR TITLE
백엔드 데일리 픽셀 api 구현

### DIFF
--- a/src/main/java/com/m3pro/groundflip/controller/PixelController.java
+++ b/src/main/java/com/m3pro/groundflip/controller/PixelController.java
@@ -164,5 +164,15 @@ public class PixelController {
 		@RequestParam(name = "community-id") @NotNull() Long communityId) {
 		return Response.createSuccess(pixelReader.getCommunityPixelCount(communityId));
 	}
+
+	@Operation(summary = "주간 픽셀 개수 조회", description = "특정 유저의 주간 방문한 픽셀을 조회하는 api")
+	@GetMapping("/count/daily/{userId}")
+	public Response<List<Integer>> getDailyPixel(
+		@PathVariable(name = "userId") @NotNull() Long userId,
+		@RequestParam(name = "start-date") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate startDate,
+		@RequestParam(name = "end-date") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate endDate
+	) {
+		return Response.createSuccess(pixelReader.getDailyPixel(userId, startDate, endDate));
+	}
 }
 

--- a/src/main/java/com/m3pro/groundflip/domain/entity/DailyPixel.java
+++ b/src/main/java/com/m3pro/groundflip/domain/entity/DailyPixel.java
@@ -1,0 +1,39 @@
+package com.m3pro.groundflip.domain.entity;
+
+import java.time.LocalDate;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "daily_pixel")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class DailyPixel {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "daily_pixel_id")
+	private Long id;
+
+	private Integer dailyPixelCount;
+
+	private LocalDate createdAt;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "user_id")
+	private User user;
+}

--- a/src/main/java/com/m3pro/groundflip/domain/entity/DailyPixel.java
+++ b/src/main/java/com/m3pro/groundflip/domain/entity/DailyPixel.java
@@ -1,6 +1,6 @@
 package com.m3pro.groundflip.domain.entity;
 
-import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -31,7 +31,7 @@ public class DailyPixel {
 
 	private Integer dailyPixelCount;
 
-	private LocalDate createdAt;
+	private LocalDateTime createdAt;
 
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "user_id")

--- a/src/main/java/com/m3pro/groundflip/repository/DailyPixelRepository.java
+++ b/src/main/java/com/m3pro/groundflip/repository/DailyPixelRepository.java
@@ -1,0 +1,35 @@
+package com.m3pro.groundflip.repository;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import com.m3pro.groundflip.domain.entity.DailyPixel;
+
+public interface DailyPixelRepository extends JpaRepository<DailyPixel, Long> {
+
+	@Query(value = """
+		WITH RECURSIVE date_series AS (
+		     SELECT :startDate AS date
+		     UNION ALL
+		     SELECT date + INTERVAL 1 DAY
+		     FROM date_series
+		     WHERE date < :endDate
+		)
+		SELECT
+		     COALESCE(dp.daily_pixel_count, 0) AS daily_pixel_count
+		FROM
+		     date_series ds
+		LEFT JOIN daily_pixel dp ON ds.date = DATE(dp.created_at) AND dp.user_id = :userId
+		ORDER BY
+		     ds.date ASC
+			""",
+		nativeQuery = true)
+	List<Integer> findAllDailyPixel(
+		@Param("userId") Long userId,
+		@Param("startDate") LocalDate startDate,
+		@Param("endDate") LocalDate endDate);
+}

--- a/src/main/java/com/m3pro/groundflip/service/PixelReader.java
+++ b/src/main/java/com/m3pro/groundflip/service/PixelReader.java
@@ -29,6 +29,7 @@ import com.m3pro.groundflip.domain.entity.global.BaseTimeEntity;
 import com.m3pro.groundflip.exception.AppException;
 import com.m3pro.groundflip.exception.ErrorCode;
 import com.m3pro.groundflip.repository.CommunityRepository;
+import com.m3pro.groundflip.repository.DailyPixelRepository;
 import com.m3pro.groundflip.repository.PixelRepository;
 import com.m3pro.groundflip.repository.PixelUserRepository;
 import com.m3pro.groundflip.repository.UserRepository;
@@ -51,6 +52,7 @@ public class PixelReader {
 	private final UserRankingService userRankingService;
 	private final CommunityRankingService communityRankingService;
 	private final CommunityRepository communityRepository;
+	private final DailyPixelRepository dailyPixelRepository;
 
 	/**
 	 * 사용자를 중심으로 일정한 반경 내에 개인전 픽셀들을 가져온다.
@@ -234,5 +236,9 @@ public class PixelReader {
 				});
 			return PixelOwnerCommunityResponse.from(ownerCommunity, currentPixelCount, accumulatePixelCount);
 		}
+	}
+
+	public List<Integer> getDailyPixel(Long userId, LocalDate startDate, LocalDate endDate) {
+		return dailyPixelRepository.findAllDailyPixel(userId, startDate, endDate);
 	}
 }

--- a/src/test/java/com/m3pro/groundflip/service/UserServiceTest.java
+++ b/src/test/java/com/m3pro/groundflip/service/UserServiceTest.java
@@ -42,6 +42,7 @@ import com.m3pro.groundflip.repository.UserCommunityRepository;
 import com.m3pro.groundflip.repository.UserRankingRedisRepository;
 import com.m3pro.groundflip.repository.UserRepository;
 import com.m3pro.groundflip.service.oauth.AppleApiClient;
+import com.m3pro.groundflip.util.DateUtils;
 import com.m3pro.groundflip.util.S3Uploader;
 
 @ExtendWith(MockitoExtension.class)
@@ -209,7 +210,10 @@ class UserServiceTest {
 			.build();
 
 		when(userRepository.findById(deleteUser.getId())).thenReturn(Optional.of(deleteUser));
-		doNothing().when(rankingHistoryRepository).deleteByUserIdAndYearAndWeek(1L, 2024, 39);
+
+		LocalDate today = LocalDate.now();
+		doNothing().when(rankingHistoryRepository)
+			.deleteByUserIdAndYearAndWeek(1L, today.getYear(), DateUtils.getWeekOfDate(today));
 
 		userService.deleteUser(1L, new UserDeleteRequest("acessToken", "refreshToken"));
 
@@ -241,7 +245,10 @@ class UserServiceTest {
 		when(userRepository.findById(deleteUser.getId())).thenReturn(Optional.of(deleteUser));
 		when(appleRefreshTokenRepository.findByUserId(any())).thenReturn(
 			Optional.of(AppleRefreshToken.builder().refreshToken("test").build()));
-		doNothing().when(rankingHistoryRepository).deleteByUserIdAndYearAndWeek(1L, 2024, 39);
+
+		LocalDate today = LocalDate.now();
+		doNothing().when(rankingHistoryRepository)
+			.deleteByUserIdAndYearAndWeek(1L, today.getYear(), DateUtils.getWeekOfDate(today));
 
 		userService.deleteUser(1L, new UserDeleteRequest("acessToken", "refreshToken"));
 


### PR DESCRIPTION
## 작업 내용*

- 사용자의 데일리  픽셀 API 구현 완료

## 고민한 내용*

- 네이티브 쿼리로 한번에 가져오는 것을 목표로 함.
- 기존의 걸음수 API와 같은 방식으로 동작하게 끔 함
