### PR TITLE
GeohashUtil 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,9 @@ build/
 
 aws.yml
 
+mysql_data/
+redis_data/
+
 ### STS ###
 .apt_generated
 .classpath

--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,8 @@ dependencies {
     // 스웨거 기본 설정을 위한 의존성
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
 
+    implementation("ch.hsr:geohash:1.4.0")
+
     // GIS 자료형을 위한 의존성
     implementation group: 'org.hibernate', name: 'hibernate-spatial', version: '6.4.2.Final'
     implementation group: 'org.n52.jackson', name: 'jackson-datatype-jts', version: '1.2.10'

--- a/geohash.sql
+++ b/geohash.sql
@@ -1,0 +1,6 @@
+ALTER TABLE pixel
+    ADD COLUMN geohash VARCHAR(12) NOT NULL,
+    ADD INDEX idx_geohash (geohash(12));
+
+UPDATE pixel
+SET geohash = ST_GeoHash(coordinate, 8);

--- a/src/main/java/com/m3pro/groundflip/domain/entity/Pixel.java
+++ b/src/main/java/com/m3pro/groundflip/domain/entity/Pixel.java
@@ -46,6 +46,8 @@ public class Pixel {
 	@JoinColumn(name = "region_id")
 	private Region region;
 
+	private String geohash;
+
 	private LocalDateTime createdAt;
 
 	private LocalDateTime userOccupiedAt;

--- a/src/main/java/com/m3pro/groundflip/util/GeoHashUtil.java
+++ b/src/main/java/com/m3pro/groundflip/util/GeoHashUtil.java
@@ -1,0 +1,41 @@
+package com.m3pro.groundflip.util;
+
+import ch.hsr.geohash.GeoHash;
+
+public class GeoHashUtil {
+	private static final double EARTH_RADIUS_M = 6371000.0;
+
+	public static String getBoundingGeoHash(double lat, double lon, int radiusMeters) {
+		double deltaLat = Math.toDegrees(radiusMeters / EARTH_RADIUS_M);
+		double deltaLon = Math.toDegrees(radiusMeters / (EARTH_RADIUS_M * Math.cos(Math.toRadians(lat))));
+
+		double latNorth = lat + deltaLat;
+		double latSouth = lat - deltaLat;
+		double lonEast = lon + deltaLon;
+		double lonWest = lon - deltaLon;
+
+		String nw = GeoHash.withCharacterPrecision(latNorth, lonWest, 12).toBase32();
+		String ne = GeoHash.withCharacterPrecision(latNorth, lonEast, 12).toBase32();
+		String sw = GeoHash.withCharacterPrecision(latSouth, lonWest, 12).toBase32();
+		String se = GeoHash.withCharacterPrecision(latSouth, lonEast, 12).toBase32();
+
+		return commonPrefix(nw, ne, sw, se);
+	}
+
+	private static String commonPrefix(String... hashes) {
+		if (hashes == null || hashes.length == 0) return "";
+		String prefix = hashes[0];
+		for (int i = 1; i < hashes.length; i++) {
+			prefix = getCommonPrefix(prefix, hashes[i]);
+		}
+		return prefix;
+	}
+
+	private static String getCommonPrefix(String a, String b) {
+		int minLen = Math.min(a.length(), b.length());
+		int i = 0;
+		while (i < minLen && a.charAt(i) == b.charAt(i)) i++;
+		return a.substring(0, i);
+	}
+
+}


### PR DESCRIPTION
## 작업 내용*

- geohash 라이브러리 의존성 추가

## 고민한 내용*
- 중심좌표, 반경을 고려하여 적절한 geohash를 골라야한다.
- 조회 영역을 정사각형이라고 가정한다면, 각 꼭짓점의 geohash들의 공통 prefix가 이들을 감싸는 가장 작은 geohash가 된다.
- 기존 원을 기반으로 하는 Buffer, Contains 연산의 경우, geohash에 적용하기에는 코드가 복잡해진다고 판단하여 정사각형 기반으로 변경
- 대부분 단순 연산이기 때문에 성능 문제는 예상되지 않는다. 