### PR TITLE
M3-353 이벤트 데이터 응답하는 api 및 공지사항 api 구현

### DIFF
--- a/src/main/java/com/m3pro/groundflip/controller/AnnouncementController.java
+++ b/src/main/java/com/m3pro/groundflip/controller/AnnouncementController.java
@@ -34,6 +34,16 @@ public class AnnouncementController {
 		return Response.createSuccess(announcementService.getEvents());
 	}
 
+	@Operation(summary = "이벤트 조회수를 카운팅한다.", description = "특정 이벤트의 조회수를 올린다.")
+	@GetMapping("/events/{eventId}/views")
+	public Response<?> increaseEventViewCount(
+		@Parameter(description = "올리고자 하는 eventId", required = true)
+		@PathVariable Long eventId
+	) {
+		announcementService.increaseViewCount(eventId);
+		return Response.createSuccessWithNoData();
+	}
+
 	@Operation(summary = "공지 목록을 조회한다.", description = "공지 목록을 조회한다. 커서 이후의 공지사항 30개를 불러온다.")
 	@GetMapping("")
 	public Response<List<AnnouncementResponse>> getAnnouncements(
@@ -45,7 +55,7 @@ public class AnnouncementController {
 	@Operation(summary = "공지 목록을 조회한다.", description = "공지 목록을 조회한다. 커서 이후의 공지사항 30개를 불러온다.")
 	@GetMapping("/{announcementId}")
 	public Response<AnnouncementInfoResponse> getAnnouncementInfo(
-		@Parameter(description = "찾고자 하는 userId", required = true)
+		@Parameter(description = "찾고자 하는 announcementId", required = true)
 		@PathVariable Long announcementId
 	) {
 		return Response.createSuccess(announcementService.getAnnouncementInfo(announcementId));

--- a/src/main/java/com/m3pro/groundflip/controller/AnnouncementController.java
+++ b/src/main/java/com/m3pro/groundflip/controller/AnnouncementController.java
@@ -3,16 +3,19 @@ package com.m3pro.groundflip.controller;
 import java.util.List;
 
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.m3pro.groundflip.domain.dto.Response;
+import com.m3pro.groundflip.domain.dto.announcement.AnnouncementInfoResponse;
 import com.m3pro.groundflip.domain.dto.announcement.AnnouncementResponse;
 import com.m3pro.groundflip.domain.dto.announcement.EventResponse;
 import com.m3pro.groundflip.service.AnnouncementService;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
@@ -37,5 +40,14 @@ public class AnnouncementController {
 		@RequestParam(name = "cursor", defaultValue = "0") Long cursor
 	) {
 		return Response.createSuccess(announcementService.getAnnouncements(cursor));
+	}
+
+	@Operation(summary = "공지 목록을 조회한다.", description = "공지 목록을 조회한다. 커서 이후의 공지사항 30개를 불러온다.")
+	@GetMapping("/{announcementId}")
+	public Response<AnnouncementInfoResponse> getAnnouncementInfo(
+		@Parameter(description = "찾고자 하는 userId", required = true)
+		@PathVariable Long announcementId
+	) {
+		return Response.createSuccess(announcementService.getAnnouncementInfo(announcementId));
 	}
 }

--- a/src/main/java/com/m3pro/groundflip/controller/AnnouncementController.java
+++ b/src/main/java/com/m3pro/groundflip/controller/AnnouncementController.java
@@ -1,0 +1,31 @@
+package com.m3pro.groundflip.controller;
+
+import java.util.List;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.m3pro.groundflip.domain.dto.Response;
+import com.m3pro.groundflip.domain.dto.announcement.EventResponse;
+import com.m3pro.groundflip.service.AnnouncementService;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/announcement")
+@Tag(name = "announcement", description = "공지 API")
+@SecurityRequirement(name = "Authorization")
+public class AnnouncementController {
+	private final AnnouncementService announcementService;
+
+	@Operation(summary = "이벤트 목록을 조회한다.", description = "현재 진행중인 이벤트 목록을 조회한다. 이벤트 사진, 공지사항 id 를 반환한다.")
+	@GetMapping("/events")
+	public Response<List<EventResponse>> getUserInfo() {
+		return Response.createSuccess(announcementService.getEvents());
+	}
+}

--- a/src/main/java/com/m3pro/groundflip/controller/AnnouncementController.java
+++ b/src/main/java/com/m3pro/groundflip/controller/AnnouncementController.java
@@ -4,9 +4,11 @@ import java.util.List;
 
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.m3pro.groundflip.domain.dto.Response;
+import com.m3pro.groundflip.domain.dto.announcement.AnnouncementResponse;
 import com.m3pro.groundflip.domain.dto.announcement.EventResponse;
 import com.m3pro.groundflip.service.AnnouncementService;
 
@@ -27,5 +29,13 @@ public class AnnouncementController {
 	@GetMapping("/events")
 	public Response<List<EventResponse>> getUserInfo() {
 		return Response.createSuccess(announcementService.getEvents());
+	}
+
+	@Operation(summary = "공지 목록을 조회한다.", description = "공지 목록을 조회한다. 커서 이후의 공지사항 30개를 불러온다.")
+	@GetMapping("")
+	public Response<List<AnnouncementResponse>> getAnnouncements(
+		@RequestParam(name = "cursor", defaultValue = "0") Long cursor
+	) {
+		return Response.createSuccess(announcementService.getAnnouncements(cursor));
 	}
 }

--- a/src/main/java/com/m3pro/groundflip/domain/dto/announcement/AnnouncementInfoResponse.java
+++ b/src/main/java/com/m3pro/groundflip/domain/dto/announcement/AnnouncementInfoResponse.java
@@ -1,0 +1,39 @@
+package com.m3pro.groundflip.domain.dto.announcement;
+
+import java.time.LocalDateTime;
+
+import com.m3pro.groundflip.domain.entity.Announcement;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Schema(title = "이벤트 정보")
+public class AnnouncementInfoResponse {
+	@Schema(description = "공지 제목", example = "제목")
+	private String title;
+
+	@Schema(description = "공지 id", example = "1")
+	private Long announcementId;
+
+	@Schema(description = "공지 작성일", example = "2024-10-18")
+	private LocalDateTime createdAt;
+
+	@Schema(description = "공지 내용", example = "안녕하세요")
+	private String content;
+
+	public static AnnouncementInfoResponse from(Announcement announcement) {
+		return AnnouncementInfoResponse.builder()
+			.title(announcement.getTitle())
+			.createdAt(announcement.getCreatedAt())
+			.content(announcement.getContent())
+			.announcementId(announcement.getId())
+			.build();
+	}
+}

--- a/src/main/java/com/m3pro/groundflip/domain/dto/announcement/AnnouncementResponse.java
+++ b/src/main/java/com/m3pro/groundflip/domain/dto/announcement/AnnouncementResponse.java
@@ -1,0 +1,25 @@
+package com.m3pro.groundflip.domain.dto.announcement;
+
+import java.time.LocalDateTime;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Schema(title = "이벤트 정보")
+public class AnnouncementResponse {
+	@Schema(description = "공지 제목", example = "제목")
+	private String title;
+
+	@Schema(description = "공지 id", example = "1")
+	private Long announcementId;
+
+	@Schema(description = "공지 작성일", example = "2024-10-18")
+	private LocalDateTime createdAt;
+}

--- a/src/main/java/com/m3pro/groundflip/domain/dto/announcement/EventResponse.java
+++ b/src/main/java/com/m3pro/groundflip/domain/dto/announcement/EventResponse.java
@@ -1,0 +1,20 @@
+package com.m3pro.groundflip.domain.dto.announcement;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Schema(title = "이벤트 정보")
+public class EventResponse {
+	@Schema(description = "사용자 닉네임", example = "홍길동")
+	private String eventImageUrl;
+
+	@Schema(description = "사용자 출생년도", example = "2000")
+	private Long announcementId;
+}

--- a/src/main/java/com/m3pro/groundflip/domain/dto/announcement/EventResponse.java
+++ b/src/main/java/com/m3pro/groundflip/domain/dto/announcement/EventResponse.java
@@ -12,9 +12,12 @@ import lombok.NoArgsConstructor;
 @Builder
 @Schema(title = "이벤트 정보")
 public class EventResponse {
-	@Schema(description = "사용자 닉네임", example = "홍길동")
+	@Schema(description = "이벤트 사진", example = "www.example.com")
 	private String eventImageUrl;
 
-	@Schema(description = "사용자 출생년도", example = "2000")
+	@Schema(description = "이벤트와 관련된 공지사항 id", example = "3")
 	private Long announcementId;
+
+	@Schema(description = "이벤트 id", example = "1")
+	private Long eventId;
 }

--- a/src/main/java/com/m3pro/groundflip/domain/entity/Announcement.java
+++ b/src/main/java/com/m3pro/groundflip/domain/entity/Announcement.java
@@ -26,7 +26,13 @@ public class Announcement {
 	@Column(name = "content", nullable = false, columnDefinition = "TEXT")
 	private String content;
 
+	private Long viewCount;
+
 	private LocalDateTime createdAt;
 
 	private LocalDateTime updatedAt;
+
+	public void incrementViewCount() {
+		this.viewCount++;
+	}
 }

--- a/src/main/java/com/m3pro/groundflip/domain/entity/Announcement.java
+++ b/src/main/java/com/m3pro/groundflip/domain/entity/Announcement.java
@@ -1,0 +1,32 @@
+package com.m3pro.groundflip.domain.entity;
+
+import java.time.LocalDateTime;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class Announcement {
+	@Id
+	@Column(name = "announcement_id")
+	private Long id;
+
+	private String title;
+
+	@Column(name = "content", nullable = false, columnDefinition = "TEXT")
+	private String content;
+
+	private LocalDateTime createdAt;
+
+	private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/m3pro/groundflip/domain/entity/Event.java
+++ b/src/main/java/com/m3pro/groundflip/domain/entity/Event.java
@@ -28,4 +28,10 @@ public class Event {
 	private LocalDateTime startDate;
 
 	private LocalDateTime endDate;
+
+	private Long viewCount;
+
+	public void increaseViewCount() {
+		this.viewCount++;
+	}
 }

--- a/src/main/java/com/m3pro/groundflip/domain/entity/Event.java
+++ b/src/main/java/com/m3pro/groundflip/domain/entity/Event.java
@@ -1,0 +1,31 @@
+package com.m3pro.groundflip.domain.entity;
+
+import java.time.LocalDateTime;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class Event {
+	@Id
+	@Column(name = "event_id")
+	private Long id;
+
+	private String eventImage;
+
+	private Long announcementId;
+
+	private LocalDateTime startDate;
+
+	private LocalDateTime endDate;
+}

--- a/src/main/java/com/m3pro/groundflip/domain/entity/UserActivityLog.java
+++ b/src/main/java/com/m3pro/groundflip/domain/entity/UserActivityLog.java
@@ -16,7 +16,7 @@ import lombok.NoArgsConstructor;
 
 @Getter
 @Entity
-@Table(name = "user")
+@Table(name = "user_activity_log")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder

--- a/src/main/java/com/m3pro/groundflip/domain/entity/UserActivityLog.java
+++ b/src/main/java/com/m3pro/groundflip/domain/entity/UserActivityLog.java
@@ -1,0 +1,32 @@
+package com.m3pro.groundflip.domain.entity;
+
+import com.m3pro.groundflip.domain.entity.global.BaseTimeEntity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "user")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class UserActivityLog extends BaseTimeEntity {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "user_activity_log_id")
+	private Long id;
+
+	private String activity;
+
+	private Long userId;
+}

--- a/src/main/java/com/m3pro/groundflip/repository/AnnouncementRepository.java
+++ b/src/main/java/com/m3pro/groundflip/repository/AnnouncementRepository.java
@@ -1,6 +1,5 @@
 package com.m3pro.groundflip.repository;
 
-import java.awt.print.Pageable;
 import java.util.List;
 
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -10,6 +9,6 @@ import org.springframework.data.repository.query.Param;
 import com.m3pro.groundflip.domain.entity.Announcement;
 
 public interface AnnouncementRepository extends JpaRepository<Announcement, Long> {
-	@Query("SELECT a FROM Announcement a WHERE a.id > :cursor ORDER BY a.id ASC")
-	List<Announcement> findAllAnnouncement(@Param("cursor") Long cursor, Pageable pageable);
+	@Query("SELECT a FROM Announcement a WHERE a.id > :cursor ORDER BY a.id ASC LIMIT :size")
+	List<Announcement> findAllAnnouncement(@Param("cursor") Long cursor, @Param("size") int size);
 }

--- a/src/main/java/com/m3pro/groundflip/repository/AnnouncementRepository.java
+++ b/src/main/java/com/m3pro/groundflip/repository/AnnouncementRepository.java
@@ -1,0 +1,15 @@
+package com.m3pro.groundflip.repository;
+
+import java.awt.print.Pageable;
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import com.m3pro.groundflip.domain.entity.Announcement;
+
+public interface AnnouncementRepository extends JpaRepository<Announcement, Long> {
+	@Query("SELECT a FROM Announcement a WHERE a.id > :cursor ORDER BY a.id ASC")
+	List<Announcement> findAllAnnouncement(@Param("cursor") Long cursor, Pageable pageable);
+}

--- a/src/main/java/com/m3pro/groundflip/repository/EventRepository.java
+++ b/src/main/java/com/m3pro/groundflip/repository/EventRepository.java
@@ -1,8 +1,15 @@
 package com.m3pro.groundflip.repository;
 
+import java.time.LocalDateTime;
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import com.m3pro.groundflip.domain.entity.Event;
 
 public interface EventRepository extends JpaRepository<Event, Long> {
+	@Query("SELECT e FROM Event e WHERE e.startDate <= :today AND e.endDate >= :today")
+	List<Event> findCurrentEvents(@Param("today") LocalDateTime today);
 }

--- a/src/main/java/com/m3pro/groundflip/repository/EventRepository.java
+++ b/src/main/java/com/m3pro/groundflip/repository/EventRepository.java
@@ -1,0 +1,8 @@
+package com.m3pro.groundflip.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.m3pro.groundflip.domain.entity.Event;
+
+public interface EventRepository extends JpaRepository<Event, Long> {
+}

--- a/src/main/java/com/m3pro/groundflip/repository/UserActivityLogRepository.java
+++ b/src/main/java/com/m3pro/groundflip/repository/UserActivityLogRepository.java
@@ -1,0 +1,8 @@
+package com.m3pro.groundflip.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.m3pro.groundflip.domain.entity.UserActivityLog;
+
+public interface UserActivityLogRepository extends JpaRepository<UserActivityLog, Long> {
+}

--- a/src/main/java/com/m3pro/groundflip/service/AnnouncementService.java
+++ b/src/main/java/com/m3pro/groundflip/service/AnnouncementService.java
@@ -15,6 +15,7 @@ import com.m3pro.groundflip.exception.ErrorCode;
 import com.m3pro.groundflip.repository.AnnouncementRepository;
 import com.m3pro.groundflip.repository.EventRepository;
 
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -48,11 +49,12 @@ public class AnnouncementService {
 			).toList();
 	}
 
+	@Transactional
 	public AnnouncementInfoResponse getAnnouncementInfo(Long announcementId) {
 		Announcement announcement = announcementRepository.findById(announcementId)
 			.orElseThrow(() -> new AppException(
 				ErrorCode.INTERNAL_SERVER_ERROR));
-
+		announcement.incrementViewCount();
 		return AnnouncementInfoResponse.from(announcement);
 	}
 }

--- a/src/main/java/com/m3pro/groundflip/service/AnnouncementService.java
+++ b/src/main/java/com/m3pro/groundflip/service/AnnouncementService.java
@@ -34,6 +34,7 @@ public class AnnouncementService {
 		return events.stream().map((event -> EventResponse.builder()
 			.eventImageUrl(event.getEventImage())
 			.announcementId(event.getAnnouncementId())
+			.eventId(event.getId())
 			.build())).toList();
 	}
 
@@ -56,5 +57,12 @@ public class AnnouncementService {
 				ErrorCode.INTERNAL_SERVER_ERROR));
 		announcement.incrementViewCount();
 		return AnnouncementInfoResponse.from(announcement);
+	}
+
+	@Transactional
+	public void increaseViewCount(Long eventId) {
+		Event event = eventRepository.findById(eventId)
+			.orElseThrow(() -> new AppException(ErrorCode.INTERNAL_SERVER_ERROR));
+		event.increaseViewCount();
 	}
 }

--- a/src/main/java/com/m3pro/groundflip/service/AnnouncementService.java
+++ b/src/main/java/com/m3pro/groundflip/service/AnnouncementService.java
@@ -5,8 +5,11 @@ import java.util.List;
 
 import org.springframework.stereotype.Service;
 
+import com.m3pro.groundflip.domain.dto.announcement.AnnouncementResponse;
 import com.m3pro.groundflip.domain.dto.announcement.EventResponse;
+import com.m3pro.groundflip.domain.entity.Announcement;
 import com.m3pro.groundflip.domain.entity.Event;
+import com.m3pro.groundflip.repository.AnnouncementRepository;
 import com.m3pro.groundflip.repository.EventRepository;
 
 import lombok.RequiredArgsConstructor;
@@ -16,7 +19,9 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 @Slf4j
 public class AnnouncementService {
+	private static final int PAGE_SIZE = 30;
 	private final EventRepository eventRepository;
+	private final AnnouncementRepository announcementRepository;
 
 	public List<EventResponse> getEvents() {
 		LocalDateTime today = LocalDateTime.now();
@@ -26,5 +31,17 @@ public class AnnouncementService {
 			.eventImageUrl(event.getEventImage())
 			.announcementId(event.getAnnouncementId())
 			.build())).toList();
+	}
+
+	public List<AnnouncementResponse> getAnnouncements(Long cursor) {
+		List<Announcement> announcements = announcementRepository.findAllAnnouncement(cursor, PAGE_SIZE);
+
+		return announcements.stream()
+			.map(announcement -> AnnouncementResponse.builder()
+				.announcementId(announcement.getId())
+				.title(announcement.getTitle())
+				.createdAt(announcement.getCreatedAt())
+				.build()
+			).toList();
 	}
 }

--- a/src/main/java/com/m3pro/groundflip/service/AnnouncementService.java
+++ b/src/main/java/com/m3pro/groundflip/service/AnnouncementService.java
@@ -5,10 +5,13 @@ import java.util.List;
 
 import org.springframework.stereotype.Service;
 
+import com.m3pro.groundflip.domain.dto.announcement.AnnouncementInfoResponse;
 import com.m3pro.groundflip.domain.dto.announcement.AnnouncementResponse;
 import com.m3pro.groundflip.domain.dto.announcement.EventResponse;
 import com.m3pro.groundflip.domain.entity.Announcement;
 import com.m3pro.groundflip.domain.entity.Event;
+import com.m3pro.groundflip.exception.AppException;
+import com.m3pro.groundflip.exception.ErrorCode;
 import com.m3pro.groundflip.repository.AnnouncementRepository;
 import com.m3pro.groundflip.repository.EventRepository;
 
@@ -43,5 +46,13 @@ public class AnnouncementService {
 				.createdAt(announcement.getCreatedAt())
 				.build()
 			).toList();
+	}
+
+	public AnnouncementInfoResponse getAnnouncementInfo(Long announcementId) {
+		Announcement announcement = announcementRepository.findById(announcementId)
+			.orElseThrow(() -> new AppException(
+				ErrorCode.INTERNAL_SERVER_ERROR));
+
+		return AnnouncementInfoResponse.from(announcement);
 	}
 }

--- a/src/main/java/com/m3pro/groundflip/service/AnnouncementService.java
+++ b/src/main/java/com/m3pro/groundflip/service/AnnouncementService.java
@@ -1,0 +1,30 @@
+package com.m3pro.groundflip.service;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+
+import com.m3pro.groundflip.domain.dto.announcement.EventResponse;
+import com.m3pro.groundflip.domain.entity.Event;
+import com.m3pro.groundflip.repository.EventRepository;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class AnnouncementService {
+	private final EventRepository eventRepository;
+
+	public List<EventResponse> getEvents() {
+		LocalDateTime today = LocalDateTime.now();
+		List<Event> events = eventRepository.findCurrentEvents(today);
+
+		return events.stream().map((event -> EventResponse.builder()
+			.eventImageUrl(event.getEventImage())
+			.announcementId(event.getAnnouncementId())
+			.build())).toList();
+	}
+}

--- a/src/test/java/com/m3pro/groundflip/service/FcmServiceTest.java
+++ b/src/test/java/com/m3pro/groundflip/service/FcmServiceTest.java
@@ -21,6 +21,7 @@ import com.m3pro.groundflip.enums.Device;
 import com.m3pro.groundflip.exception.AppException;
 import com.m3pro.groundflip.exception.ErrorCode;
 import com.m3pro.groundflip.repository.FcmTokenRepository;
+import com.m3pro.groundflip.repository.UserActivityLogRepository;
 import com.m3pro.groundflip.repository.UserRepository;
 
 @ExtendWith(MockitoExtension.class)
@@ -32,6 +33,8 @@ class FcmServiceTest {
 	private UserRepository userRepository;
 	@Mock
 	private FcmTokenRepository fcmTokenRepository;
+	@Mock
+	private UserActivityLogRepository userActivityLogRepository;
 	@InjectMocks
 	private FcmService fcmService;
 
@@ -53,12 +56,14 @@ class FcmServiceTest {
 	@DisplayName("[registerFcmToken] fcm 토큰 새로 등록")
 	void registerFcmToken_RegisterNewToken() {
 		User user = User.builder().id(1L).email("test@test.com").build();
+
 		when(userRepository.findById(testUserId)).thenReturn(Optional.of(user));
 		when(fcmTokenRepository.findByUser(user)).thenReturn(Optional.empty());
 
 		fcmService.registerFcmToken(fcmTokenRequest);
 
 		verify(fcmTokenRepository, times(1)).save(any());
+		verify(userActivityLogRepository, times(1)).save(any());
 	}
 
 	@Test
@@ -72,5 +77,6 @@ class FcmServiceTest {
 		fcmService.registerFcmToken(fcmTokenRequest);
 
 		assertThat(fcmToken.getModifiedAt()).isNotNull();
+		verify(userActivityLogRepository, times(1)).save(any());
 	}
 }


### PR DESCRIPTION
## 작업 내용*
- event 테이블 생성
- event 테이블 반환 로직 구현
- announcement 테이블 생성
- 공지사항 목록 페이지네이션 적용
- 공지사항 상세보기 기능 구현
- 공지사항, 조회수 집계 기능 구현

## 고민한 내용*
- 후에 공지사항이 많아질 것 을 대비하여 커서기반 페이지네이션 적용
- 조회수 카운트를 집계하는 로직 구현
- dau 를 정확히 알기 위해 앱을 킨 사용자들의 로그를 수집하도록 했다.