### PR TITLE
M3-420 현재 px 이 0인 데이터를 필터링하는 기능 추가

### DIFF
--- a/src/main/java/com/m3pro/groundflip/repository/CommunityRankingHistoryRepository.java
+++ b/src/main/java/com/m3pro/groundflip/repository/CommunityRankingHistoryRepository.java
@@ -16,7 +16,7 @@ public interface CommunityRankingHistoryRepository extends JpaRepository<Communi
 			(c.id, c.name, c.backgroundImageUrl, crh.currentPixelCount, crh.ranking)
 			FROM CommunityRankingHistory crh 
 			INNER JOIN Community c on c.id = crh.communityId 
-			WHERE crh.year = :requestYear AND crh.week = :requestWeek
+			WHERE crh.year = :requestYear AND crh.week = :requestWeek AND crh.currentPixelCount > 0
 			ORDER BY crh.ranking ASC 
 			LIMIT 30 
 		""")

--- a/src/main/java/com/m3pro/groundflip/repository/RankingHistoryRepository.java
+++ b/src/main/java/com/m3pro/groundflip/repository/RankingHistoryRepository.java
@@ -16,7 +16,7 @@ public interface RankingHistoryRepository extends JpaRepository<RankingHistory, 
 			(u.id, u.nickname, u.profileImage, rh.currentPixelCount, rh.ranking)
 			FROM RankingHistory rh 
 			INNER JOIN User u on u.id = rh.userId 
-			WHERE rh.year = :requestYear AND rh.week = :requestWeek
+			WHERE rh.year = :requestYear AND rh.week = :requestWeek AND rh.currentPixelCount > 0
 			ORDER BY rh.ranking ASC 
 			LIMIT 30 
 		""")

--- a/src/main/java/com/m3pro/groundflip/repository/RankingRedisRepository.java
+++ b/src/main/java/com/m3pro/groundflip/repository/RankingRedisRepository.java
@@ -2,6 +2,7 @@ package com.m3pro.groundflip.repository;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 
@@ -89,7 +90,10 @@ public class RankingRedisRepository {
 		List<Ranking> rankings = new ArrayList<>();
 		long rank = 1;
 		for (ZSetOperations.TypedTuple<String> typedTuple : typedTuples) {
-			rankings.add(Ranking.from(typedTuple, rank++));
+			if (!Objects.equals(typedTuple.getScore(), (double)0)) {
+				rankings.add(Ranking.from(typedTuple, rank++));
+			}
+
 		}
 		return rankings;
 	}

--- a/src/main/java/com/m3pro/groundflip/service/CommunityRankingService.java
+++ b/src/main/java/com/m3pro/groundflip/service/CommunityRankingService.java
@@ -160,7 +160,7 @@ public class CommunityRankingService {
 			DateUtils.getWeekOfDate(lookUpDate)
 		);
 
-		if (rankingHistory.isPresent()) {
+		if (rankingHistory.isPresent() && rankingHistory.get().getCurrentPixelCount() > 0) {
 			return CommunityRankingResponse.from(
 				community,
 				rankingHistory.get().getRanking(),

--- a/src/main/java/com/m3pro/groundflip/service/CommunityRankingService.java
+++ b/src/main/java/com/m3pro/groundflip/service/CommunityRankingService.java
@@ -173,10 +173,14 @@ public class CommunityRankingService {
 	private CommunityRankingResponse getCurrentWeekCurrentPixelCommunityRanking(Long communityId) {
 		Community community = communityRepository.findById(communityId)
 			.orElseThrow(() -> new AppException(ErrorCode.COMMUNITY_NOT_FOUND));
-
-		Long rank = getCommunityCurrentPixelRankFromCache(communityId);
 		Long currentPixelCount = getCurrentPixelCountFromCache(communityId);
-		return CommunityRankingResponse.from(community, rank, currentPixelCount);
+
+		if (currentPixelCount == 0) {
+			return CommunityRankingResponse.from(community, null, null);
+		} else {
+			Long rank = getCommunityCurrentPixelRankFromCache(communityId);
+			return CommunityRankingResponse.from(community, rank, currentPixelCount);
+		}
 	}
 
 	/**

--- a/src/main/java/com/m3pro/groundflip/service/UserRankingService.java
+++ b/src/main/java/com/m3pro/groundflip/service/UserRankingService.java
@@ -184,9 +184,14 @@ public class UserRankingService {
 	private UserRankingResponse getCurrentWeekCurrentPixelUserRanking(Long userId) {
 		User user = userRepository.findById(userId)
 			.orElseThrow(() -> new AppException(ErrorCode.USER_NOT_FOUND));
-		Long rank = getUserCurrentPixelRankFromCache(userId);
 		Long currentPixelCount = getCurrentPixelCountFromCache(userId);
-		return UserRankingResponse.from(user, rank, currentPixelCount);
+
+		if (currentPixelCount == 0) {
+			return UserRankingResponse.from(user, null, null);
+		} else {
+			Long rank = getUserCurrentPixelRankFromCache(userId);
+			return UserRankingResponse.from(user, rank, currentPixelCount);
+		}
 	}
 
 	/**

--- a/src/main/java/com/m3pro/groundflip/service/UserRankingService.java
+++ b/src/main/java/com/m3pro/groundflip/service/UserRankingService.java
@@ -171,7 +171,7 @@ public class UserRankingService {
 			DateUtils.getWeekOfDate(lookUpDate)
 		);
 
-		if (rankingHistory.isPresent()) {
+		if (rankingHistory.isPresent() && rankingHistory.get().getCurrentPixelCount() > 0) {
 			return UserRankingResponse.from(
 				user,
 				rankingHistory.get().getRanking(),


### PR DESCRIPTION
## 작업 내용*

- 전체 랭킹 조회시 score가 0인 데이터에 대해서는 api 로 응답하지 않도록 필터링 하도록 하였다.
  - redis 에서 조회하는 부분과 DB 에서 조회하는 부분 모두 수정
- 개인 랭킹 조회시 score가 0인 데이터는 랭킹과 점수가 null 로 응답되도록 수정
  - redis 에서 조회하는 부분과 DB 에서 조회하는 부분 모두 수정

## 고민한 내용*

- 점수가 0인 유저가 랭킹을 갖는게 비효율적이라고 생각이 들었다. 아무 의미없는 데이터가 랭킹을 가지는 것 보다 점수가 있는 유저 들이 랭킹을 갖는 것이 맞다고 생각했다.
- 추후 배치 서버의 저장 로직도 수정하려고 한다. 현재 ranking_history 테이블의 데이터를 살펴 보니 38079 개의 데이터 중 33835 개의 데이터가 점수가 0인 데이터였다. 약 88%의 데이터가 의미 없는 데이터이기에 점수가 0인 데이터는 저장하지 않는 방향으로 수정한다.



## 스크린샷