### PR TITLE
M3-418 알림 시스템 구현

### DIFF
--- a/.github/workflows/cd_dev.yml
+++ b/.github/workflows/cd_dev.yml
@@ -39,6 +39,7 @@ jobs:
           echo "LATEST_VERSION=${{ secrets.LATEST_VERSION }}" >> .env
           echo "FORCE_UPDATE_VERSION=${{  secrets.FORCE_UPDATE_VERSION  }}" >> .env
           echo "GEOCODING_API=${{  secrets.GEOCODING_API  }}" >> .env
+          echo "FIREBASE_SECRET_KEY=${{  secrets.FIREBASE_SECRET_KEY  }}" >> .env
           
           echo "SPRING_PROFILES_ACTIVE=dev" >> .env
 

--- a/.github/workflows/cd_prod.yml
+++ b/.github/workflows/cd_prod.yml
@@ -39,6 +39,7 @@ jobs:
           echo "LATEST_VERSION=${{ secrets.LATEST_VERSION_PROD }}" >> .env
           echo "FORCE_UPDATE_VERSION=${{  secrets.FORCE_UPDATE_VERSION_PROD  }}" >> .env
           echo "GEOCODING_API=${{  secrets.GEOCODING_API  }}" >> .env
+          echo "FIREBASE_SECRET_KEY=${{  secrets.FIREBASE_SECRET_KEY  }}" >> .env
 
       - name: gradlew에 실행 권한 부여
         run: chmod +x ./gradlew

--- a/build.gradle
+++ b/build.gradle
@@ -58,6 +58,8 @@ dependencies {
 
     implementation 'org.redisson:redisson-spring-boot-starter:3.16.3'
 
+    implementation 'com.google.firebase:firebase-admin:9.2.0'
+
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     runtimeOnly 'com.mysql:mysql-connector-j'

--- a/src/main/java/com/m3pro/groundflip/config/FirebaseConfig.java
+++ b/src/main/java/com/m3pro/groundflip/config/FirebaseConfig.java
@@ -7,6 +7,7 @@ import java.util.Base64;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 
 import com.google.auth.oauth2.GoogleCredentials;
 import com.google.firebase.FirebaseApp;
@@ -16,6 +17,7 @@ import com.google.firebase.messaging.FirebaseMessaging;
 import jakarta.annotation.PostConstruct;
 
 @Configuration
+@Profile("!test")
 public class FirebaseConfig {
 	private FirebaseApp firebaseApp;
 	@Value("${spring.firebase.secret}")

--- a/src/main/java/com/m3pro/groundflip/config/FirebaseConfig.java
+++ b/src/main/java/com/m3pro/groundflip/config/FirebaseConfig.java
@@ -1,0 +1,37 @@
+package com.m3pro.groundflip.config;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.util.Base64;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.FirebaseOptions;
+import com.google.firebase.messaging.FirebaseMessaging;
+
+import jakarta.annotation.PostConstruct;
+
+@Configuration
+public class FirebaseConfig {
+	private FirebaseApp firebaseApp;
+	@Value("${spring.firebase.secret}")
+	private String secretKey;
+
+	@PostConstruct
+	public void init() throws IOException {
+		byte[] decodedBytes = Base64.getDecoder().decode(secretKey);
+		FirebaseOptions options = FirebaseOptions.builder()
+			.setCredentials(GoogleCredentials.fromStream(new ByteArrayInputStream(decodedBytes)))
+			.build();
+		firebaseApp = FirebaseApp.initializeApp(options);
+	}
+
+	@Bean
+	public FirebaseMessaging firebaseMessaging() {
+		return FirebaseMessaging.getInstance(firebaseApp);
+	}
+}

--- a/src/main/java/com/m3pro/groundflip/controller/NotificationController.java
+++ b/src/main/java/com/m3pro/groundflip/controller/NotificationController.java
@@ -47,4 +47,15 @@ public class NotificationController {
 		notificationService.markNotificationAsRead(notificationId);
 		return Response.createSuccessWithNoData();
 	}
+
+	@Operation(summary = "유저 별 읽지 않은 알림이 있는 지 여부 조회", description = "특정 유저가 최근 14일 동안 읽지 않는 알림이 있다면 true 를 반환한다.")
+	@Parameters({
+		@Parameter(name = "user-id", description = "찾고자 하는 user의 id", example = "14"),
+	})
+	@GetMapping("/unread/check")
+	public Response<Boolean> checkForUnreadNotifications(
+		@RequestParam(name = "user-id") Long userId
+	) {
+		return Response.createSuccess(notificationService.checkForUnreadNotifications(userId));
+	}
 }

--- a/src/main/java/com/m3pro/groundflip/controller/NotificationController.java
+++ b/src/main/java/com/m3pro/groundflip/controller/NotificationController.java
@@ -1,0 +1,50 @@
+package com.m3pro.groundflip.controller;
+
+import java.util.List;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.m3pro.groundflip.domain.dto.Response;
+import com.m3pro.groundflip.domain.dto.notification.NotificationResponse;
+import com.m3pro.groundflip.service.NotificationService;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@RestController
+@RequiredArgsConstructor
+@Slf4j
+@RequestMapping("/api/notifications")
+@Tag(name = "achievements", description = "알림 API")
+@SecurityRequirement(name = "Authorization")
+public class NotificationController {
+	private final NotificationService notificationService;
+
+	@Operation(summary = "유저 별 알림 목록 조회", description = "특정 유저의 14일 전부터 모든 알림 목록을 반환한다.")
+	@Parameters({
+		@Parameter(name = "user-id", description = "찾고자 하는 user의 id", example = "14"),
+	})
+	@GetMapping("")
+	public Response<List<NotificationResponse>> getNotifications(
+		@RequestParam(name = "user-id") Long userId
+	) {
+		return Response.createSuccess(notificationService.getAllNotifications(userId));
+	}
+
+	@Operation(summary = "알림 읽음 상태로 변경", description = "특정 알림의 상태를 읽음 상태로 변경한다.")
+	@PatchMapping("/{notificationId}/read")
+	public Response<?> markNotificationAsRead(@PathVariable("notificationId") Long notificationId) {
+		notificationService.markNotificationAsRead(notificationId);
+		return Response.createSuccessWithNoData();
+	}
+}

--- a/src/main/java/com/m3pro/groundflip/domain/dto/notification/NotificationResponse.java
+++ b/src/main/java/com/m3pro/groundflip/domain/dto/notification/NotificationResponse.java
@@ -2,6 +2,7 @@ package com.m3pro.groundflip.domain.dto.notification;
 
 import java.time.LocalDateTime;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.m3pro.groundflip.domain.entity.Notification;
 import com.m3pro.groundflip.domain.entity.UserNotification;
 
@@ -39,6 +40,7 @@ public class NotificationResponse {
 	private String contents;
 
 	@Schema(description = "알림 읽었는지 여부", example = "1")
+	@JsonProperty("isRead")
 	private boolean isRead;
 
 	public static NotificationResponse from(UserNotification userNotification) {

--- a/src/main/java/com/m3pro/groundflip/domain/dto/notification/NotificationResponse.java
+++ b/src/main/java/com/m3pro/groundflip/domain/dto/notification/NotificationResponse.java
@@ -1,0 +1,57 @@
+package com.m3pro.groundflip.domain.dto.notification;
+
+import java.time.LocalDateTime;
+
+import com.m3pro.groundflip.domain.entity.Notification;
+import com.m3pro.groundflip.domain.entity.UserNotification;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Schema(title = "알림 리스트의 정보")
+public class NotificationResponse {
+	@Schema(description = "알림 id", example = "1")
+	private Long notificationId;
+
+	@Schema(description = "알림 카테고리", example = "1")
+	private String category;
+
+	@Schema(description = "알림 id", example = "1")
+	private Long categoryId;
+
+	@Schema(description = "알림 제목", example = "1")
+	private String title;
+
+	@Schema(description = "알림 날짜", example = "1")
+	private LocalDateTime date;
+
+	@Schema(description = "알림 내용에 해당하는 데이터 id", example = "1")
+	private Long contentId;
+
+	@Schema(description = "알림 내용", example = "1")
+	private String contents;
+
+	@Schema(description = "알림 읽었는지 여부", example = "1")
+	private boolean isRead;
+
+	public static NotificationResponse from(UserNotification userNotification) {
+		Notification notification = userNotification.getNotification();
+		return NotificationResponse.builder()
+			.notificationId(userNotification.getId())
+			.category(notification.getCategory())
+			.categoryId(notification.getCategoryId())
+			.title(notification.getTitle())
+			.date(userNotification.getCreatedAt())
+			.contentId(notification.getContentId())
+			.contents(notification.getContent())
+			.isRead(userNotification.getReadAt() != null)
+			.build();
+	}
+}

--- a/src/main/java/com/m3pro/groundflip/domain/entity/Notification.java
+++ b/src/main/java/com/m3pro/groundflip/domain/entity/Notification.java
@@ -1,0 +1,36 @@
+package com.m3pro.groundflip.domain.entity;
+
+import com.m3pro.groundflip.domain.entity.global.BaseTimeEntity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class Notification extends BaseTimeEntity {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "notification_id")
+	private Long id;
+
+	private String title;
+
+	private String content;
+
+	private Long contentId;
+
+	private String category;
+
+	private Long categoryId;
+}

--- a/src/main/java/com/m3pro/groundflip/domain/entity/UserNotification.java
+++ b/src/main/java/com/m3pro/groundflip/domain/entity/UserNotification.java
@@ -1,0 +1,39 @@
+package com.m3pro.groundflip.domain.entity;
+
+import java.time.LocalDateTime;
+
+import com.m3pro.groundflip.domain.entity.global.BaseTimeEntity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class UserNotification extends BaseTimeEntity {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "notification_id")
+	private Long id;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "notification_id")
+	private Notification notification;
+
+	private Long userId;
+
+	private LocalDateTime readAt;
+}

--- a/src/main/java/com/m3pro/groundflip/domain/entity/UserNotification.java
+++ b/src/main/java/com/m3pro/groundflip/domain/entity/UserNotification.java
@@ -36,4 +36,8 @@ public class UserNotification extends BaseTimeEntity {
 	private Long userId;
 
 	private LocalDateTime readAt;
+
+	public void markAsRead() {
+		this.readAt = LocalDateTime.now();
+	}
 }

--- a/src/main/java/com/m3pro/groundflip/domain/entity/UserNotification.java
+++ b/src/main/java/com/m3pro/groundflip/domain/entity/UserNotification.java
@@ -26,7 +26,7 @@ import lombok.NoArgsConstructor;
 public class UserNotification extends BaseTimeEntity {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
-	@Column(name = "notification_id")
+	@Column(name = "user_notification_id")
 	private Long id;
 
 	@ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/m3pro/groundflip/enums/NotificationCategory.java
+++ b/src/main/java/com/m3pro/groundflip/enums/NotificationCategory.java
@@ -6,9 +6,10 @@ import lombok.Getter;
 @AllArgsConstructor
 @Getter
 public enum NotificationCategory {
-	ANNOUNCEMENT(1L),
-	NOTIFICATION(2L),
-	ACHIEVEMENT(3L);
+	ANNOUNCEMENT(1L, "공지"),
+	NOTIFICATION(2L, "알림"),
+	ACHIEVEMENT(3L, "업적");
 
 	private final Long categoryId;
+	private final String categoryName;
 }

--- a/src/main/java/com/m3pro/groundflip/enums/NotificationCategory.java
+++ b/src/main/java/com/m3pro/groundflip/enums/NotificationCategory.java
@@ -1,0 +1,14 @@
+package com.m3pro.groundflip.enums;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public enum NotificationCategory {
+	ANNOUNCEMENT(1L),
+	NOTIFICATION(2L),
+	ACHIEVEMENT(3L);
+
+	private final Long categoryId;
+}

--- a/src/main/java/com/m3pro/groundflip/enums/PushKind.java
+++ b/src/main/java/com/m3pro/groundflip/enums/PushKind.java
@@ -1,0 +1,13 @@
+package com.m3pro.groundflip.enums;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public enum PushKind {
+	SERVICE("service"),
+	MARKETING("marketing");
+
+	private final String kind;
+}

--- a/src/main/java/com/m3pro/groundflip/enums/PushTarget.java
+++ b/src/main/java/com/m3pro/groundflip/enums/PushTarget.java
@@ -1,0 +1,14 @@
+package com.m3pro.groundflip.enums;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public enum PushTarget {
+	ALL("all"),
+	IOS("iOS"),
+	ANDROID("Android");
+
+	private final String target;
+}

--- a/src/main/java/com/m3pro/groundflip/exception/ErrorCode.java
+++ b/src/main/java/com/m3pro/groundflip/exception/ErrorCode.java
@@ -16,6 +16,7 @@ public enum ErrorCode {
 	ACHIEVEMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 업적입니다."),
 	ACHIEVEMENT_CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 업적 카테고리 입니다."),
 	COMMUNITY_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 그룹입니다."),
+	NOTIFICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 알림입니다."),
 	PIXEL_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 픽셀입니다."),
 	IMAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 이미지입니다."),
 	PLACE_NOT_FOUND(HttpStatus.NOT_FOUND, "장소가 등록되어 있지 않습니다."),

--- a/src/main/java/com/m3pro/groundflip/repository/FcmTokenRepository.java
+++ b/src/main/java/com/m3pro/groundflip/repository/FcmTokenRepository.java
@@ -3,6 +3,8 @@ package com.m3pro.groundflip.repository;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import com.m3pro.groundflip.domain.entity.FcmToken;
 import com.m3pro.groundflip.domain.entity.User;
@@ -11,4 +13,12 @@ public interface FcmTokenRepository extends JpaRepository<FcmToken, Long> {
 	Optional<FcmToken> findByUser(User user);
 
 	void deleteByUser(User user);
+
+	@Query("""
+		SELECT f FROM FcmToken f
+		JOIN Permission p ON f.user.id = p.user.id
+		WHERE p.serviceNotificationsEnabled = true
+		AND f.user.id = :user_id
+		""")
+	Optional<FcmToken> findTokenForServiceNotifications(@Param("user_id") Long userId);
 }

--- a/src/main/java/com/m3pro/groundflip/repository/NotificationRepository.java
+++ b/src/main/java/com/m3pro/groundflip/repository/NotificationRepository.java
@@ -1,0 +1,8 @@
+package com.m3pro.groundflip.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.m3pro.groundflip.domain.entity.Notification;
+
+public interface NotificationRepository extends JpaRepository<Notification, Long> {
+}

--- a/src/main/java/com/m3pro/groundflip/repository/UserNotificationRepository.java
+++ b/src/main/java/com/m3pro/groundflip/repository/UserNotificationRepository.java
@@ -19,4 +19,13 @@ public interface UserNotificationRepository extends JpaRepository<UserNotificati
 		""")
 	List<UserNotification> findAllByUserId(@Param("user_id") Long userId,
 		@Param("lookup_date") LocalDateTime lookupDate);
+
+	@Query("""
+		SELECT count(un) > 0 FROM UserNotification un
+		WHERE un.userId = :user_id
+		AND un.createdAt > :lookup_date
+		AND un.readAt is null
+		""")
+	boolean existsByUserId(@Param("user_id") Long userId,
+		@Param("lookup_date") LocalDateTime lookupDate);
 }

--- a/src/main/java/com/m3pro/groundflip/repository/UserNotificationRepository.java
+++ b/src/main/java/com/m3pro/groundflip/repository/UserNotificationRepository.java
@@ -1,0 +1,21 @@
+package com.m3pro.groundflip.repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import com.m3pro.groundflip.domain.entity.UserNotification;
+
+public interface UserNotificationRepository extends JpaRepository<UserNotification, Long> {
+	@Query("""
+		SELECT un FROM UserNotification un
+		JOIN FETCH un.notification
+		WHERE un.userId = :userId
+		AND un.createdAt > :lookup_date
+		""")
+	List<UserNotification> findAllByUserId(@Param("user_id") Long userId,
+		@Param("lookup_date") LocalDateTime lookupDate);
+}

--- a/src/main/java/com/m3pro/groundflip/repository/UserNotificationRepository.java
+++ b/src/main/java/com/m3pro/groundflip/repository/UserNotificationRepository.java
@@ -13,7 +13,7 @@ public interface UserNotificationRepository extends JpaRepository<UserNotificati
 	@Query("""
 		SELECT un FROM UserNotification un
 		JOIN FETCH un.notification
-		WHERE un.userId = :userId
+		WHERE un.userId = :user_id
 		AND un.createdAt > :lookup_date
 		""")
 	List<UserNotification> findAllByUserId(@Param("user_id") Long userId,

--- a/src/main/java/com/m3pro/groundflip/repository/UserNotificationRepository.java
+++ b/src/main/java/com/m3pro/groundflip/repository/UserNotificationRepository.java
@@ -15,6 +15,7 @@ public interface UserNotificationRepository extends JpaRepository<UserNotificati
 		JOIN FETCH un.notification
 		WHERE un.userId = :user_id
 		AND un.createdAt > :lookup_date
+		ORDER BY un.createdAt DESC
 		""")
 	List<UserNotification> findAllByUserId(@Param("user_id") Long userId,
 		@Param("lookup_date") LocalDateTime lookupDate);

--- a/src/main/java/com/m3pro/groundflip/service/AchievementManager.java
+++ b/src/main/java/com/m3pro/groundflip/service/AchievementManager.java
@@ -28,6 +28,7 @@ public class AchievementManager {
 	private final AchievementRepository achievementRepository;
 	private final UserAchievementRepository userAchievementRepository;
 	private final UserRepository userRepository;
+	private final NotificationService notificationService;
 
 	@Transactional
 	public void updateAccumulateAchievement(Long userId, AchievementCategoryId categoryId) {
@@ -43,6 +44,8 @@ public class AchievementManager {
 
 	private void completeAchievement(UserAchievement achievementToUpdate, Long userId) {
 		achievementToUpdate.setObtainedAt();
+		notificationService.createAchievementNotification(userId, achievementToUpdate.getAchievement());
+
 		Long nextAchievementId = achievementToUpdate.getAchievement().getNextAchievementId();
 		if (nextAchievementId != null) {
 			UserAchievement nextAchievement = UserAchievement.builder()
@@ -81,6 +84,8 @@ public class AchievementManager {
 			achievementRepository.getReferenceById(specialAchievement.getAchievementId()), userId);
 
 		if (userAchievement.isEmpty()) {
+			Achievement achievementToUpdate = achievementRepository.getReferenceById(
+				specialAchievement.getAchievementId());
 			UserAchievement newUserAchievement = UserAchievement.builder()
 				.achievement(achievementRepository.getReferenceById(specialAchievement.getAchievementId()))
 				.user(userRepository.getReferenceById(userId))
@@ -89,6 +94,8 @@ public class AchievementManager {
 				.isRewardReceived(false)
 				.build();
 			userAchievementRepository.save(newUserAchievement);
+
+			notificationService.createAchievementNotification(userId, achievementToUpdate);
 		}
 	}
 }

--- a/src/main/java/com/m3pro/groundflip/service/FcmService.java
+++ b/src/main/java/com/m3pro/groundflip/service/FcmService.java
@@ -4,6 +4,13 @@ import java.util.Optional;
 
 import org.springframework.stereotype.Service;
 
+import com.google.firebase.messaging.ApnsConfig;
+import com.google.firebase.messaging.Aps;
+import com.google.firebase.messaging.FirebaseMessaging;
+import com.google.firebase.messaging.FirebaseMessagingException;
+import com.google.firebase.messaging.Message;
+import com.google.firebase.messaging.MessagingErrorCode;
+import com.google.firebase.messaging.Notification;
 import com.m3pro.groundflip.domain.dto.user.FcmTokenRequest;
 import com.m3pro.groundflip.domain.entity.FcmToken;
 import com.m3pro.groundflip.domain.entity.User;
@@ -25,6 +32,14 @@ public class FcmService {
 	private final UserRepository userRepository;
 	private final FcmTokenRepository fcmTokenRepository;
 	private final UserActivityLogRepository userActivityLogRepository;
+	private final FirebaseMessaging firebaseMessaging;
+
+	private static Notification createNotification(String title, String body) {
+		return Notification.builder()
+			.setTitle(title)
+			.setBody(body)
+			.build();
+	}
 
 	@Transactional
 	public void registerFcmToken(FcmTokenRequest fcmTokenRequest) {
@@ -54,5 +69,50 @@ public class FcmService {
 			.activity("APP_OPEN")
 			.build();
 		userActivityLogRepository.save(userActivityLog);
+	}
+
+	public void sendNotificationToUser(String title, String body, Long userId) {
+		Optional<FcmToken> fcmToken = fcmTokenRepository.findTokenForServiceNotifications(userId);
+		if (fcmToken.isPresent()) {
+			FcmToken token = fcmToken.get();
+			try {
+				log.info("success send notification to user [{}]: tokenId = {}", token.getUser().getId(),
+					token.getId());
+				sendMessage(title, body, token.getToken());
+			} catch (FirebaseMessagingException e) {
+				if (isInvalidTokenError(e)) {
+					fcmTokenRepository.deleteByUser(token.getUser());
+					log.info("Failed to send notification to [{}]: {}", token.getUser().getId(), token.getToken());
+				}
+			}
+		}
+	}
+
+	public void sendMessage(String title, String body, String fcmToken) throws FirebaseMessagingException {
+		Message message = createMessage(title, body, fcmToken);
+		firebaseMessaging.send(message);
+	}
+
+	private Message createMessage(String title, String body, String fcmToken) {
+		Notification notification = createNotification(title, body);
+		return Message.builder()
+			.setToken(fcmToken)
+			.setNotification(notification)
+			.setApnsConfig(getApnsConfig())
+			.build();
+	}
+
+	private ApnsConfig getApnsConfig() {
+		return ApnsConfig.builder()
+			.setAps(Aps.builder()
+				.setSound("default")
+				.build()
+			).build();
+	}
+
+	private boolean isInvalidTokenError(FirebaseMessagingException e) {
+		MessagingErrorCode errorCode = e.getMessagingErrorCode();
+		return errorCode.equals(MessagingErrorCode.UNREGISTERED) || errorCode.equals(
+			MessagingErrorCode.INVALID_ARGUMENT);
 	}
 }

--- a/src/main/java/com/m3pro/groundflip/service/NotificationService.java
+++ b/src/main/java/com/m3pro/groundflip/service/NotificationService.java
@@ -7,8 +7,11 @@ import org.springframework.stereotype.Service;
 
 import com.m3pro.groundflip.domain.dto.notification.NotificationResponse;
 import com.m3pro.groundflip.domain.entity.UserNotification;
+import com.m3pro.groundflip.exception.AppException;
+import com.m3pro.groundflip.exception.ErrorCode;
 import com.m3pro.groundflip.repository.UserNotificationRepository;
 
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -23,5 +26,13 @@ public class NotificationService {
 		List<UserNotification> userNotifications = userNotificationRepository.findAllByUserId(userId, lookupDate);
 
 		return userNotifications.stream().map((NotificationResponse::from)).toList();
+	}
+
+	@Transactional
+	public void markNotificationAsRead(Long notificationId) {
+		UserNotification userNotification = userNotificationRepository.findById(notificationId)
+			.orElseThrow(() -> new AppException(ErrorCode.NOTIFICATION_NOT_FOUND));
+
+		userNotification.markAsRead();
 	}
 }

--- a/src/main/java/com/m3pro/groundflip/service/NotificationService.java
+++ b/src/main/java/com/m3pro/groundflip/service/NotificationService.java
@@ -35,4 +35,9 @@ public class NotificationService {
 
 		userNotification.markAsRead();
 	}
+
+	public boolean checkForUnreadNotifications(Long userId) {
+		LocalDateTime lookupDate = LocalDateTime.now().minusDays(14);
+		return userNotificationRepository.existsByUserId(userId, lookupDate);
+	}
 }

--- a/src/main/java/com/m3pro/groundflip/service/NotificationService.java
+++ b/src/main/java/com/m3pro/groundflip/service/NotificationService.java
@@ -25,6 +25,7 @@ import lombok.extern.slf4j.Slf4j;
 public class NotificationService {
 	private final UserNotificationRepository userNotificationRepository;
 	private final NotificationRepository notificationRepository;
+	private final FcmService fcmService;
 
 	public List<NotificationResponse> getAllNotifications(Long userId) {
 		LocalDateTime lookupDate = LocalDateTime.now().minusDays(14);
@@ -59,5 +60,6 @@ public class NotificationService {
 			.userId(userId)
 			.notification(notification)
 			.build());
+		fcmService.sendNotificationToUser(achievement.getName() + " 획득!", achievement.getName() + " 획득하였습니다!", userId);
 	}
 }

--- a/src/main/java/com/m3pro/groundflip/service/NotificationService.java
+++ b/src/main/java/com/m3pro/groundflip/service/NotificationService.java
@@ -1,0 +1,27 @@
+package com.m3pro.groundflip.service;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+
+import com.m3pro.groundflip.domain.dto.notification.NotificationResponse;
+import com.m3pro.groundflip.domain.entity.UserNotification;
+import com.m3pro.groundflip.repository.UserNotificationRepository;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class NotificationService {
+	private final UserNotificationRepository userNotificationRepository;
+
+	public List<NotificationResponse> getAllNotifications(Long userId) {
+		LocalDateTime lookupDate = LocalDateTime.now().minusDays(14);
+		List<UserNotification> userNotifications = userNotificationRepository.findAllByUserId(userId, lookupDate);
+
+		return userNotifications.stream().map((NotificationResponse::from)).toList();
+	}
+}

--- a/src/main/java/com/m3pro/groundflip/service/NotificationService.java
+++ b/src/main/java/com/m3pro/groundflip/service/NotificationService.java
@@ -6,9 +6,13 @@ import java.util.List;
 import org.springframework.stereotype.Service;
 
 import com.m3pro.groundflip.domain.dto.notification.NotificationResponse;
+import com.m3pro.groundflip.domain.entity.Achievement;
+import com.m3pro.groundflip.domain.entity.Notification;
 import com.m3pro.groundflip.domain.entity.UserNotification;
+import com.m3pro.groundflip.enums.NotificationCategory;
 import com.m3pro.groundflip.exception.AppException;
 import com.m3pro.groundflip.exception.ErrorCode;
+import com.m3pro.groundflip.repository.NotificationRepository;
 import com.m3pro.groundflip.repository.UserNotificationRepository;
 
 import jakarta.transaction.Transactional;
@@ -20,6 +24,7 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class NotificationService {
 	private final UserNotificationRepository userNotificationRepository;
+	private final NotificationRepository notificationRepository;
 
 	public List<NotificationResponse> getAllNotifications(Long userId) {
 		LocalDateTime lookupDate = LocalDateTime.now().minusDays(14);
@@ -39,5 +44,20 @@ public class NotificationService {
 	public boolean checkForUnreadNotifications(Long userId) {
 		LocalDateTime lookupDate = LocalDateTime.now().minusDays(14);
 		return userNotificationRepository.existsByUserId(userId, lookupDate);
+	}
+
+	@Transactional
+	public void createAchievementNotification(Long userId, Achievement achievement) {
+		Notification notification = notificationRepository.save(Notification.builder()
+			.title(achievement.getName() + " 획득!")
+			.category(NotificationCategory.ACHIEVEMENT.getCategoryName())
+			.categoryId(NotificationCategory.ACHIEVEMENT.getCategoryId())
+			.contentId(achievement.getId())
+			.build()
+		);
+		userNotificationRepository.save(UserNotification.builder()
+			.userId(userId)
+			.notification(notification)
+			.build());
 	}
 }

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -25,6 +25,8 @@ spring:
     multipart:
       max-file-size: 10MB
       max-request-size: 10MB
+  firebase:
+    secret: ${FIREBASE_SECRET_KEY}
 
 logging:
   level:

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -26,6 +26,8 @@ spring:
     multipart:
       max-file-size: 10MB
       max-request-size: 10MB
+  firebase:
+    secret: ${FIREBASE_SECRET_KEY}
 
 logging:
   level:

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -25,6 +25,8 @@ spring:
     multipart:
       max-file-size: 10MB
       max-request-size: 10MB
+  firebase:
+    secret: ${FIREBASE_SECRET_KEY}
 
 logging:
   level:

--- a/src/test/java/com/m3pro/groundflip/GroundFlipApplicationTests.java
+++ b/src/test/java/com/m3pro/groundflip/GroundFlipApplicationTests.java
@@ -1,15 +1,19 @@
 package com.m3pro.groundflip;
 
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.ActiveProfiles;
+
+import com.google.firebase.messaging.FirebaseMessaging;
 
 @SpringBootTest
 @ActiveProfiles("test")
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 class GroundFlipApplicationTests {
+	@MockBean
+	private FirebaseMessaging firebaseMessaging;
 
 	@Test
 	void contextLoads() {

--- a/src/test/java/com/m3pro/groundflip/repository/PixelRepositoryTest.java
+++ b/src/test/java/com/m3pro/groundflip/repository/PixelRepositoryTest.java
@@ -15,8 +15,10 @@ import org.locationtech.jts.geom.Point;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.ActiveProfiles;
 
+import com.google.firebase.messaging.FirebaseMessaging;
 import com.m3pro.groundflip.domain.dto.pixel.IndividualModePixelResponse;
 import com.m3pro.groundflip.domain.entity.Pixel;
 import com.m3pro.groundflip.util.DateUtils;
@@ -35,12 +37,12 @@ public class PixelRepositoryTest {
 	private static final double LATITUDE_200M_AWAY = 37.604058;
 	private static final double LONGITUDE_200M_AWAY = 126.925948;
 	private static final int RADIUS = 100;
-
 	@Autowired
 	PixelRepository pixelRepository;
-
 	@Autowired
 	GeometryFactory geometryFactory;
+	@MockBean
+	private FirebaseMessaging firebaseMessaging;
 
 	@BeforeEach
 	void setUp() {

--- a/src/test/java/com/m3pro/groundflip/repository/PixelUserRepositoryTest.java
+++ b/src/test/java/com/m3pro/groundflip/repository/PixelUserRepositoryTest.java
@@ -12,8 +12,10 @@ import org.locationtech.jts.geom.Point;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.ActiveProfiles;
 
+import com.google.firebase.messaging.FirebaseMessaging;
 import com.m3pro.groundflip.domain.entity.Community;
 import com.m3pro.groundflip.domain.entity.Pixel;
 import com.m3pro.groundflip.domain.entity.PixelUser;
@@ -30,6 +32,8 @@ public class PixelUserRepositoryTest {
 	CommunityRepository communityRepository;
 	@Autowired
 	GeometryFactory geometryFactory;
+	@MockBean
+	private FirebaseMessaging firebaseMessaging;
 	@Autowired
 	private PixelUserRepository pixelUserRepository;
 	@Autowired

--- a/src/test/java/com/m3pro/groundflip/repository/RankingHistoryRepositoryTest.java
+++ b/src/test/java/com/m3pro/groundflip/repository/RankingHistoryRepositoryTest.java
@@ -9,8 +9,10 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.ActiveProfiles;
 
+import com.google.firebase.messaging.FirebaseMessaging;
 import com.m3pro.groundflip.domain.dto.ranking.UserRankingResponse;
 import com.m3pro.groundflip.domain.entity.RankingHistory;
 import com.m3pro.groundflip.domain.entity.User;
@@ -21,6 +23,8 @@ import jakarta.transaction.Transactional;
 @ActiveProfiles("test")
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 public class RankingHistoryRepositoryTest {
+	@MockBean
+	private FirebaseMessaging firebaseMessaging;
 	@Autowired
 	private RankingHistoryRepository rankingHistoryRepository;
 	@Autowired

--- a/src/test/java/com/m3pro/groundflip/repository/RankingRedisRepositoryTest.java
+++ b/src/test/java/com/m3pro/groundflip/repository/RankingRedisRepositoryTest.java
@@ -10,20 +10,32 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
 import org.springframework.data.redis.core.RedisCallback;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.ZSetOperations;
 import org.springframework.test.context.ActiveProfiles;
 
+import com.google.firebase.messaging.FirebaseMessaging;
+import com.m3pro.groundflip.config.FirebaseConfig;
 import com.m3pro.groundflip.domain.dto.ranking.Ranking;
 
 @SpringBootTest
 @ActiveProfiles("test")
+@ComponentScan(
+	excludeFilters = @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, value = FirebaseConfig.class)
+)
+@ImportAutoConfiguration(exclude = FirebaseConfig.class)
 class RankingRedisRepositoryTest {
 	private static final String CURRENT_RANKING_KEY = "current_pixel_ranking";
 	private static final String ACCUMULATE_RANKING_KEY = "accumulate_pixel_ranking";
 	RankingRedisRepository rankingRedisRepository;
+	@MockBean
+	private FirebaseMessaging firebaseMessaging;
 	@Autowired
 	private RedisTemplate<String, String> redisTemplate;
 

--- a/src/test/java/com/m3pro/groundflip/service/PixelEventTest.java
+++ b/src/test/java/com/m3pro/groundflip/service/PixelEventTest.java
@@ -10,6 +10,7 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.ApplicationContext;
 import org.springframework.test.context.ActiveProfiles;
 
+import com.google.firebase.messaging.FirebaseMessaging;
 import com.m3pro.groundflip.domain.dto.pixel.event.PixelAddressUpdateEvent;
 import com.m3pro.groundflip.domain.dto.pixel.event.PixelUserInsertEvent;
 import com.m3pro.groundflip.domain.entity.Pixel;
@@ -20,6 +21,8 @@ import jakarta.transaction.Transactional;
 @ActiveProfiles("test")
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 public class PixelEventTest {
+	@MockBean
+	private FirebaseMessaging firebaseMessaging;
 	@Autowired
 	private ApplicationContext applicationContext;
 	@MockBean

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -26,7 +26,7 @@ spring:
       max-file-size: 10MB
       max-request-size: 10MB
   firebase:
-    secret: ${FIREBASE_SECRET_KEY}
+    secret: 1234
 
 logging:
   level:
@@ -89,3 +89,6 @@ version:
 
 geocoding:
   api: "http://localhost:3030/find_district"
+
+firebase:
+  enabled: false

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -25,6 +25,8 @@ spring:
     multipart:
       max-file-size: 10MB
       max-request-size: 10MB
+  firebase:
+    secret: ${FIREBASE_SECRET_KEY}
 
 logging:
   level:


### PR DESCRIPTION
## 작업 내용*
- 알림 목록을 반환하는 api 구현
- 알림의 읽음 여부를 업데이트 하는 api 구현
- 업적 획득시 알림이 전송되는 기능 구현

## 고민한 내용*

- 테이블을 notification, user_notification 으로 분리 하였다.
  - 분리한 이유는 전체 공지의 경우 모든 유저에게 데이터를 만들경우 데이터 중복이 많기 때문에 알림 정보를 저장하는 테이블과 해당알림이 어떤 유저에게 전달되고 읽었는지를 파악하는 테이블로 분리하였다.
  - 가입하고 나서의 모든 알림은 보여줄 필요가 없다고 판단하여 최근 14일 동안의 알림만 전달하도록 구현했다.
  - 업적 획득시 유저에게 알리기 위해 기존 배치 서버에서만 사용했던 fcmService 를 가져왔다.
  - 업적 획득시 notification, user_notification 에 알림 데이터가 저장되고 fcm 을 통해 알림이 전송되게 된다.

## 리뷰 요구사항

- 리뷰할 때 중점적으로 봐줬으면 하는 내용들

## 스크린샷