### PR TITLE
M3-409 즐겨찾기 쿼리, 기본 이미지 수정

### DIFF
--- a/.github/workflows/cd_dev.yml
+++ b/.github/workflows/cd_dev.yml
@@ -39,6 +39,7 @@ jobs:
           echo "LATEST_VERSION=${{ secrets.LATEST_VERSION }}" >> .env
           echo "FORCE_UPDATE_VERSION=${{  secrets.FORCE_UPDATE_VERSION  }}" >> .env
           echo "GEOCODING_API=${{  secrets.GEOCODING_API  }}" >> .env
+          echo "DEFAULT_IMAGE"=${{ secrets.DEFAULT_IMAGE }}" >> .env
           
           echo "SPRING_PROFILES_ACTIVE=dev" >> .env
 

--- a/.github/workflows/cd_prod.yml
+++ b/.github/workflows/cd_prod.yml
@@ -39,6 +39,7 @@ jobs:
           echo "LATEST_VERSION=${{ secrets.LATEST_VERSION_PROD }}" >> .env
           echo "FORCE_UPDATE_VERSION=${{  secrets.FORCE_UPDATE_VERSION_PROD  }}" >> .env
           echo "GEOCODING_API=${{  secrets.GEOCODING_API  }}" >> .env
+          echo "DEFAULT_IMAGE"=${{ secrets.DEFAULT_IMAGE }}" >> .env
 
       - name: gradlew에 실행 권한 부여
         run: chmod +x ./gradlew

--- a/src/main/java/com/m3pro/groundflip/controller/MyPlaceController.java
+++ b/src/main/java/com/m3pro/groundflip/controller/MyPlaceController.java
@@ -41,7 +41,7 @@ public class MyPlaceController {
 	@GetMapping("/{userId}")
 	public Response<List<MyPlaceResponse>> getMyPlace(
 		@Parameter(description = "찾고자 하는 userId", required = true)
-		@PathVariable Long userId
+		@PathVariable("userId") Long userId
 	) {
 		return Response.createSuccess(myPlaceService.getMyPlace(userId));
 	}

--- a/src/main/java/com/m3pro/groundflip/domain/entity/MyPlace.java
+++ b/src/main/java/com/m3pro/groundflip/domain/entity/MyPlace.java
@@ -2,6 +2,7 @@ package com.m3pro.groundflip.domain.entity;
 
 import org.locationtech.jts.geom.Point;
 
+import com.m3pro.groundflip.domain.entity.global.BaseTimeEntity;
 import com.m3pro.groundflip.enums.Place;
 
 import jakarta.persistence.Column;
@@ -27,7 +28,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder
-public class MyPlace {
+public class MyPlace extends BaseTimeEntity {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	@Column(name = "my_place_id")

--- a/src/main/java/com/m3pro/groundflip/repository/MyPlaceRepository.java
+++ b/src/main/java/com/m3pro/groundflip/repository/MyPlaceRepository.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import com.m3pro.groundflip.domain.entity.MyPlace;
 import com.m3pro.groundflip.enums.Place;
@@ -12,16 +13,17 @@ public interface MyPlaceRepository extends JpaRepository<MyPlace, Long> {
 
 	@Query(value = """
 		SELECT mp.*
-		    FROM my_place mp
-		    JOIN (
-		        SELECT place_name, MAX(my_place_id) AS max_place_mark_id
-		        FROM my_place
-		        GROUP BY place_name
-		    ) grouped_mp
-		    ON mp.my_place_id = grouped_mp.max_place_mark_id
-		    WHERE mp.user_id = :userId
+		FROM my_place mp
+		JOIN (
+		    SELECT place_name, MAX(created_at) AS latest_created_at
+		    FROM my_place
+		    WHERE user_id = :userId
+		    GROUP BY place_name
+		) grouped_mp
+		ON mp.place_name = grouped_mp.place_name AND mp.created_at = grouped_mp.latest_created_at
+		WHERE mp.user_id = :userId
 		""", nativeQuery = true)
-	List<MyPlace> findByUserId(Long userId);
+	List<MyPlace> findByUserId(@Param("userId") Long userId);
 
 	List<MyPlace> findByUserIdAndPlaceName(Long userId, Place placeName);
 }

--- a/src/main/java/com/m3pro/groundflip/service/UserService.java
+++ b/src/main/java/com/m3pro/groundflip/service/UserService.java
@@ -6,6 +6,7 @@ import java.time.ZoneId;
 import java.util.Date;
 import java.util.List;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -47,6 +48,9 @@ public class UserService {
 	private final S3Uploader s3Uploader;
 	private final JwtProvider jwtProvider;
 	private final AppleApiClient appleApiClient;
+
+	@Value("${image.default}")
+	private String defaultImagePath;
 
 	/**
 	 * 유저의 정보를 반환한다.
@@ -93,7 +97,7 @@ public class UserService {
 		if (multipartFile != null) {
 			fileS3Url = s3Uploader.uploadFiles(multipartFile, userId);
 		} else {
-			fileS3Url = user.getProfileImage();
+			fileS3Url = defaultImagePath;
 		}
 
 		user.updateGender(userInfoRequest.getGender());

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -92,3 +92,5 @@ version:
 geocoding:
   api: ${GEOCODING_API}
 
+image:
+  default: ${DEFAULT_IMAGE}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -92,3 +92,6 @@ version:
 geocoding:
   api: ${GEOCODING_API}
 
+image:
+  default: ${DEFAULT_IMAGE}
+

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -89,3 +89,6 @@ version:
 
 geocoding:
   api: ${GEOCODING_API}
+
+image:
+  default: ${DEFAULT_IMAGE}


### PR DESCRIPTION
## 작업 내용*
- myplace entity에 created_at column추가
- get 쿼리 수정
- 수정되는 프로필 이미지가 null이면 s3에 저장된 기본 이미지로 변경

## 고민한 내용*
- myplace의 데이터 양이 많지 않아 탐색 시간이 오래 걸리지 않을 것이라 생각됨
- 원래 이미지 수정에서 x를 누르면 수정하기 이전 이미지로 돌아가도록 되어있었는데, 그냥 default 이미지로 돌아가도록 수정
