### PR TITLE
M3-412 동시성 문제 해결

### DIFF
--- a/src/main/java/com/m3pro/groundflip/controller/PixelController.java
+++ b/src/main/java/com/m3pro/groundflip/controller/PixelController.java
@@ -22,7 +22,6 @@ import com.m3pro.groundflip.domain.dto.pixel.IndividualPixelInfoResponse;
 import com.m3pro.groundflip.domain.dto.pixel.PixelCountResponse;
 import com.m3pro.groundflip.domain.dto.pixel.PixelOccupyRequest;
 import com.m3pro.groundflip.domain.dto.pixelUser.IndividualHistoryPixelInfoResponse;
-import com.m3pro.groundflip.service.PixelManager;
 import com.m3pro.groundflip.service.PixelManagerWithLock;
 import com.m3pro.groundflip.service.PixelReader;
 import com.m3pro.groundflip.service.RegionService;
@@ -45,8 +44,7 @@ import lombok.extern.slf4j.Slf4j;
 @Tag(name = "pixels", description = "픽셀 API")
 @SecurityRequirement(name = "Authorization")
 public class PixelController {
-	private final PixelManager pixelManager;
-	private final PixelManagerWithLock pixelManagerWithLock
+	private final PixelManagerWithLock pixelManagerWithLock;
 	private final PixelReader pixelReader;
 	private final RegionService regionService;
 
@@ -219,7 +217,7 @@ public class PixelController {
 		return Response.createSuccess(
 			regionService.getCommunityModeClusteredPixelCount(currentLatitude, currentLongitude, radius));
 	}
-	
+
 	@Operation(summary = "주간 픽셀 개수 조회", description = "특정 유저의 주간 방문한 픽셀을 조회하는 api")
 	@GetMapping("/count/daily/{userId}")
 	public Response<List<Integer>> getDailyPixel(

--- a/src/main/java/com/m3pro/groundflip/controller/PixelController.java
+++ b/src/main/java/com/m3pro/groundflip/controller/PixelController.java
@@ -23,6 +23,7 @@ import com.m3pro.groundflip.domain.dto.pixel.PixelCountResponse;
 import com.m3pro.groundflip.domain.dto.pixel.PixelOccupyRequest;
 import com.m3pro.groundflip.domain.dto.pixelUser.IndividualHistoryPixelInfoResponse;
 import com.m3pro.groundflip.service.PixelManager;
+import com.m3pro.groundflip.service.PixelManagerWithLock;
 import com.m3pro.groundflip.service.PixelReader;
 import com.m3pro.groundflip.service.RegionService;
 
@@ -45,6 +46,7 @@ import lombok.extern.slf4j.Slf4j;
 @SecurityRequirement(name = "Authorization")
 public class PixelController {
 	private final PixelManager pixelManager;
+	private final PixelManagerWithLock pixelManagerWithLock
 	private final PixelReader pixelReader;
 	private final RegionService regionService;
 
@@ -149,7 +151,7 @@ public class PixelController {
 	@Operation(summary = "픽셀 차지", description = "특정 픽셀의 id, 사용자 id, 커뮤니티 id를 사용해 소유권을 바꾸는 API ")
 	@PostMapping("")
 	public Response<?> occupyPixel(@RequestBody PixelOccupyRequest pixelOccupyRequest) {
-		pixelManager.occupyPixelWithLock(pixelOccupyRequest);
+		pixelManagerWithLock.occupyPixelWithLock(pixelOccupyRequest);
 		return Response.createSuccessWithNoData();
 	}
 

--- a/src/main/java/com/m3pro/groundflip/service/PixelManager.java
+++ b/src/main/java/com/m3pro/groundflip/service/PixelManager.java
@@ -3,26 +3,24 @@ package com.m3pro.groundflip.service;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.Optional;
-import java.util.concurrent.TimeUnit;
 
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.GeometryFactory;
 import org.locationtech.jts.geom.Point;
-import org.redisson.api.RLock;
-import org.redisson.api.RedissonClient;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.m3pro.groundflip.domain.dto.pixel.PixelOccupyRequest;
-import com.m3pro.groundflip.domain.dto.pixel.event.PixelUserInsertEvent;
 import com.m3pro.groundflip.domain.dto.pixel.naverApi.ReverseGeocodingResult;
 import com.m3pro.groundflip.domain.entity.CompetitionCount;
 import com.m3pro.groundflip.domain.entity.Pixel;
+import com.m3pro.groundflip.domain.entity.PixelUser;
 import com.m3pro.groundflip.domain.entity.Region;
 import com.m3pro.groundflip.domain.entity.UserRegionCount;
 import com.m3pro.groundflip.exception.AppException;
 import com.m3pro.groundflip.exception.ErrorCode;
+import com.m3pro.groundflip.repository.CommunityRepository;
 import com.m3pro.groundflip.repository.CompetitionCountRepository;
 import com.m3pro.groundflip.repository.PixelRepository;
 import com.m3pro.groundflip.repository.PixelUserRepository;
@@ -38,7 +36,6 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 @Slf4j
 public class PixelManager {
-	private static final String REDISSON_LOCK_PREFIX = "LOCK:";
 	private static final Long DEFAULT_COMMUNITY_ID = -1L;
 	private static final int WGS84_SRID = 4326;
 	private static final double lat_per_pixel = 0.000724;
@@ -50,7 +47,6 @@ public class PixelManager {
 	private final UserRankingService userRankingService;
 	private final CommunityRankingService communityRankingService;
 	private final ApplicationEventPublisher eventPublisher;
-	private final RedissonClient redissonClient;
 	private final PixelUserRepository pixelUserRepository;
 	private final GeometryFactory geometryFactory;
 	private final ReverseGeoCodingService reverseGeoCodingService;
@@ -58,6 +54,7 @@ public class PixelManager {
 	private final CompetitionCountRepository competitionCountRepository;
 	private final UserRegionCountRepository userRegionCountRepository;
 	private final UserRepository userRepository;
+	private final CommunityRepository communityRepository;
 
 	/**
 	 * 픽셀을 차지한다.
@@ -65,30 +62,29 @@ public class PixelManager {
 	 * @return
 	 * @author 김민욱
 	 */
+	// public void occupyPixelWithLock(PixelOccupyRequest pixelOccupyRequest) {
+	// 	String lockName = REDISSON_LOCK_PREFIX + pixelOccupyRequest.getX() + pixelOccupyRequest.getY();
+	// 	RLock rLock = redissonClient.getLock(lockName);
+	//
+	// 	long waitTime = 5L;
+	// 	long leaseTime = 3L;
+	// 	TimeUnit timeUnit = TimeUnit.SECONDS;
+	// 	try {
+	// 		boolean available = rLock.tryLock(waitTime, leaseTime, timeUnit);
+	// 		if (!available) {
+	// 			throw new AppException(ErrorCode.LOCK_ACQUISITION_ERROR);
+	// 		}
+	//
+	// 		occupyPixel(pixelOccupyRequest);
+	//
+	// 	} catch (InterruptedException e) {
+	// 		throw new RuntimeException(e);
+	// 	} finally {
+	// 		rLock.unlock();
+	// 	}
+	// }
 	@Transactional
-	public void occupyPixelWithLock(PixelOccupyRequest pixelOccupyRequest) {
-		String lockName = REDISSON_LOCK_PREFIX + pixelOccupyRequest.getX() + pixelOccupyRequest.getY();
-		RLock rLock = redissonClient.getLock(lockName);
-
-		long waitTime = 5L;
-		long leaseTime = 3L;
-		TimeUnit timeUnit = TimeUnit.SECONDS;
-		try {
-			boolean available = rLock.tryLock(waitTime, leaseTime, timeUnit);
-			if (!available) {
-				throw new AppException(ErrorCode.LOCK_ACQUISITION_ERROR);
-			}
-
-			occupyPixel(pixelOccupyRequest);
-
-		} catch (InterruptedException e) {
-			throw new RuntimeException(e);
-		} finally {
-			rLock.unlock();
-		}
-	}
-
-	private void occupyPixel(PixelOccupyRequest pixelOccupyRequest) {
+	public void occupyPixel(PixelOccupyRequest pixelOccupyRequest) {
 		Long occupyingUserId = pixelOccupyRequest.getUserId();
 		Long occupyingCommunityId = Optional.ofNullable(pixelOccupyRequest.getCommunityId()).orElse(-1L);
 		log.info("[Visit Pixel] x : {}, y: {}, user : {}", pixelOccupyRequest.getX(), pixelOccupyRequest.getY(),
@@ -110,10 +106,13 @@ public class PixelManager {
 		updateCommunityAccumulatePixelCount(targetPixel, occupyingCommunityId);
 		updatePixelOwnerCommunity(targetPixel, occupyingCommunityId);
 
-		pixelRepository.saveAndFlush(targetPixel);
-
-		eventPublisher.publishEvent(
-			new PixelUserInsertEvent(targetPixel.getId(), occupyingUserId, occupyingCommunityId));
+		pixelRepository.save(targetPixel);
+		PixelUser pixelUser = PixelUser.builder()
+			.pixel(targetPixel)
+			.user(userRepository.getReferenceById(occupyingUserId))
+			.community(communityRepository.getReferenceById(occupyingCommunityId))
+			.build();
+		pixelUserRepository.save(pixelUser);
 	}
 
 	private boolean isValidCoordinate(Long x, Long y) {
@@ -197,7 +196,7 @@ public class PixelManager {
 			.region(region)
 			.user(userRepository.getReferenceById(userId))
 			.build();
-		return userRegionCountRepository.saveAndFlush(userRegionCount);
+		return userRegionCountRepository.save(userRegionCount);
 	}
 
 	private void updateCommunityCurrentPixelCount(Pixel targetPixel, Long communityId) {
@@ -237,7 +236,7 @@ public class PixelManager {
 			.week(week)
 			.year(year)
 			.build();
-		return competitionCountRepository.saveAndFlush(competitionCount);
+		return competitionCountRepository.save(competitionCount);
 	}
 
 	private void updatePixelOwnerCommunity(Pixel targetPixel, Long occupyingCommunityId) {

--- a/src/main/java/com/m3pro/groundflip/service/PixelManagerWithLock.java
+++ b/src/main/java/com/m3pro/groundflip/service/PixelManagerWithLock.java
@@ -1,0 +1,45 @@
+package com.m3pro.groundflip.service;
+
+import java.util.concurrent.TimeUnit;
+
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
+import org.springframework.stereotype.Service;
+
+import com.m3pro.groundflip.domain.dto.pixel.PixelOccupyRequest;
+import com.m3pro.groundflip.exception.AppException;
+import com.m3pro.groundflip.exception.ErrorCode;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class PixelManagerWithLock {
+	private static final String REDISSON_LOCK_PREFIX = "LOCK:";
+	private final PixelManager pixelManager;
+	private final RedissonClient redissonClient;
+
+	public void occupyPixelWithLock(PixelOccupyRequest pixelOccupyRequest) {
+		String lockName = REDISSON_LOCK_PREFIX + pixelOccupyRequest.getX() + pixelOccupyRequest.getY();
+		RLock rLock = redissonClient.getLock(lockName);
+
+		long waitTime = 5L;
+		long leaseTime = 3L;
+		TimeUnit timeUnit = TimeUnit.SECONDS;
+		try {
+			boolean available = rLock.tryLock(waitTime, leaseTime, timeUnit);
+			if (!available) {
+				throw new AppException(ErrorCode.LOCK_ACQUISITION_ERROR);
+			}
+
+			pixelManager.occupyPixel(pixelOccupyRequest);
+
+		} catch (InterruptedException e) {
+			throw new RuntimeException(e);
+		} finally {
+			rLock.unlock();
+		}
+	}
+}

--- a/src/test/java/com/m3pro/groundflip/service/AnnouncementServiceTest.java
+++ b/src/test/java/com/m3pro/groundflip/service/AnnouncementServiceTest.java
@@ -1,0 +1,118 @@
+package com.m3pro.groundflip.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.m3pro.groundflip.domain.dto.announcement.AnnouncementInfoResponse;
+import com.m3pro.groundflip.domain.dto.announcement.AnnouncementResponse;
+import com.m3pro.groundflip.domain.dto.announcement.EventResponse;
+import com.m3pro.groundflip.domain.entity.Announcement;
+import com.m3pro.groundflip.domain.entity.Event;
+import com.m3pro.groundflip.repository.AnnouncementRepository;
+import com.m3pro.groundflip.repository.EventRepository;
+
+@ExtendWith(MockitoExtension.class)
+class AnnouncementServiceTest {
+
+	@Mock
+	private EventRepository eventRepository;
+
+	@Mock
+	private AnnouncementRepository announcementRepository;
+
+	@InjectMocks
+	private AnnouncementService announcementService;
+
+	@Test
+	@DisplayName("[getEvents] 이벤트 목록을 정상적으로 반환한다.")
+	void testGetEvents() {
+		// Given
+		LocalDateTime today = LocalDateTime.now();
+		Event mockEvent = Event.builder()
+			.id(1L)
+			.announcementId(10L)
+			.eventImage("https://example.com/image.jpg")
+			.build();
+		when(eventRepository.findCurrentEvents(any())).thenReturn(Collections.singletonList(mockEvent));
+
+		// When
+		List<EventResponse> result = announcementService.getEvents();
+
+		// Then
+		assertEquals(1, result.size());
+		assertEquals(1L, result.get(0).getEventId());
+		assertEquals(10L, result.get(0).getAnnouncementId());
+		assertEquals("https://example.com/image.jpg", result.get(0).getEventImageUrl());
+	}
+
+	@Test
+	@DisplayName("[getAnnouncements] 최근 공지사항 목록을 반환한다.")
+	void testGetAnnouncements() {
+		// Given
+		Announcement mockAnnouncement = Announcement.builder()
+			.id(1L)
+			.title("New Announcement")
+			.createdAt(LocalDateTime.now())
+			.build();
+		when(announcementRepository.findAllRecentAnnouncement(anyInt())).thenReturn(
+			Collections.singletonList(mockAnnouncement));
+
+		// When
+		List<AnnouncementResponse> result = announcementService.getAnnouncements(0L);
+
+		// Then
+		assertEquals(1, result.size());
+		assertEquals(1L, result.get(0).getAnnouncementId());
+		assertEquals("New Announcement", result.get(0).getTitle());
+	}
+
+	@Test
+	@DisplayName("[getAnnouncementInfo] 공지사항 정보를 정상적으로 반환하고 조회수를 증가시킨다.")
+	void testGetAnnouncementInfo() {
+		// Given
+		Announcement mockAnnouncement = Announcement.builder()
+			.id(1L)
+			.title("Important Announcement")
+			.viewCount(0L)
+			.createdAt(LocalDateTime.now())
+			.build();
+		when(announcementRepository.findById(1L)).thenReturn(Optional.of(mockAnnouncement));
+
+		// When
+		AnnouncementInfoResponse result = announcementService.getAnnouncementInfo(1L);
+
+		// Then
+		assertEquals(1L, result.getAnnouncementId());
+		assertEquals("Important Announcement", result.getTitle());
+		assertEquals(1, mockAnnouncement.getViewCount()); // View count should be incremented
+	}
+
+	@Test
+	@DisplayName("[increaseViewCount] 이벤트 조회수를 증가시킨다.")
+	void testIncreaseViewCount() {
+		// Given
+		Event mockEvent = Event.builder()
+			.id(1L)
+			.viewCount(0L)
+			.build();
+		when(eventRepository.findById(1L)).thenReturn(Optional.of(mockEvent));
+
+		// When
+		announcementService.increaseViewCount(1L);
+
+		// Then
+		assertEquals(1, mockEvent.getViewCount()); // View count should be incremented
+	}
+}

--- a/src/test/java/com/m3pro/groundflip/service/PixelManagerTest.java
+++ b/src/test/java/com/m3pro/groundflip/service/PixelManagerTest.java
@@ -5,8 +5,6 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 import java.util.Optional;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.locks.Condition;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -18,20 +16,18 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.redisson.api.RFuture;
-import org.redisson.api.RLock;
-import org.redisson.api.RedissonClient;
 import org.springframework.context.ApplicationEventPublisher;
 
 import com.m3pro.groundflip.domain.dto.pixel.PixelOccupyRequest;
 import com.m3pro.groundflip.domain.dto.pixel.event.PixelAddressUpdateEvent;
-import com.m3pro.groundflip.domain.dto.pixel.event.PixelUserInsertEvent;
 import com.m3pro.groundflip.domain.dto.pixel.naverApi.ReverseGeocodingResult;
 import com.m3pro.groundflip.domain.entity.Pixel;
 import com.m3pro.groundflip.exception.AppException;
 import com.m3pro.groundflip.exception.ErrorCode;
+import com.m3pro.groundflip.repository.CommunityRepository;
 import com.m3pro.groundflip.repository.PixelRepository;
 import com.m3pro.groundflip.repository.PixelUserRepository;
+import com.m3pro.groundflip.repository.UserRepository;
 
 @ExtendWith(MockitoExtension.class)
 class PixelManagerTest {
@@ -40,15 +36,16 @@ class PixelManagerTest {
 	private static final double upper_left_lat = 38.240675;
 	private static final double upper_left_lon = 125.905952;
 	private static final int WGS84_SRID = 4326;
-
+	@Mock
+	private UserRepository userRepository;
+	@Mock
+	private CommunityRepository communityRepository;
 	@Mock
 	private PixelRepository pixelRepository;
 	@Mock
 	private PixelUserRepository pixelUserRepository;
 	@Mock
 	private ApplicationEventPublisher applicationEventPublisher;
-	@Mock
-	private RedissonClient redissonClient;
 	@Mock
 	private UserRankingService userRankingService;
 	@Mock
@@ -72,10 +69,9 @@ class PixelManagerTest {
 			.address("대한민국")
 			.build();
 		when(pixelRepository.findByXAndY(222L, 233L)).thenReturn(Optional.of(pixel));
-		when(redissonClient.getLock(any())).thenReturn(new RedissonLock());
 		when(pixelUserRepository.existsByPixelIdAndUserId(any(), any())).thenReturn(false);
 		// When
-		pixelManager.occupyPixelWithLock(pixelOccupyRequest);
+		pixelManager.occupyPixel(pixelOccupyRequest);
 
 		//Then
 		verify(userRankingService, times(1)).updateCurrentPixelRanking(any(), any());
@@ -95,14 +91,13 @@ class PixelManagerTest {
 			.address("대한민국")
 			.build();
 		when(pixelRepository.findByXAndY(222L, 233L)).thenReturn(Optional.of(pixel));
-		when(redissonClient.getLock(any())).thenReturn(new RedissonLock());
 		// When
-		pixelManager.occupyPixelWithLock(pixelOccupyRequest);
+		pixelManager.occupyPixel(pixelOccupyRequest);
 
 		// Then
-		verify(applicationEventPublisher, times(1)).publishEvent(any(PixelUserInsertEvent.class));
 		verify(userRankingService, times(1)).updateAccumulatedRanking(any());
 		verify(communityRankingService, times(1)).updateCurrentPixelRanking(any(), any());
+		verify(pixelUserRepository, times(1)).save(any());
 	}
 
 	@Test
@@ -116,15 +111,13 @@ class PixelManagerTest {
 			.address(null)
 			.build();
 		when(pixelRepository.findByXAndY(222L, 233L)).thenReturn(Optional.of(pixel));
-		when(redissonClient.getLock(any())).thenReturn(new RedissonLock());
 		lenient().when(reverseGeoCodingService.getRegionFromCoordinates(Mockito.any(Double.class),
 			Mockito.any(Double.class))).thenReturn(
 			ReverseGeocodingResult.builder().regionId(null).regionName(null).build());
 		// When
-		pixelManager.occupyPixelWithLock(pixelOccupyRequest);
+		pixelManager.occupyPixel(pixelOccupyRequest);
 
 		// Then
-		// verify(applicationEventPublisher, times(1)).publishEvent(any(PixelAddressUpdateEvent.class));
 		verify(userRankingService, times(1)).updateAccumulatedRanking(any());
 		verify(communityRankingService, times(1)).updateCurrentPixelRanking(any(), any());
 	}
@@ -140,9 +133,8 @@ class PixelManagerTest {
 			.address("대한민국 ")
 			.build();
 		when(pixelRepository.findByXAndY(222L, 233L)).thenReturn(Optional.of(pixel));
-		when(redissonClient.getLock(any())).thenReturn(new RedissonLock());
 		// When
-		pixelManager.occupyPixelWithLock(pixelOccupyRequest);
+		pixelManager.occupyPixel(pixelOccupyRequest);
 
 		// Then
 		verify(applicationEventPublisher, times(0)).publishEvent(any(PixelAddressUpdateEvent.class));
@@ -154,11 +146,10 @@ class PixelManagerTest {
 	@DisplayName("[occupyPixel] 대한민국에 속한 pixel 이 아니라면 에러 발생")
 	void pixelIncorrectPixel() {
 		PixelOccupyRequest pixelOccupyRequest = new PixelOccupyRequest(5L, 78611L, 9000L, 233L);
-		when(redissonClient.getLock(any())).thenReturn(new RedissonLock());
 
 		// Then
 		AppException exception = assertThrows(AppException.class,
-			() -> pixelManager.occupyPixelWithLock(pixelOccupyRequest));
+			() -> pixelManager.occupyPixel(pixelOccupyRequest));
 		assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.PIXEL_NOT_FOUND);
 	}
 
@@ -172,7 +163,6 @@ class PixelManagerTest {
 			.userId(1L)
 			.address("대한민국 ")
 			.build();
-		when(redissonClient.getLock(any())).thenReturn(new RedissonLock());
 		double expectedLongitude = upper_left_lon + (233L * lon_per_pixel);
 		double expectedLatitude = upper_left_lat - (213L * lat_per_pixel);
 
@@ -180,173 +170,15 @@ class PixelManagerTest {
 		Point mockPoint = new GeometryFactory().createPoint(coordinate);
 		mockPoint.setSRID(WGS84_SRID);
 
-		// When - geometryFactory.createPoint를 모킹
 		when(geometryFactory.createPoint(any(Coordinate.class))).thenReturn(mockPoint);
 		when(pixelRepository.save(any())).thenReturn(pixel);
 		lenient().when(reverseGeoCodingService.getRegionFromCoordinates(Mockito.any(Double.class),
 			Mockito.any(Double.class))).thenReturn(
 			ReverseGeocodingResult.builder().regionId(null).regionName(null).build());
 		// When
-		pixelManager.occupyPixelWithLock(pixelOccupyRequest);
+		pixelManager.occupyPixel(pixelOccupyRequest);
 
 		// Then
 		verify(pixelRepository, times(1)).save(any());
-	}
-
-	static class RedissonLock implements RLock {
-		@Override
-		public String getName() {
-			return "";
-		}
-
-		@Override
-		public void lockInterruptibly(long l, TimeUnit timeUnit) throws InterruptedException {
-
-		}
-
-		@Override
-		public boolean tryLock(long l, long l1, TimeUnit timeUnit) throws InterruptedException {
-			return true;
-		}
-
-		@Override
-		public void lock(long l, TimeUnit timeUnit) {
-
-		}
-
-		@Override
-		public boolean forceUnlock() {
-			return false;
-		}
-
-		@Override
-		public boolean isLocked() {
-			return false;
-		}
-
-		@Override
-		public boolean isHeldByThread(long l) {
-			return false;
-		}
-
-		@Override
-		public boolean isHeldByCurrentThread() {
-			return false;
-		}
-
-		@Override
-		public int getHoldCount() {
-			return 0;
-		}
-
-		@Override
-		public long remainTimeToLive() {
-			return 0;
-		}
-
-		@Override
-		public void lock() {
-
-		}
-
-		@Override
-		public void lockInterruptibly() throws InterruptedException {
-
-		}
-
-		@Override
-		public boolean tryLock() {
-			return false;
-		}
-
-		@Override
-		public boolean tryLock(long time, TimeUnit unit) throws InterruptedException {
-			return false;
-		}
-
-		@Override
-		public void unlock() {
-
-		}
-
-		@Override
-		public Condition newCondition() {
-			return null;
-		}
-
-		@Override
-		public RFuture<Boolean> forceUnlockAsync() {
-			return null;
-		}
-
-		@Override
-		public RFuture<Void> unlockAsync() {
-			return null;
-		}
-
-		@Override
-		public RFuture<Void> unlockAsync(long l) {
-			return null;
-		}
-
-		@Override
-		public RFuture<Boolean> tryLockAsync() {
-			return null;
-		}
-
-		@Override
-		public RFuture<Void> lockAsync() {
-			return null;
-		}
-
-		@Override
-		public RFuture<Void> lockAsync(long l) {
-			return null;
-		}
-
-		@Override
-		public RFuture<Void> lockAsync(long l, TimeUnit timeUnit) {
-			return null;
-		}
-
-		@Override
-		public RFuture<Void> lockAsync(long l, TimeUnit timeUnit, long l1) {
-			return null;
-		}
-
-		@Override
-		public RFuture<Boolean> tryLockAsync(long l) {
-			return null;
-		}
-
-		@Override
-		public RFuture<Boolean> tryLockAsync(long l, TimeUnit timeUnit) {
-			return null;
-		}
-
-		@Override
-		public RFuture<Boolean> tryLockAsync(long l, long l1, TimeUnit timeUnit) {
-			return null;
-		}
-
-		@Override
-		public RFuture<Boolean> tryLockAsync(long l, long l1, TimeUnit timeUnit, long l2) {
-			return null;
-		}
-
-		@Override
-		public RFuture<Integer> getHoldCountAsync() {
-			return null;
-		}
-
-		@Override
-		public RFuture<Boolean> isLockedAsync() {
-			return null;
-		}
-
-		@Override
-		public RFuture<Long> remainTimeToLiveAsync() {
-			return null;
-		}
 	}
 }

--- a/src/test/java/com/m3pro/groundflip/service/RegionServiceTest.java
+++ b/src/test/java/com/m3pro/groundflip/service/RegionServiceTest.java
@@ -1,0 +1,70 @@
+package com.m3pro.groundflip.service;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.Point;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.m3pro.groundflip.domain.dto.pixel.ClusteredPixelCount;
+import com.m3pro.groundflip.repository.RegionRepository;
+
+@ExtendWith(MockitoExtension.class)
+class RegionServiceTest {
+	private static final double lat_per_pixel = 0.000724;
+	private static final double lon_per_pixel = 0.000909;
+	private static final double upper_left_lat = 38.240675;
+	private static final double upper_left_lon = 125.905952;
+	private static final int WGS84_SRID = 4326;
+
+	@Mock
+	private RegionRepository regionRepository;
+	@Mock
+	private GeometryFactory geometryFactory;
+	@InjectMocks
+	private RegionService regionService;
+
+	@Test
+	@DisplayName("[getIndividualModeClusteredPixelCount] City 레벨의 클러스터링 집계 결과를 반환한다")
+	void testGetIndividualModeClusteredPixelCountCity() {
+		double expectedLongitude = upper_left_lon + (233L * lon_per_pixel);
+		double expectedLatitude = upper_left_lat - (213L * lat_per_pixel);
+		Coordinate coordinate = new Coordinate(expectedLongitude, expectedLatitude);
+		Point mockPoint = new GeometryFactory().createPoint(coordinate);
+		mockPoint.setSRID(WGS84_SRID);
+
+		when(geometryFactory.createPoint(any(Coordinate.class))).thenReturn(mockPoint);
+
+		List<ClusteredPixelCount> result = regionService.getIndividualModeClusteredPixelCount(expectedLatitude,
+			expectedLongitude, 6000);
+
+		verify(regionRepository, times(1)).findAllIndividualCityRegionsByCoordinate(any(), anyInt(), anyInt(),
+			anyInt());
+	}
+
+	@Test
+	@DisplayName("[getIndividualModeClusteredPixelCount] Province 레벨의 클러스터링 집계 결과를 반환한다")
+	void testGetIndividualModeClusteredPixelCountProvince() {
+		double expectedLongitude = upper_left_lon + (233L * lon_per_pixel);
+		double expectedLatitude = upper_left_lat - (213L * lat_per_pixel);
+		Coordinate coordinate = new Coordinate(expectedLongitude, expectedLatitude);
+		Point mockPoint = new GeometryFactory().createPoint(coordinate);
+		mockPoint.setSRID(WGS84_SRID);
+
+		when(geometryFactory.createPoint(any(Coordinate.class))).thenReturn(mockPoint);
+
+		regionService.getIndividualModeClusteredPixelCount(expectedLatitude,
+			expectedLongitude, 70001);
+
+		verify(regionRepository, times(1)).findAllIndividualProvinceRegionsByCoordinate(anyInt(), anyInt());
+	}
+}

--- a/src/test/java/com/m3pro/groundflip/service/RegionServiceTest.java
+++ b/src/test/java/com/m3pro/groundflip/service/RegionServiceTest.java
@@ -41,7 +41,6 @@ class RegionServiceTest {
 		Coordinate coordinate = new Coordinate(expectedLongitude, expectedLatitude);
 		Point mockPoint = new GeometryFactory().createPoint(coordinate);
 		mockPoint.setSRID(WGS84_SRID);
-
 		when(geometryFactory.createPoint(any(Coordinate.class))).thenReturn(mockPoint);
 
 		List<ClusteredPixelCount> result = regionService.getIndividualModeClusteredPixelCount(expectedLatitude,
@@ -66,5 +65,73 @@ class RegionServiceTest {
 			expectedLongitude, 70001);
 
 		verify(regionRepository, times(1)).findAllIndividualProvinceRegionsByCoordinate(anyInt(), anyInt());
+	}
+
+	@Test
+	@DisplayName("[getCommunityModeClusteredPixelCount] City 레벨의 클러스터링 집계 결과를 반환한다")
+	void testGetCommunityModeClusteredPixelCountCity() {
+		double expectedLongitude = upper_left_lon + (233L * lon_per_pixel);
+		double expectedLatitude = upper_left_lat - (213L * lat_per_pixel);
+		Coordinate coordinate = new Coordinate(expectedLongitude, expectedLatitude);
+		Point mockPoint = new GeometryFactory().createPoint(coordinate);
+		mockPoint.setSRID(WGS84_SRID);
+
+		when(geometryFactory.createPoint(any(Coordinate.class))).thenReturn(mockPoint);
+
+		regionService.getCommunityModeClusteredPixelCount(expectedLatitude,
+			expectedLongitude, 6000);
+
+		verify(regionRepository, times(1)).findAllCommunityCityRegionsByCoordinate(any(), anyInt(), anyInt(), anyInt());
+	}
+
+	@Test
+	@DisplayName("[getCommunityModeClusteredPixelCount] Province 레벨의 클러스터링 집계 결과를 반환한다")
+	void testGetCommunityModeClusteredPixelCountProvince() {
+		double expectedLongitude = upper_left_lon + (233L * lon_per_pixel);
+		double expectedLatitude = upper_left_lat - (213L * lat_per_pixel);
+		Coordinate coordinate = new Coordinate(expectedLongitude, expectedLatitude);
+		Point mockPoint = new GeometryFactory().createPoint(coordinate);
+		mockPoint.setSRID(WGS84_SRID);
+
+		when(geometryFactory.createPoint(any(Coordinate.class))).thenReturn(mockPoint);
+
+		regionService.getCommunityModeClusteredPixelCount(expectedLatitude,
+			expectedLongitude, 70001);
+
+		verify(regionRepository, times(1)).findAllCommunityProvinceRegionsByCoordinate(anyInt(), anyInt());
+	}
+
+	@Test
+	@DisplayName("[getIndividualHistoryClusteredPixelCount] City 레벨의 클러스터링 집계 결과를 반환한다")
+	void testGetIndividualHistoryClusteredPixelCountCity() {
+		double expectedLongitude = upper_left_lon + (233L * lon_per_pixel);
+		double expectedLatitude = upper_left_lat - (213L * lat_per_pixel);
+		Coordinate coordinate = new Coordinate(expectedLongitude, expectedLatitude);
+		Point mockPoint = new GeometryFactory().createPoint(coordinate);
+		mockPoint.setSRID(WGS84_SRID);
+
+		when(geometryFactory.createPoint(any(Coordinate.class))).thenReturn(mockPoint);
+
+		regionService.getIndividualHistoryClusteredPixelCount(expectedLatitude,
+			expectedLongitude, 6000, 1L);
+
+		verify(regionRepository, times(1)).findAllIndividualHistoryCityRegionsByCoordinate(any(), anyInt(), any());
+	}
+
+	@Test
+	@DisplayName("[getIndividualHistoryClusteredPixelCount] Province 레벨의 클러스터링 집계 결과를 반환한다")
+	void testGetIndividualHistoryClusteredPixelCountProvince() {
+		double expectedLongitude = upper_left_lon + (233L * lon_per_pixel);
+		double expectedLatitude = upper_left_lat - (213L * lat_per_pixel);
+		Coordinate coordinate = new Coordinate(expectedLongitude, expectedLatitude);
+		Point mockPoint = new GeometryFactory().createPoint(coordinate);
+		mockPoint.setSRID(WGS84_SRID);
+
+		when(geometryFactory.createPoint(any(Coordinate.class))).thenReturn(mockPoint);
+
+		regionService.getIndividualHistoryClusteredPixelCount(expectedLatitude,
+			expectedLongitude, 70001, 1L);
+
+		verify(regionRepository, times(1)).findAllIndividualHistoryProvinceRegionsByCoordinate(any());
 	}
 }


### PR DESCRIPTION
## 작업 내용*
- 추가로 발생되는 동시성 문제를 해결


## 고민한 내용*
- 기존에는 락이 풀린 후에 트랜잭션이 반영되게 구현되어있었음
- 때문에 분산락을 제대로 사용하기 위해서는 락 안에서 강제 트랜잭션 커밋을 했어야하는데 이 것을 까먹고 제대로 적용하지 않아 문제 발생
- 또한 이벤트 기반으로 분리한 로직이 락안에서 사용하는 자원이라서 락이 제대로 적용되지 않는 문제가 발생하여 이벤트를 로직안으로 통합시켰다.

## 리뷰 요구사항

- 리뷰할 때 중점적으로 봐줬으면 하는 내용들

## 스크린샷