### PR TITLE
M3-415 업적 진행 기능 구현

### DIFF
--- a/src/main/java/com/m3pro/groundflip/domain/entity/Achievement.java
+++ b/src/main/java/com/m3pro/groundflip/domain/entity/Achievement.java
@@ -4,12 +4,9 @@ import java.time.LocalDateTime;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.OneToOne;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -47,7 +44,5 @@ public class Achievement {
 
 	private LocalDateTime endAt;
 
-	@OneToOne(fetch = FetchType.LAZY)
-	@JoinColumn(name = "next_achievement_id")
-	private Achievement nextAchievement;
+	private Long nextAchievementId;
 }

--- a/src/main/java/com/m3pro/groundflip/domain/entity/UserAchievement.java
+++ b/src/main/java/com/m3pro/groundflip/domain/entity/UserAchievement.java
@@ -49,4 +49,11 @@ public class UserAchievement {
 	@Column(name = "is_reward_received")
 	private Boolean isRewardReceived;
 
+	public void increaseCurrentValue() {
+		this.currentValue++;
+	}
+
+	public void setObtainedAt() {
+		this.obtainedAt = LocalDateTime.now();
+	}
 }

--- a/src/main/java/com/m3pro/groundflip/domain/entity/UserAchievement.java
+++ b/src/main/java/com/m3pro/groundflip/domain/entity/UserAchievement.java
@@ -2,6 +2,8 @@ package com.m3pro.groundflip.domain.entity;
 
 import java.time.LocalDateTime;
 
+import com.m3pro.groundflip.domain.entity.global.BaseTimeEntity;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -21,7 +23,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder
-public class UserAchievement {
+public class UserAchievement extends BaseTimeEntity {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
@@ -36,12 +38,6 @@ public class UserAchievement {
 
 	@Column(name = "current_value")
 	private Integer currentValue;
-
-	@Column(name = "created_at")
-	private LocalDateTime createdAt;
-
-	@Column(name = "modified_at")
-	private LocalDateTime modifiedAt;
 
 	@Column(name = "obtained_at")
 	private LocalDateTime obtainedAt;

--- a/src/main/java/com/m3pro/groundflip/enums/AchievementCategoryId.java
+++ b/src/main/java/com/m3pro/groundflip/enums/AchievementCategoryId.java
@@ -1,0 +1,16 @@
+package com.m3pro.groundflip.enums;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public enum AchievementCategoryId {
+	EXPLORER(1L),
+	CONQUEROR(2L),
+	RANKER(3L),
+	STEADY(4L),
+	SPECIAL(5L);
+
+	private final Long categoryId;
+}

--- a/src/main/java/com/m3pro/groundflip/enums/SpecialAchievement.java
+++ b/src/main/java/com/m3pro/groundflip/enums/SpecialAchievement.java
@@ -1,0 +1,12 @@
+package com.m3pro.groundflip.enums;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public enum SpecialAchievement {
+	JOIN_GROUP(27L);
+
+	private final Long achievementId;
+}

--- a/src/main/java/com/m3pro/groundflip/repository/AchievementRepository.java
+++ b/src/main/java/com/m3pro/groundflip/repository/AchievementRepository.java
@@ -29,6 +29,6 @@ public interface AchievementRepository extends JpaRepository<Achievement, Long> 
 		@Param("user_id") Long userId
 	);
 
-	@Query("SELECT a FROM Achievement a WHERE a.categoryId = :categoryId ORDER BY a.id ASC")
+	@Query("SELECT a FROM Achievement a WHERE a.categoryId = :categoryId ORDER BY a.id ASC LIMIT 1")
 	Optional<Achievement> findByCategoryId(Long categoryId);
 }

--- a/src/main/java/com/m3pro/groundflip/repository/AchievementRepository.java
+++ b/src/main/java/com/m3pro/groundflip/repository/AchievementRepository.java
@@ -1,6 +1,7 @@
 package com.m3pro.groundflip.repository;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -27,4 +28,7 @@ public interface AchievementRepository extends JpaRepository<Achievement, Long> 
 		@Param("achievement_category_id") Long achievementCategoryId,
 		@Param("user_id") Long userId
 	);
+
+	@Query("SELECT a FROM Achievement a WHERE a.categoryId = :categoryId ORDER BY a.id ASC")
+	Optional<Achievement> findByCategoryId(Long categoryId);
 }

--- a/src/main/java/com/m3pro/groundflip/repository/PixelUserRepository.java
+++ b/src/main/java/com/m3pro/groundflip/repository/PixelUserRepository.java
@@ -68,5 +68,11 @@ public interface PixelUserRepository extends JpaRepository<PixelUser, Long> {
 
 	boolean existsByPixelIdAndUserId(Long pixelId, Long userId);
 
+	@Query("SELECT COUNT(pu) > 0 FROM PixelUser pu WHERE pu.user.id = :userId AND FUNCTION('DATE', pu.createdAt) = FUNCTION('DATE', :currentDate)")
+	boolean existsByUserIdAndPixelIdForToday(
+		@Param("userId") Long userId,
+		@Param("currentDate") LocalDateTime currentDate
+	);
+
 	boolean existsByPixelIdAndCommunityId(Long pixelId, Long communityId);
 }

--- a/src/main/java/com/m3pro/groundflip/repository/UserAchievementRepository.java
+++ b/src/main/java/com/m3pro/groundflip/repository/UserAchievementRepository.java
@@ -35,5 +35,13 @@ public interface UserAchievementRepository extends JpaRepository<UserAchievement
 		""")
 	List<UserAchievement> findAllByUserId(Long userId);
 
+	@Query("""
+		SELECT ua FROM UserAchievement ua
+			JOIN FETCH ua.achievement a
+			WHERE ua.user.id = :userId AND a.categoryId = :categoryId
+			ORDER BY ua.obtainedAt DESC
+		""")
+	List<UserAchievement> findAllByUserIdAndCategoryId(Long userId, Long categoryId);
+
 	Optional<UserAchievement> findByAchievementAndUserId(Achievement achievement, Long userId);
 }

--- a/src/main/java/com/m3pro/groundflip/service/AchievementManager.java
+++ b/src/main/java/com/m3pro/groundflip/service/AchievementManager.java
@@ -1,0 +1,74 @@
+package com.m3pro.groundflip.service;
+
+import java.util.List;
+import java.util.Objects;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.m3pro.groundflip.domain.entity.Achievement;
+import com.m3pro.groundflip.domain.entity.UserAchievement;
+import com.m3pro.groundflip.enums.AchievementCategoryId;
+import com.m3pro.groundflip.exception.AppException;
+import com.m3pro.groundflip.exception.ErrorCode;
+import com.m3pro.groundflip.repository.AchievementRepository;
+import com.m3pro.groundflip.repository.UserAchievementRepository;
+import com.m3pro.groundflip.repository.UserRepository;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class AchievementManager {
+	private final AchievementRepository achievementRepository;
+	private final UserAchievementRepository userAchievementRepository;
+	private final UserRepository userRepository;
+
+	@Transactional
+	public void updateAccumulateAchievement(Long userId, AchievementCategoryId categoryId) {
+		UserAchievement achievementToUpdate = getAchievementToUpdate(categoryId.getCategoryId(), userId);
+
+		achievementToUpdate.increaseCurrentValue();
+
+		if (Objects.equals(achievementToUpdate.getCurrentValue(),
+			achievementToUpdate.getAchievement().getCompletionGoal())) {
+			completeAchievement(achievementToUpdate, userId);
+		}
+	}
+
+	private void completeAchievement(UserAchievement achievementToUpdate, Long userId) {
+		achievementToUpdate.setObtainedAt();
+		Long nextAchievementId = achievementToUpdate.getAchievement().getNextAchievementId();
+		if (nextAchievementId != null) {
+			UserAchievement nextAchievement = UserAchievement.builder()
+				.achievement(achievementRepository.getReferenceById(nextAchievementId))
+				.user(userRepository.getReferenceById(userId))
+				.currentValue(achievementToUpdate.getCurrentValue())
+				.isRewardReceived(false)
+				.build();
+			userAchievementRepository.save(nextAchievement);
+		}
+	}
+
+	private UserAchievement getAchievementToUpdate(Long categoryId, Long userId) {
+		List<UserAchievement> userAchievements = userAchievementRepository
+			.findAllByUserIdAndCategoryId(userId, categoryId);
+
+		if (userAchievements.isEmpty()) {
+			Achievement achievement = achievementRepository
+				.findByCategoryId(categoryId).orElseThrow(() -> new AppException(ErrorCode.ACHIEVEMENT_NOT_FOUND));
+
+			UserAchievement nextAchievement = UserAchievement.builder()
+				.achievement(achievement)
+				.user(userRepository.getReferenceById(userId))
+				.currentValue(0)
+				.isRewardReceived(false)
+				.build();
+			return userAchievementRepository.save(nextAchievement);
+		} else {
+			return userAchievements.get(userAchievements.size() - 1);
+		}
+	}
+}

--- a/src/main/java/com/m3pro/groundflip/service/AchievementManager.java
+++ b/src/main/java/com/m3pro/groundflip/service/AchievementManager.java
@@ -1,7 +1,9 @@
 package com.m3pro.groundflip.service;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -9,6 +11,7 @@ import org.springframework.transaction.annotation.Transactional;
 import com.m3pro.groundflip.domain.entity.Achievement;
 import com.m3pro.groundflip.domain.entity.UserAchievement;
 import com.m3pro.groundflip.enums.AchievementCategoryId;
+import com.m3pro.groundflip.enums.SpecialAchievement;
 import com.m3pro.groundflip.exception.AppException;
 import com.m3pro.groundflip.exception.ErrorCode;
 import com.m3pro.groundflip.repository.AchievementRepository;
@@ -69,6 +72,23 @@ public class AchievementManager {
 			return userAchievementRepository.save(nextAchievement);
 		} else {
 			return userAchievements.get(userAchievements.size() - 1);
+		}
+	}
+
+	@Transactional
+	public void updateSpecialAchievement(Long userId, SpecialAchievement specialAchievement) {
+		Optional<UserAchievement> userAchievement = userAchievementRepository.findByAchievementAndUserId(
+			achievementRepository.getReferenceById(specialAchievement.getAchievementId()), userId);
+
+		if (userAchievement.isEmpty()) {
+			UserAchievement newUserAchievement = UserAchievement.builder()
+				.achievement(achievementRepository.getReferenceById(specialAchievement.getAchievementId()))
+				.user(userRepository.getReferenceById(userId))
+				.currentValue(1)
+				.obtainedAt(LocalDateTime.now())
+				.isRewardReceived(false)
+				.build();
+			userAchievementRepository.save(newUserAchievement);
 		}
 	}
 }

--- a/src/main/java/com/m3pro/groundflip/service/CommunityService.java
+++ b/src/main/java/com/m3pro/groundflip/service/CommunityService.java
@@ -19,6 +19,7 @@ import com.m3pro.groundflip.domain.dto.ranking.UserRankingResponse;
 import com.m3pro.groundflip.domain.entity.Community;
 import com.m3pro.groundflip.domain.entity.User;
 import com.m3pro.groundflip.domain.entity.UserCommunity;
+import com.m3pro.groundflip.enums.SpecialAchievement;
 import com.m3pro.groundflip.exception.AppException;
 import com.m3pro.groundflip.exception.ErrorCode;
 import com.m3pro.groundflip.repository.CommunityRankingRedisRepository;
@@ -37,6 +38,7 @@ public class CommunityService {
 	private final CommunityRepository communityRepository;
 	private final UserCommunityRepository userCommunityRepository;
 	private final CommunityRankingService communityRankingService;
+	private final AchievementManager achievementManager;
 	private final UserRepository userRepository;
 	private final UserRankingRedisRepository userRankingRedisRepository;
 	private final CommunityRankingRedisRepository communityRankingRedisRepository;
@@ -64,6 +66,7 @@ public class CommunityService {
 		return CommunityInfoResponse.from(community, rank, memberCount, currentPixel, accumulatePixel);
 	}
 
+	@Transactional
 	public void signInCommunity(Long communityId, CommunitySignRequest communitySignRequest) {
 		User user = userRepository.findById(communitySignRequest.getUserId())
 			.orElseThrow(() -> new AppException(ErrorCode.USER_NOT_FOUND));
@@ -83,6 +86,7 @@ public class CommunityService {
 			.build();
 
 		userCommunityRepository.save(userCommunity);
+		achievementManager.updateSpecialAchievement(user.getId(), SpecialAchievement.JOIN_GROUP);
 	}
 
 	public void signOutCommunity(Long communityId, CommunitySignRequest communitySignRequest) {

--- a/src/main/java/com/m3pro/groundflip/service/PixelManager.java
+++ b/src/main/java/com/m3pro/groundflip/service/PixelManager.java
@@ -183,8 +183,23 @@ public class PixelManager {
 	}
 
 	private void updatePixelOwnerUser(Pixel targetPixel, Long occupyingUserId) {
+		if (isLandTakenFromExistingUser(targetPixel, occupyingUserId)) {
+			achievementManager.updateAccumulateAchievement(occupyingUserId, AchievementCategoryId.CONQUEROR);
+		}
 		targetPixel.updateUserId(occupyingUserId);
 		targetPixel.updateUserOccupiedAtToNow();
+	}
+
+	private boolean isLandTakenFromExistingUser(Pixel targetPixel, Long occupyingUserId) {
+		Long originalOwnerUserId = targetPixel.getUserId();
+		LocalDateTime thisWeekStart = DateUtils.getThisWeekStartDate().atTime(0, 0);
+		LocalDateTime userOccupiedAt = targetPixel.getUserOccupiedAt();
+		if (!Objects.equals(originalOwnerUserId, occupyingUserId)) {
+			return originalOwnerUserId != null && !userOccupiedAt.isBefore(thisWeekStart);
+		} else {
+			return false;
+		}
+
 	}
 
 	private void updateRegionCount(Pixel targetPixel, boolean isCommunityUpdatable) {

--- a/src/main/java/com/m3pro/groundflip/service/PixelManager.java
+++ b/src/main/java/com/m3pro/groundflip/service/PixelManager.java
@@ -2,6 +2,7 @@ package com.m3pro.groundflip.service;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.Objects;
 import java.util.Optional;
 
 import org.locationtech.jts.geom.Coordinate;
@@ -154,6 +155,9 @@ public class PixelManager {
 			updateUserRegionCount(targetPixel, userId);
 			userRankingService.updateAccumulatedRanking(userId);
 			achievementManager.updateAccumulateAchievement(userId, AchievementCategoryId.EXPLORER);
+		}
+		if (!pixelUserRepository.existsByUserIdAndPixelIdForToday(userId, LocalDateTime.now())) {
+			achievementManager.updateAccumulateAchievement(userId, AchievementCategoryId.STEADY);
 		}
 	}
 

--- a/src/main/java/com/m3pro/groundflip/service/PixelManager.java
+++ b/src/main/java/com/m3pro/groundflip/service/PixelManager.java
@@ -17,6 +17,7 @@ import com.m3pro.groundflip.domain.entity.Pixel;
 import com.m3pro.groundflip.domain.entity.PixelUser;
 import com.m3pro.groundflip.domain.entity.Region;
 import com.m3pro.groundflip.domain.entity.UserRegionCount;
+import com.m3pro.groundflip.enums.AchievementCategoryId;
 import com.m3pro.groundflip.exception.AppException;
 import com.m3pro.groundflip.exception.ErrorCode;
 import com.m3pro.groundflip.repository.CommunityRepository;
@@ -53,6 +54,7 @@ public class PixelManager {
 	private final UserRegionCountRepository userRegionCountRepository;
 	private final UserRepository userRepository;
 	private final CommunityRepository communityRepository;
+	private final AchievementManager achievementManager;
 
 	@Transactional
 	public void occupyPixel(PixelOccupyRequest pixelOccupyRequest) {
@@ -151,6 +153,7 @@ public class PixelManager {
 		if (!pixelUserRepository.existsByPixelIdAndUserId(targetPixel.getId(), userId)) {
 			updateUserRegionCount(targetPixel, userId);
 			userRankingService.updateAccumulatedRanking(userId);
+			achievementManager.updateAccumulateAchievement(userId, AchievementCategoryId.EXPLORER);
 		}
 	}
 

--- a/src/test/java/com/m3pro/groundflip/service/CommunityServiceTest.java
+++ b/src/test/java/com/m3pro/groundflip/service/CommunityServiceTest.java
@@ -37,6 +37,9 @@ class CommunityServiceTest {
 	private UserCommunityRepository userCommunityRepository;
 
 	@Mock
+	private AchievementManager achievementManager;
+
+	@Mock
 	private UserRepository userRepository;
 
 	@Mock

--- a/src/test/java/com/m3pro/groundflip/service/PixelManagerTest.java
+++ b/src/test/java/com/m3pro/groundflip/service/PixelManagerTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
+import java.time.LocalDateTime;
 import java.util.Optional;
 
 import org.junit.jupiter.api.DisplayName;
@@ -41,6 +42,8 @@ class PixelManagerTest {
 	@Mock
 	private CommunityRepository communityRepository;
 	@Mock
+	private AchievementManager achievementManager;
+	@Mock
 	private PixelRepository pixelRepository;
 	@Mock
 	private PixelUserRepository pixelUserRepository;
@@ -66,6 +69,7 @@ class PixelManagerTest {
 			.x(222L)
 			.y(233L)
 			.userId(1L)
+			.userOccupiedAt(LocalDateTime.now())
 			.address("대한민국")
 			.build();
 		when(pixelRepository.findByXAndY(222L, 233L)).thenReturn(Optional.of(pixel));
@@ -88,6 +92,7 @@ class PixelManagerTest {
 			.x(222L)
 			.y(233L)
 			.userId(1L)
+			.userOccupiedAt(LocalDateTime.now())
 			.address("대한민국")
 			.build();
 		when(pixelRepository.findByXAndY(222L, 233L)).thenReturn(Optional.of(pixel));
@@ -108,6 +113,7 @@ class PixelManagerTest {
 			.x(222L)
 			.y(233L)
 			.userId(1L)
+			.userOccupiedAt(LocalDateTime.now())
 			.address(null)
 			.build();
 		when(pixelRepository.findByXAndY(222L, 233L)).thenReturn(Optional.of(pixel));
@@ -130,6 +136,7 @@ class PixelManagerTest {
 			.x(222L)
 			.y(233L)
 			.userId(1L)
+			.userOccupiedAt(LocalDateTime.now())
 			.address("대한민국 ")
 			.build();
 		when(pixelRepository.findByXAndY(222L, 233L)).thenReturn(Optional.of(pixel));
@@ -161,6 +168,7 @@ class PixelManagerTest {
 			.x(222L)
 			.y(233L)
 			.userId(1L)
+			.userOccupiedAt(LocalDateTime.now())
 			.address("대한민국 ")
 			.build();
 		double expectedLongitude = upper_left_lon + (233L * lon_per_pixel);


### PR DESCRIPTION
## 작업 내용*

- 누적 업정 업데이트 기능 구현
- 일회성 업적 업데이트 기능 구현

## 고민한 내용*

- 땅의 주인이 바뀔 때, 새로운 땅을 방문 할 때, 하루에 처음 땅을 먹었을때를 관련 업적의 진행도를 업데이트 하게 구현했다.
- 각 업적 데이터에 다음 목표가 있는 경우, 업적의 id 가 기록되어있어 하나의 업적이 달성되면 다음 업적으로 넘어가도록 구현했다.

## 리뷰 요구사항

- 리뷰할 때 중점적으로 봐줬으면 하는 내용들

## 스크린샷