### PR TITLE
M3-412 스레드가 락을 소유하지 않았는데 락을 해제 하는 문제 해결

### DIFF
--- a/src/main/java/com/m3pro/groundflip/service/PixelManagerWithLock.java
+++ b/src/main/java/com/m3pro/groundflip/service/PixelManagerWithLock.java
@@ -39,7 +39,9 @@ public class PixelManagerWithLock {
 		} catch (InterruptedException e) {
 			throw new RuntimeException(e);
 		} finally {
-			rLock.unlock();
+			if (rLock != null && rLock.isLocked()) {
+				rLock.unlock();
+			}
 		}
 	}
 }


### PR DESCRIPTION
## 작업 내용*

- 락이 해제 되지 않은 경우에만 락을 해제하는 로직 추가

## 고민한 내용*
### 에러 설명
부하 상황에서 땅을 차지 하는 로직에서 엄청나게 많은 에러 발생

### 발생 원인
스레드가 현재 소유하지 않은 락을 해제하려고 하면서 발생하는 문제 (추청)


```
		} finally {
			rLock.unlock();
		}
```
기존 코드에서 무조건 락을 해제 하도록 구현

## 리뷰 요구사항


## 스크린샷