### PR TITLE
M3-410 픽셀 차지시 클러스터링에서  동시성 문제

### DIFF
--- a/src/main/java/com/m3pro/groundflip/repository/AnnouncementRepository.java
+++ b/src/main/java/com/m3pro/groundflip/repository/AnnouncementRepository.java
@@ -9,6 +9,6 @@ import org.springframework.data.repository.query.Param;
 import com.m3pro.groundflip.domain.entity.Announcement;
 
 public interface AnnouncementRepository extends JpaRepository<Announcement, Long> {
-	@Query("SELECT a FROM Announcement a WHERE a.id > :cursor ORDER BY a.id ASC LIMIT :size")
+	@Query("SELECT a FROM Announcement a WHERE a.id < :cursor ORDER BY a.id DESC LIMIT :size")
 	List<Announcement> findAllAnnouncement(@Param("cursor") Long cursor, @Param("size") int size);
 }

--- a/src/main/java/com/m3pro/groundflip/service/PixelManager.java
+++ b/src/main/java/com/m3pro/groundflip/service/PixelManager.java
@@ -197,7 +197,7 @@ public class PixelManager {
 			.region(region)
 			.user(userRepository.getReferenceById(userId))
 			.build();
-		return userRegionCountRepository.save(userRegionCount);
+		return userRegionCountRepository.saveAndFlush(userRegionCount);
 	}
 
 	private void updateCommunityCurrentPixelCount(Pixel targetPixel, Long communityId) {
@@ -237,7 +237,7 @@ public class PixelManager {
 			.week(week)
 			.year(year)
 			.build();
-		return competitionCountRepository.save(competitionCount);
+		return competitionCountRepository.saveAndFlush(competitionCount);
 	}
 
 	private void updatePixelOwnerCommunity(Pixel targetPixel, Long occupyingCommunityId) {


### PR DESCRIPTION
## 작업 내용*

- save 메소드를 saveAndFlush 로 수정

## 고민한 내용*

### 발생 원인

- 클러스터링 부분에서 에러가 발생

- user_region_count 와 competition_count 에서 같은 지역의 데이터가 두번 동시에 삽입되어 발생함

- `org.springframework.dao.IncorrectResultSizeDataAccessException: Query did not return a unique result: 2 results were returned`

- 코드에 분명 분산락을 적용해두었는데 왜 발생하는지 처음에 이해가 안되었는데 코드를 보니 알 수 있었다.
- 기존에 만들어둔 count 가 없을 때 count 데이터를 생성하는 로직에 `userRegionCountRepository.save(userRegionCount)`
- 이런 식으로 save 만 하였다. 트랜잭션 내에서 동작하기에 save 만 한다면 트랜잭션이 끝난후 커밋된다. 커밋되는 시간 까지 딜레이가 생기면 그 사이에 다른 트랜잭션이 반영되지 않는 데이터를 조회하여 하나 더 만들 수 있다.

### 해결 방법
- save 가 아닌 saveAndFlush 를 사용하여 트랜잭션 중에 커밋 하도록 한다.

## 리뷰 요구사항

- 리뷰할 때 중점적으로 봐줬으면 하는 내용들

## 스크린샷