### PR TITLE
M3-421 현재 누적 랭킹을 반환하는 api 구현

### DIFF
--- a/src/main/java/com/m3pro/groundflip/controller/RankingController.java
+++ b/src/main/java/com/m3pro/groundflip/controller/RankingController.java
@@ -63,4 +63,18 @@ public class RankingController {
 		return Response.createSuccess(
 			communityRankingService.getCommunityCurrentPixelRankInfo(communityId, lookUpDate));
 	}
+
+	@Operation(summary = "개인전 전체 누적 랭킹 조회", description = "현재 개인전 유저들의 지금 까지 차지한 누적 픽셀 기준으로 상위 100명의 랭킹을 반환한다.")
+	@GetMapping("/accumulate/user")
+	public Response<List<UserRankingResponse>> getAllUserAccumulateRanking() {
+		return Response.createSuccess(userRankingService.getAccumulatePixelAllUserRankings());
+	}
+
+	@Operation(summary = "개인전 개인 누적 랭킹 조회", description = "특정 유저의 현재 누적 픽셀 순위를 반환한다.")
+	@GetMapping("/accumulate/user/{userId}")
+	public Response<UserRankingResponse> getAccumulateRank(
+		@Parameter(description = "찾고자 하는 userID", required = true) @PathVariable("userId") Long userId
+	) {
+		return Response.createSuccess(userRankingService.getUserAccumulatePixelRankInfo(userId));
+	}
 }

--- a/src/main/java/com/m3pro/groundflip/domain/entity/RankingHistory.java
+++ b/src/main/java/com/m3pro/groundflip/domain/entity/RankingHistory.java
@@ -30,6 +30,10 @@ public class RankingHistory extends BaseTimeEntity {
 
 	Long currentPixelCount;
 
+	Long accumulateRanking;
+
+	Long accumulatePixelCount;
+
 	Integer year;
 
 	Integer week;

--- a/src/main/java/com/m3pro/groundflip/domain/entity/RankingHistory.java
+++ b/src/main/java/com/m3pro/groundflip/domain/entity/RankingHistory.java
@@ -30,10 +30,6 @@ public class RankingHistory extends BaseTimeEntity {
 
 	Long currentPixelCount;
 
-	Long accumulateRanking;
-
-	Long accumulatePixelCount;
-
 	Integer year;
 
 	Integer week;

--- a/src/main/java/com/m3pro/groundflip/repository/RankingHistoryRepository.java
+++ b/src/main/java/com/m3pro/groundflip/repository/RankingHistoryRepository.java
@@ -22,19 +22,6 @@ public interface RankingHistoryRepository extends JpaRepository<RankingHistory, 
 		""")
 	List<UserRankingResponse> findAllByYearAndWeek(@Param("requestYear") int year, @Param("requestWeek") int week);
 
-	@Query("""
-			SELECT new com.m3pro.groundflip.domain.dto.ranking.UserRankingResponse
-			(u.id, u.nickname, u.profileImage, rh.accumulatePixelCount, rh.accumulateRanking)
-			FROM RankingHistory rh 
-			INNER JOIN User u on u.id = rh.userId 
-			WHERE rh.year = :requestYear AND rh.week = :requestWeek AND rh.accumulatePixelCount > 0
-			ORDER BY rh.ranking ASC 
-			LIMIT 100 
-		""")
-	List<UserRankingResponse> findAllAccumulateRankingByYearAndWeek(
-		@Param("requestYear") int year,
-		@Param("requestWeek") int week);
-
 	Optional<RankingHistory> findByUserIdAndYearAndWeek(
 		@Param("userId") Long userId,
 		@Param("requestYear") int year,

--- a/src/main/java/com/m3pro/groundflip/repository/RankingHistoryRepository.java
+++ b/src/main/java/com/m3pro/groundflip/repository/RankingHistoryRepository.java
@@ -18,9 +18,22 @@ public interface RankingHistoryRepository extends JpaRepository<RankingHistory, 
 			INNER JOIN User u on u.id = rh.userId 
 			WHERE rh.year = :requestYear AND rh.week = :requestWeek AND rh.currentPixelCount > 0
 			ORDER BY rh.ranking ASC 
-			LIMIT 30 
+			LIMIT 100 
 		""")
 	List<UserRankingResponse> findAllByYearAndWeek(@Param("requestYear") int year, @Param("requestWeek") int week);
+
+	@Query("""
+			SELECT new com.m3pro.groundflip.domain.dto.ranking.UserRankingResponse
+			(u.id, u.nickname, u.profileImage, rh.accumulatePixelCount, rh.accumulateRanking)
+			FROM RankingHistory rh 
+			INNER JOIN User u on u.id = rh.userId 
+			WHERE rh.year = :requestYear AND rh.week = :requestWeek AND rh.accumulatePixelCount > 0
+			ORDER BY rh.ranking ASC 
+			LIMIT 100 
+		""")
+	List<UserRankingResponse> findAllAccumulateRankingByYearAndWeek(
+		@Param("requestYear") int year,
+		@Param("requestWeek") int week);
 
 	Optional<RankingHistory> findByUserIdAndYearAndWeek(
 		@Param("userId") Long userId,

--- a/src/main/java/com/m3pro/groundflip/repository/RankingRedisRepository.java
+++ b/src/main/java/com/m3pro/groundflip/repository/RankingRedisRepository.java
@@ -102,18 +102,23 @@ public class RankingRedisRepository {
 		return rankings;
 	}
 
-	public Optional<Long> getCurrentPixelRank(Long userId) {
-		Long rank = zSetOperations.reverseRank(currentPixelRankingKey, userId.toString());
+	public Optional<Long> getCurrentPixelRank(Long id) {
+		Long rank = zSetOperations.reverseRank(currentPixelRankingKey, id.toString());
 		return Optional.ofNullable(rank).map(r -> r + 1);
 	}
 
-	public Optional<Long> getCurrentPixelCount(Long userId) {
-		Double currentPixelCount = zSetOperations.score(currentPixelRankingKey, userId.toString());
+	public Optional<Long> getCurrentPixelCount(Long id) {
+		Double currentPixelCount = zSetOperations.score(currentPixelRankingKey, id.toString());
 		return Optional.ofNullable(currentPixelCount).map(Double::longValue);
 	}
 
-	public Optional<Long> getAccumulatePixelCount(Long userId) {
-		Double accumulatePixelCount = zSetOperations.score(accumulatePixelRankingKey, userId.toString());
+	public Optional<Long> getAccumulatePixelRank(Long id) {
+		Long rank = zSetOperations.reverseRank(accumulatePixelRankingKey, id.toString());
+		return Optional.ofNullable(rank).map(r -> r + 1);
+	}
+
+	public Optional<Long> getAccumulatePixelCount(Long id) {
+		Double accumulatePixelCount = zSetOperations.score(accumulatePixelRankingKey, id.toString());
 		return Optional.ofNullable(accumulatePixelCount).map(Double::longValue);
 	}
 }

--- a/src/main/java/com/m3pro/groundflip/repository/RankingRedisRepository.java
+++ b/src/main/java/com/m3pro/groundflip/repository/RankingRedisRepository.java
@@ -75,6 +75,10 @@ public class RankingRedisRepository {
 		return getRankings(currentPixelRankingKey, RANKING_END_INDEX);
 	}
 
+	public List<Ranking> getRankingsWithAccumulatePixelCount() {
+		return getRankings(accumulatePixelRankingKey, RANKING_END_INDEX);
+	}
+
 	public List<Ranking> getRankingsWithCurrentPixelCount(int endIndex) {
 		return getRankings(currentPixelRankingKey, -1);
 	}

--- a/src/main/java/com/m3pro/groundflip/service/UserRankingService.java
+++ b/src/main/java/com/m3pro/groundflip/service/UserRankingService.java
@@ -97,27 +97,12 @@ public class UserRankingService {
 		}
 	}
 
-	public List<UserRankingResponse> getAccumulatePixelAllUserRankings(LocalDate lookUpDate) {
-		if (lookUpDate == null) {
-			lookUpDate = LocalDate.now();
-		}
-
-		if (DateUtils.isDateInCurrentWeek(lookUpDate)) {
-			return getCurrentWeekAccumulatePixelRankings();
-		} else {
-			return getPastWeekAccumulatePixelRankingsByDate(lookUpDate);
-		}
+	public List<UserRankingResponse> getAccumulatePixelAllUserRankings() {
+		return getCurrentWeekAccumulatePixelRankings();
 	}
 
 	private List<UserRankingResponse> getPastWeekCurrentPixelRankingsByDate(LocalDate lookUpDate) {
 		return rankingHistoryRepository.findAllByYearAndWeek(
-			lookUpDate.getYear(),
-			DateUtils.getWeekOfDate(lookUpDate)
-		);
-	}
-
-	private List<UserRankingResponse> getPastWeekAccumulatePixelRankingsByDate(LocalDate lookUpDate) {
-		return rankingHistoryRepository.findAllAccumulateRankingByYearAndWeek(
 			lookUpDate.getYear(),
 			DateUtils.getWeekOfDate(lookUpDate)
 		);
@@ -190,16 +175,8 @@ public class UserRankingService {
 		}
 	}
 
-	public UserRankingResponse getUserAccumulatePixelRankInfo(Long userId, LocalDate lookUpDate) {
-		if (lookUpDate == null) {
-			lookUpDate = LocalDate.now();
-		}
-
-		if (DateUtils.isDateInCurrentWeek(lookUpDate)) {
-			return getCurrentWeekAccumulatePixelUserRanking(userId);
-		} else {
-			return getPastWeekAccumulatePixelUserRanking(userId, lookUpDate);
-		}
+	public UserRankingResponse getUserAccumulatePixelRankInfo(Long userId) {
+		return getCurrentWeekAccumulatePixelUserRanking(userId);
 	}
 
 	private UserRankingResponse getPastWeekPixelUserRanking(
@@ -234,15 +211,6 @@ public class UserRankingService {
 			lookUpDate,
 			RankingHistory::getCurrentPixelCount,
 			RankingHistory::getRanking
-		);
-	}
-
-	public UserRankingResponse getPastWeekAccumulatePixelUserRanking(Long userId, LocalDate lookUpDate) {
-		return getPastWeekPixelUserRanking(
-			userId,
-			lookUpDate,
-			RankingHistory::getAccumulatePixelCount,
-			RankingHistory::getAccumulateRanking
 		);
 	}
 

--- a/src/main/java/com/m3pro/groundflip/service/UserRankingService.java
+++ b/src/main/java/com/m3pro/groundflip/service/UserRankingService.java
@@ -96,6 +96,19 @@ public class UserRankingService {
 		}
 	}
 
+	public List<UserRankingResponse> getAccumulatePixelAllUserRankings(LocalDate lookUpDate) {
+		if (lookUpDate == null) {
+			lookUpDate = LocalDate.now();
+		}
+
+		if (DateUtils.isDateInCurrentWeek(lookUpDate)) {
+			return getCurrentWeekAccumulatePixelRankings();
+		} else {
+			// Todo 이전 주차 랭킹을 가져오는 메서드 구현 후 대체
+			return getPastWeekCurrentPixelRankingsByDate(lookUpDate);
+		}
+	}
+
 	private List<UserRankingResponse> getPastWeekCurrentPixelRankingsByDate(LocalDate lookUpDate) {
 		return rankingHistoryRepository.findAllByYearAndWeek(
 			lookUpDate.getYear(),
@@ -105,6 +118,15 @@ public class UserRankingService {
 
 	private List<UserRankingResponse> getCurrentWeekCurrentPixelRankings() {
 		List<Ranking> rankings = userRankingRedisRepository.getRankingsWithCurrentPixelCount();
+		return getCurrentWeekRankings(rankings);
+	}
+
+	private List<UserRankingResponse> getCurrentWeekAccumulatePixelRankings() {
+		List<Ranking> rankings = userRankingRedisRepository.getRankingsWithAccumulatePixelCount();
+		return getCurrentWeekRankings(rankings);
+	}
+
+	private List<UserRankingResponse> getCurrentWeekRankings(List<Ranking> rankings) {
 		Map<Long, User> users = getRankedUsers(rankings);
 
 		rankings = filterNotExistUsers(rankings, users);

--- a/src/main/java/com/m3pro/groundflip/util/DateUtils.java
+++ b/src/main/java/com/m3pro/groundflip/util/DateUtils.java
@@ -9,8 +9,16 @@ import java.util.Date;
 
 public class DateUtils {
 	public static boolean isDateInCurrentWeek(LocalDate date) {
-		return getWeekOfDate(LocalDate.now()) == getWeekOfDate(date)
-			&& LocalDate.now().getYear() == date.getYear();
+		WeekFields weekFields = WeekFields.of(DayOfWeek.MONDAY, 1);
+		LocalDate today = LocalDate.now();
+
+		int currentYear = today.get(weekFields.weekBasedYear());
+		int currentWeek = today.get(weekFields.weekOfWeekBasedYear());
+
+		int dateYear = date.get(weekFields.weekBasedYear());
+		int dateWeek = date.get(weekFields.weekOfWeekBasedYear());
+
+		return currentYear == dateYear && currentWeek == dateWeek;
 	}
 
 	public static int getWeekOfDate(LocalDate date) {

--- a/src/main/java/com/m3pro/groundflip/util/DateUtils.java
+++ b/src/main/java/com/m3pro/groundflip/util/DateUtils.java
@@ -9,7 +9,8 @@ import java.util.Date;
 
 public class DateUtils {
 	public static boolean isDateInCurrentWeek(LocalDate date) {
-		return getWeekOfDate(LocalDate.now()) == getWeekOfDate(date);
+		return getWeekOfDate(LocalDate.now()) == getWeekOfDate(date)
+			&& LocalDate.now().getYear() == date.getYear();
 	}
 
 	public static int getWeekOfDate(LocalDate date) {

--- a/src/test/java/com/m3pro/groundflip/service/UserRankingServiceTest.java
+++ b/src/test/java/com/m3pro/groundflip/service/UserRankingServiceTest.java
@@ -203,6 +203,32 @@ class UserRankingServiceTest {
 	}
 
 	@Test
+	@DisplayName("[getAccumulatePixelAllUserRankings] 현재 상위 30명의 랭킹을 가져온다.")
+	void getAccumulatePixelAllUserRankingsTest() {
+		List<Ranking> rankings = Arrays.asList(
+			new Ranking(1L, 10L, 3L),
+			new Ranking(2L, 20L, 1L),
+			new Ranking(3L, 15L, 2L)
+		);
+
+		List<User> users = Arrays.asList(
+			User.builder().id(1L).nickname("User1").profileImage("url1").build(),
+			User.builder().id(2L).nickname("User2").profileImage("url2").build(),
+			User.builder().id(3L).nickname("User3").profileImage("url3").build()
+		);
+
+		when(userRankingRedisRepository.getRankingsWithAccumulatePixelCount()).thenReturn(rankings);
+		when(userRepository.findAllById(anySet())).thenReturn(users);
+
+		List<UserRankingResponse> responses = userRankingService.getAccumulatePixelAllUserRankings();
+
+		assertEquals(3, responses.size());
+		assertEquals(1L, responses.get(0).getUserId());
+		assertEquals(2L, responses.get(1).getUserId());
+		assertEquals(3L, responses.get(2).getUserId());
+	}
+
+	@Test
 	@DisplayName("[getAllUserRanking] 레디스에서 찾은 유저가 DB 에서 찾아온 유저에 필터링된다.")
 	void getAllUserRankingTest_UserNotFound() {
 		List<Ranking> rankings = Arrays.asList(


### PR DESCRIPTION
## 작업 내용*
- 전체 유저에 대한 누적 랭킹을 반환하는 api 구현
- 특정 유저에 대한 누적 랭킹을 반환하는 api 구현

## 고민한 내용*
### 이번 주차인지 확인하는 함수의 버그
```
public static boolean isDateInCurrentWeek(LocalDate date) {
 		return getWeekOfDate(LocalDate.now()) == getWeekOfDate(date);
 	}
```

- 기존 코드에서는 단순 주차만 비교 하기 때문에 2024/01/01 과 2025/01/01 이 같은 주차로 판단되는 문제가 있었다.
- 따라서 기존의 주차 뿐만 아닌 년도도 같이 비교하도록 코드를 수정 하였다.
- 하지만 기본적인 년도로 비교 하게 되면 2024/12/31 과 2025/01/01 이 다른 주차로 판단되는 경우가 생겨 `weekBasedYear` 라는 것을 사용하여 비교 하였다.


## 리뷰 요구사항

- 리뷰할 때 중점적으로 봐줬으면 하는 내용들

## 스크린샷